### PR TITLE
MIN_PEER_PROTO_VERSION and p2p network protocol version related code cleanup

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4262,8 +4262,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             return false;
         }
 
-        if (pfrom->nVersion == 10300)
-            pfrom->nVersion = 300;
         if (!vRecv.empty())
             vRecv >> addrFrom >> nNonce;
         if (!vRecv.empty()) {
@@ -4322,12 +4320,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                 }
             }
 
-            // Get recent addresses
-            if (pfrom->fOneShot || pfrom->nVersion >= CADDR_TIME_VERSION || addrman.size() < 1000)
-            {
-                pfrom->PushMessage("getaddr");
-                pfrom->fGetAddr = true;
-            }
+            pfrom->PushMessage("getaddr");
+            pfrom->fGetAddr = true;
             addrman.Good(pfrom->addr);
         } else {
             if (((CNetAddr)pfrom->addr) == (CNetAddr)addrFrom)
@@ -4387,9 +4381,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         vector<CAddress> vAddr;
         vRecv >> vAddr;
 
-        // Don't want addr from older versions unless seeding
-        if (pfrom->nVersion < CADDR_TIME_VERSION && addrman.size() > 1000)
-            return true;
         if (vAddr.size() > 1000)
         {
             Misbehaving(pfrom->GetId(), 20);
@@ -4424,8 +4415,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     multimap<uint256, CNode*> mapMix;
                     BOOST_FOREACH(CNode* pnode, vNodes)
                     {
-                        if (pnode->nVersion < CADDR_TIME_VERSION)
-                            continue;
                         unsigned int nPointer;
                         memcpy(&nPointer, &pnode, sizeof(nPointer));
                         uint256 hashKey = ArithToUint256(UintToArith256(hashRand) ^ nPointer);
@@ -4863,23 +4852,20 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
     else if (strCommand == "ping")
     {
-        if (pfrom->nVersion > BIP0031_VERSION)
-        {
-            uint64_t nonce = 0;
-            vRecv >> nonce;
-            // Echo the message back with the nonce. This allows for two useful features:
-            //
-            // 1) A remote node can quickly check if the connection is operational
-            // 2) Remote nodes can measure the latency of the network thread. If this node
-            //    is overloaded it won't respond to pings quickly and the remote node can
-            //    avoid sending us more work, like chain download requests.
-            //
-            // The nonce stops the remote getting confused between different pings: without
-            // it, if the remote node sends a ping once per second and this node takes 5
-            // seconds to respond to each, the 5th ping the remote sends would appear to
-            // return very quickly.
-            pfrom->PushMessage("pong", nonce);
-        }
+        uint64_t nonce = 0;
+        vRecv >> nonce;
+        // Echo the message back with the nonce. This allows for two useful features:
+        //
+        // 1) A remote node can quickly check if the connection is operational
+        // 2) Remote nodes can measure the latency of the network thread. If this node
+        //    is overloaded it won't respond to pings quickly and the remote node can
+        //    avoid sending us more work, like chain download requests.
+        //
+        // The nonce stops the remote getting confused between different pings: without
+        // it, if the remote node sends a ping once per second and this node takes 5
+        // seconds to respond to each, the 5th ping the remote sends would appear to
+        // return very quickly.
+        pfrom->PushMessage("pong", nonce);
     }
 
 
@@ -5202,14 +5188,8 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
             }
             pto->fPingQueued = false;
             pto->nPingUsecStart = GetTimeMicros();
-            if (pto->nVersion > BIP0031_VERSION) {
-                pto->nPingNonceSent = nonce;
-                pto->PushMessage("ping", nonce);
-            } else {
-                // Peer is too old to support ping command with nonce, pong will never arrive.
-                pto->nPingNonceSent = 0;
-                pto->PushMessage("ping");
-            }
+            pto->nPingNonceSent = nonce;
+            pto->PushMessage("ping", nonce);
         }
 
         TRY_LOCK(cs_main, lockMain); // Acquire cs_main for IsInitialBlockDownload() and CNodeState()

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1000,7 +1000,7 @@ void ThreadSocketHandler()
                     LogPrintf("socket sending timeout: %is\n", nTime - pnode->nLastSend);
                     pnode->fDisconnect = true;
                 }
-                else if (nTime - pnode->nLastRecv > (pnode->nVersion > BIP0031_VERSION ? TIMEOUT_INTERVAL : 90*60))
+                else if (nTime - pnode->nLastRecv > TIMEOUT_INTERVAL)
                 {
                     LogPrintf("socket receive timeout: %is\n", nTime - pnode->nLastRecv);
                     pnode->fDisconnect = true;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -104,7 +104,7 @@ public:
         if (nType & SER_DISK)
             READWRITE(nVersion);
         if ((nType & SER_DISK) ||
-            (nVersion >= CADDR_TIME_VERSION && !(nType & SER_GETHASH)))
+            !(nType & SER_GETHASH))
             READWRITE(nTime);
         READWRITE(nServices);
         READWRITE(*(CService*)this);

--- a/src/version.h
+++ b/src/version.h
@@ -12,6 +12,6 @@ static const int MIN_PEER_PROTO_VERSION = 70010;
 static const int PROTOCOL_VERSION = MIN_PEER_PROTO_VERSION + 0;
 
 // initial protocol version used between peers. the version used between peers may be increased by version/verack negotiation.
-static const int INIT_PROTO_VERSION = MIN_PEER_PROTO_VERSION;
+static const int INIT_PROTO_VERSION = 209;
 
 #endif // BITCOIN_VERSION_H

--- a/src/version.h
+++ b/src/version.h
@@ -5,33 +5,13 @@
 #ifndef BITCOIN_VERSION_H
 #define BITCOIN_VERSION_H
 
-/**
- * network protocol versioning
- */
+// disconnect from peers older than this protocol version.
+static const int MIN_PEER_PROTO_VERSION = 70010;
 
-static const int PROTOCOL_VERSION = 70010;
+// p2p network protocol version that this node implements.
+static const int PROTOCOL_VERSION = MIN_PEER_PROTO_VERSION + 0;
 
-//! initial proto version, to be increased after version/verack negotiation
-static const int INIT_PROTO_VERSION = 209;
-
-//! In this version, 'getheaders' was introduced.
-static const int GETHEADERS_VERSION = 31800;
-
-//! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = GETHEADERS_VERSION;
-
-//! nTime field added to CAddress, starting with this version;
-//! if possible, avoid requesting addresses nodes older than this
-static const int CADDR_TIME_VERSION = 31402;
-
-//! only request blocks from nodes outside this range of versions
-static const int NOBLKS_VERSION_START = 32000;
-static const int NOBLKS_VERSION_END = 32400;
-
-//! BIP 0031, pong message, is enabled for all versions AFTER this one
-static const int BIP0031_VERSION = 60000;
-
-//! "mempool" command, enhanced "getdata" behavior starts with this version
-static const int MEMPOOL_GD_VERSION = 60002;
+// initial protocol version used between peers. the version used between peers may be increased by version/verack negotiation.
+static const int INIT_PROTO_VERSION = MIN_PEER_PROTO_VERSION;
 
 #endif // BITCOIN_VERSION_H


### PR DESCRIPTION
MIN_PEER_PROTO_VERSION and p2p network protocol version related code cleanup as discussed with Gavin at https://groups.google.com/forum/#!topic/bitcoin-xt/4z8ojdVonKI

These changes are for a release post-network upgrade to protocol version 70010. Just putting these out there to get it off my todo list.