### PR TITLE
Double-spend relay fixes

### DIFF
--- a/qa/rpc-tests/doublespendrelay.py
+++ b/qa/rpc-tests/doublespendrelay.py
@@ -28,8 +28,6 @@ class DoubleSpendRelay(BitcoinTestFramework):
         connect_nodes(self.nodes[0], 2)
         connect_nodes(self.nodes[1], 2)
         connect_nodes(self.nodes[3], 2)
-        self.nodes[0].setgenerate(True, 110)
-        sync_blocks(self.nodes)
         return self.nodes
 
     def run_test(self):

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -314,6 +314,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += "  -upgradewallet         " + _("Upgrade wallet to latest format") + " " + _("on startup") + "\n";
     strUsage += "  -wallet=<file>         " + _("Specify wallet file (within data directory)") + " " + strprintf(_("(default: %s)"), "wallet.dat") + "\n";
     strUsage += "  -walletnotify=<cmd>    " + _("Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)") + "\n";
+    strUsage += "  -respendnotify=<cmd>   " + _("Execute command when a network tx respends wallet tx input (%s=respend TxID, %t=wallet TxID)") + "\n";
     strUsage += "  -zapwallettxes=<mode>  " + _("Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup") + "\n";
     strUsage += "                         " + _("(1 = keep tx meta data e.g. account owner and payment request information, 2 = drop tx meta data)") + "\n";
 #endif

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -259,17 +259,6 @@ void TransactionTableModel::updateTransaction(const QString &hash, int status, b
     updated.SetHex(hash.toStdString());
 
     priv->updateWallet(updated, status, showTransaction);
-
-    if (status == CT_GOT_CONFLICT)
-    {
-        // TODO: Figure out how to do this after commit 023e63df78b847812040bf6958c97476606dfbfd
-        /*
-        emit message(tr("Conflict Received"),
-                     tr("WARNING: Transaction may never be confirmed. Its input was seen being spent by another transaction on the network. Wait for confirmation!"),
-                     CClientUIInterface::MSG_WARNING);
-         */
-        return;
-    }
 }
 
 void TransactionTableModel::updateConfirmations()


### PR DESCRIPTION
 - Clean up "todo" comments relating to alert dialog, this was "todone".
 - Update double-spend regtest to conform to changes in framework
 - Add back missing help text on -respendnotify option