### PR TITLE
tighten up message size sanity checking

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -58,6 +58,7 @@ BITCOIN_TESTS =\
   test/mruset_tests.cpp \
   test/multisig_tests.cpp \
   test/netbase_tests.cpp \
+  test/p2p_protocol_tests.cpp \
   test/pmt_tests.cpp \
   test/policyestimator_tests.cpp \
   test/pow_tests.cpp \

--- a/src/main.h
+++ b/src/main.h
@@ -185,6 +185,8 @@ bool LoadBlockIndex();
 void UnloadBlockIndex();
 /** Process protocol messages received from a given node */
 bool ProcessMessages(CNode* pfrom);
+/** Process a single message from a given node */
+bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, int64_t nTimeReceived);
 /**
  * Send queued protocol messages to be sent to a give node.
  *

--- a/src/test/p2p_protocol_tests.cpp
+++ b/src/test/p2p_protocol_tests.cpp
@@ -1,0 +1,111 @@
+// Copyright (c) 2011-2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "main.h"
+
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(p2p_protocol_tests, TestingSetup)
+
+BOOST_AUTO_TEST_CASE(MaxSizeVersionMessage)
+{
+    CNode n(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    nLocalHostNonce = 2; // this trips the version message logic to end shortly after reading the data (which is the focus of this test)
+    s << PROTOCOL_VERSION;
+    s << n.nServices;
+    s << GetTime();
+    s << CAddress(CService("0.0.0.0", 0));
+    s << CAddress(CService("0.0.0.0", 0));
+    s << nLocalHostNonce;
+    s << std::string(256, 'a'); // 256 is the max allowed length in the Bitcoin Core/XT protocol processing code
+    s << n.nStartingHeight;
+    s << n.fRelayTxes;
+    BOOST_CHECK_EQUAL(352, s.size());
+    BOOST_CHECK(ProcessMessage(&n, "version", s, 0));
+}
+
+BOOST_AUTO_TEST_CASE(OverMaxSizeVersionMessage)
+{
+    CNode n(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    nLocalHostNonce = 2; // this trips the version message logic to end shortly after reading the data (which is the focus of this test)
+    s << PROTOCOL_VERSION;
+    s << n.nServices;
+    s << GetTime();
+    s << CAddress(CService("0.0.0.0", 0));
+    s << CAddress(CService("0.0.0.0", 0));
+    s << nLocalHostNonce;
+    s << std::string(257, 'a'); // invalid, max is 256
+    s << n.nStartingHeight;
+    s << n.fRelayTxes;
+    BOOST_CHECK_EQUAL(353, s.size());
+    BOOST_CHECK_THROW(ProcessMessage(&n, "version", s, 0), std::ios_base::failure);
+}
+
+BOOST_AUTO_TEST_CASE(MaxSizeWeirdRejectMessage)
+{
+    CNode n(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    n.nVersion = PROTOCOL_VERSION;
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    s << std::string(12, 'a'); // not a real command, but it uses the max of 12 here.
+    s << (uint8_t)0x10;
+    s << std::string(111, 'a');
+    BOOST_CHECK_EQUAL(126, s.size());
+    bool temp = fDebug;
+    fDebug = true;
+    BOOST_CHECK(ProcessMessage(&n, "reject", s, 0));
+    fDebug = temp;
+}
+
+BOOST_AUTO_TEST_CASE(MaxSizeValidRejectMessage)
+{
+    CNode n(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    n.nVersion = PROTOCOL_VERSION;
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    s << std::string("block"); // does not use the max of 12, but "block" is the longest command that has a defined extension of 32 bytes
+    s << (uint8_t)0x10;
+    s << std::string(111, 'a');
+    s << uint256();
+    BOOST_CHECK_EQUAL(151, s.size());
+    bool temp = fDebug;
+    fDebug = true;
+    BOOST_CHECK(ProcessMessage(&n, "reject", s, 0));
+    fDebug = temp;
+}
+
+BOOST_AUTO_TEST_CASE(OverMaxSizeWeirdRejectMessage)
+{
+    CNode n(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    n.nVersion = PROTOCOL_VERSION;
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    s << std::string(13, 'a'); // invalid, max is 12
+    s << (uint8_t)0x10;
+    s << std::string(111, 'a');
+    BOOST_CHECK_EQUAL(127, s.size());
+    bool temp = fDebug;
+    fDebug = true;
+    BOOST_CHECK(!ProcessMessage(&n, "reject", s, 0)); // check this way since the reject message processing swallows the exception
+    fDebug = temp;
+}
+
+BOOST_AUTO_TEST_CASE(OverMaxSizeValidRejectMessage)
+{
+    CNode n(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    n.nVersion = PROTOCOL_VERSION;
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    s << std::string("block");
+    s << (uint8_t)0x10;
+    s << std::string(112, 'a'); // invalid, max is 111
+    s << uint256();
+    BOOST_CHECK_EQUAL(152, s.size());
+    bool temp = fDebug;
+    fDebug = true;
+    BOOST_CHECK(!ProcessMessage(&n, "reject", s, 0)); // check this way since the reject message processing swallows the exception
+    fDebug = temp;
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
tighten up message size sanity checking. add version, filterclear, and reject to maxMessageSizes.

i brought this up a couple of weeks ago at https://github.com/bitcoin/bitcoin/pull/6261#issuecomment-127055875 and didn't get any response so i figured i'd bring it up here (where gavin's patch already made it in).

i got the reject message sizing by looking at the code and referencing:
https://github.com/bitcoin/bips/blob/master/bip-0061.mediawiki
https://bitcoin.org/en/developer-reference#reject