### PR TITLE
gitian: added systemd configs to debian installer creation script

### DIFF
--- a/contrib/gitian-debian/README.md
+++ b/contrib/gitian-debian/README.md
@@ -50,16 +50,15 @@
   
   ```
   bitcoinxt-qt -listen=0:8444
+  ```
   
-**Test Uninstalling bitcoinxt Package**
-
-1. Uninstall bitcoinxt without removing config file or data:
+8. Uninstall bitcoinxt without removing config file or data:
 
   ```
   sudo apt-install uninstall bitcoinxt
   ```
 
-2. Uninstall bitcoinxt AND remove config file and data:
+9. Uninstall bitcoinxt AND remove config file and data:
 
   ```
   sudo apt-install purge bitcoinxt

--- a/contrib/gitian-debian/README.md
+++ b/contrib/gitian-debian/README.md
@@ -1,4 +1,5 @@
-**How To Create A Debian Package Installer**
+
+**Create A Debian Package Installer**
 
 1. Download gitian created bitcoinxt tar file to bitcoinxt/contrib/gitian-debian folder:
 
@@ -12,7 +13,7 @@
   ./build.sh
   ```
 
-**How To Test New Debian Package Installer**
+**Test New Debian Package Installer**
 
 1. Install newly created debian package on test debian system:
 
@@ -32,7 +33,7 @@
   sudo usermod -a -G bitcoin <your username>
   ```
   
-4. Logout and back into your account so new group assignment takes affect
+4. Logout and back into your account so new group assignment takes affect.
 
 5. Verify your username was added to the bitcoin group:
 
@@ -45,3 +46,8 @@
   ```
   /usr/bin/bitcoinxt-cli -conf=/etc/bitcoinxt/bitcoin.conf getinfo
   ```
+  
+7. Test bitcoinxt-qt with non-conflicting IP port:
+  
+  ```
+  bitcoinxt-qt -listen=0:8444

--- a/contrib/gitian-debian/README.md
+++ b/contrib/gitian-debian/README.md
@@ -1,4 +1,3 @@
-
 **Create A Debian Package Installer**
 
 1. Download gitian created bitcoinxt tar file to bitcoinxt/contrib/gitian-debian folder:
@@ -51,3 +50,18 @@
   
   ```
   bitcoinxt-qt -listen=0:8444
+  
+**Test Uninstalling bitcoinxt Package**
+
+1. Uninstall bitcoinxt without removing config file or data:
+
+  ```
+  sudo apt-install uninstall bitcoinxt
+  ```
+
+2. Uninstall bitcoinxt AND remove config file and data:
+
+  ```
+  sudo apt-install purge bitcoinxt
+  sudo rm -rf /var/lib/bitcoinxt
+  ```

--- a/contrib/gitian-debian/README.md
+++ b/contrib/gitian-debian/README.md
@@ -1,0 +1,47 @@
+**How To Create A Debian Package Installer**
+
+1. Download gitian created bitcoinxt tar file to bitcoinxt/contrib/gitian-debian folder:
+
+  ```
+  cd bitcoinxt/contrib/gitian-debian
+  wget https://github.com/bitcoinxt/bitcoinxt/releases/download/v0.11A/bitcoin-0.11.0-linux64.tar.gz
+  ```
+
+2. Execute debian installer build script:
+  ```
+  ./build.sh
+  ```
+
+**How To Test New Debian Package Installer**
+
+1. Install newly created debian package on test debian system:
+
+  ```
+  sudo gdebi bitcoinxt-0.11A.deb
+  ```
+
+2. Verify bitcoinxt daemon installed and started:
+
+  ```
+  sudo systemctl status bitcoinxt
+  ```
+
+3. Add your user account to the bitcoin system group:
+   
+  ```
+  sudo usermod -a -G bitcoin <your username>
+  ```
+  
+4. Logout and back into your account so new group assignment takes affect
+
+5. Verify your username was added to the bitcoin group:
+
+  ```
+  groups
+  ```
+
+6. Test bitcoinxt-cli access:
+
+  ```
+  /usr/bin/bitcoinxt-cli -conf=/etc/bitcoinxt/bitcoin.conf getinfo
+  ```

--- a/contrib/gitian-debian/bitcoin.conf
+++ b/contrib/gitian-debian/bitcoin.conf
@@ -1,0 +1,133 @@
+##
+## bitcoin.conf configuration file. Lines beginning with # are comments.
+##
+ 
+# Network-related settings:
+
+# Run on the test network instead of the real bitcoin network.
+#testnet=0
+
+# Run a regression test network
+#regtest=0
+
+# Connect via a SOCKS5 proxy
+#proxy=127.0.0.1:9050
+
+# Bind to given address and always listen on it. Use [host]:port notation for IPv6
+#bind=<addr>
+
+# Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6
+#whitebind=<addr>
+
+##############################################################
+##            Quick Primer on addnode vs connect            ##
+##  Let's say for instance you use addnode=4.2.2.4          ##
+##  addnode will connect you to and tell you about the      ##
+##    nodes connected to 4.2.2.4.  In addition it will tell ##
+##    the other nodes connected to it that you exist so     ##
+##    they can connect to you.                              ##
+##  connect will not do the above when you 'connect' to it. ##
+##    It will *only* connect you to 4.2.2.4 and no one else.##
+##                                                          ##
+##  So if you're behind a firewall, or have other problems  ##
+##  finding nodes, add some using 'addnode'.                ##
+##                                                          ##
+##  If you want to stay private, use 'connect' to only      ##
+##  connect to "trusted" nodes.                             ##
+##                                                          ##
+##  If you run multiple nodes on a LAN, there's no need for ##
+##  all of them to open lots of connections.  Instead       ##
+##  'connect' them all to one node that is port forwarded   ##
+##  and has lots of connections.                            ##
+##       Thanks goes to [Noodle] on Freenode.               ##
+##############################################################
+
+# Use as many addnode= settings as you like to connect to specific peers
+#addnode=69.164.218.197
+#addnode=10.0.0.2:8333
+
+# Alternatively use as many connect= settings as you like to connect ONLY to specific peers
+#connect=69.164.218.197
+#connect=10.0.0.1:8333
+
+# Listening mode, enabled by default except when 'connect' is being used
+#listen=1
+
+# Maximum number of inbound+outbound connections.
+#maxconnections=
+
+#
+# JSON-RPC options (for controlling a running Bitcoin/bitcoind process)
+#
+
+# server=1 tells Bitcoin-QT and bitcoind to accept JSON-RPC commands
+#server=0
+
+# Bind to given address to listen for JSON-RPC connections. Use [host]:port notation for IPv6.
+# This option can be specified multiple times (default: bind to all interfaces)
+#rpcbind=<addr>
+
+# How many seconds bitcoin will wait for a complete RPC HTTP request.
+# after the HTTP connection is established. 
+#rpctimeout=30
+
+# By default, only RPC connections from localhost are allowed.
+# Specify as many rpcallowip= settings as you like to allow connections from other hosts,
+# either as a single IPv4/IPv6 or with a subnet specification.
+
+# NOTE: opening up the RPC port to hosts outside your local trusted network is NOT RECOMMENDED,
+# because the rpcpassword is transmitted over the network unencrypted.
+
+# server=1 tells Bitcoin-QT to accept JSON-RPC commands.
+# it is also read by bitcoind to determine if RPC should be enabled 
+#rpcallowip=10.1.1.34/255.255.255.0
+#rpcallowip=1.2.3.4/24
+#rpcallowip=2001:db8:85a3:0:0:8a2e:370:7334/96
+
+# Listen for RPC connections on this TCP port:
+#rpcport=8332
+
+# You can use Bitcoin or bitcoind to send commands to Bitcoin/bitcoind
+# running on another host using this option:
+#rpcconnect=127.0.0.1
+
+# Use Secure Sockets Layer (also known as TLS or HTTPS) to communicate
+# with Bitcoin -server or bitcoind
+#rpcssl=1
+
+# OpenSSL settings used when rpcssl=1
+#rpcsslciphers=TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!AH:!3DES:@STRENGTH
+#rpcsslcertificatechainfile=server.cert
+#rpcsslprivatekeyfile=server.pem
+
+# Transaction Fee Changes in 0.10.0
+
+# Send transactions as zero-fee transactions if possible (default: 0)
+#sendfreetransactions=0
+
+# Create transactions that have enough fees (or priority) so they are likely to begin confirmation within n blocks (default: 1).
+# This setting is over-ridden by the -paytxfee option.
+#txconfirmtarget=n
+
+# Miscellaneous options
+
+# Pre-generate this many public/private key pairs, so wallet backups will be valid for
+# both prior transactions and several dozen future transactions.
+#keypool=100
+
+# Pay an optional transaction fee every time you send bitcoins.  Transactions with fees
+# are more likely than free transactions to be included in generated blocks, so may
+# be validated sooner.
+#paytxfee=0.00
+
+# User interface options
+
+# Start Bitcoin minimized
+#min=1
+
+# Minimize to the system tray
+#minimizetotray=1
+
+# You must set rpcuser and rpcpassword to secure the JSON-RPC api
+rpcuser=bitcoinxt
+#rpcpassword=YourSuperGreatPasswordNumber_DO_NOT_USE_THIS_OR_YOU_WILL_GET_ROBBED_385593

--- a/contrib/gitian-debian/bitcoinxt.service
+++ b/contrib/gitian-debian/bitcoinxt.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Bitcoin's distributed currency daemon
+After=network.target
+
+[Service]
+User=bitcoin
+Group=bitcoin
+
+Type=forking
+PIDFile=/var/lib/bitcoinxt/bitcoinxt.pid
+ExecStart=/usr/bin/bitcoinxt -daemon -pid=/var/lib/bitcoinxt/bitcoinxt.pid \
+-conf=/etc/bitcoinxt/bitcoin.conf -datadir=/var/lib/bitcoinxt -disablewallet
+
+Restart=always
+PrivateTmp=true
+TimeoutStopSec=60s
+TimeoutStartSec=2s
+StartLimitInterval=120s
+StartLimitBurst=5
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/gitian-debian/build.sh
+++ b/contrib/gitian-debian/build.sh
@@ -4,8 +4,7 @@
 #
 #  Improvement ideas:
 #  - Install the man page from the source repo.
-#  - Install an init script or systemd file or whatever then hip kids use these days, so it starts at boot.
-#  - Wrap in a script that restarts the node if it crashes and/or sends crash reports/core dumps to some issue tracker.
+#  - Wrap in a script that sends crash reports/core dumps to some issue tracker.
 #  - etc ...
 
 ver=0.11.0
@@ -38,9 +37,9 @@ touch var/lib/bitcoinxt/.empty
 mv usr/bin/bitcoind usr/bin/bitcoinxt
 mv usr/bin/bitcoin-cli usr/bin/bitcoinxt-cli
 mv usr/bin/bitcoin-tx usr/bin/bitcoinxt-tx
+mv usr/bin/bitcoin-qt usr/bin/bitcoinxt-qt
 
 # Remove unneeded files 
-rm usr/bin/bitcoin-qt
 rm usr/bin/test_bitcoin
 rm usr/bin/test_bitcoin-qt
 rm usr/include/*
@@ -53,7 +52,7 @@ cat <<EOF >DEBIAN/control
 Package: bitcoinxt
 Architecture: amd64
 Description: Bitcoin XT is a fully verifying Bitcoin node implementation, based on the sources of Bitcoin Core.
-Maintainer: Mike Hearn <hearn@vinumeris.com>
+Maintainer: Steve Myers <steven.myers@gmail.com>
 Version: $realver
 Depends: adduser, ntp
 EOF

--- a/contrib/gitian-debian/build.sh
+++ b/contrib/gitian-debian/build.sh
@@ -90,9 +90,15 @@ chmod o-rw /etc/bitcoinxt/bitcoin.conf
 chown -R bitcoin:bitcoin /var/lib/bitcoinxt
 chmod u+rwx /var/lib/bitcoinxt
 
-# enable and start bitcoinxt service
-systemctl enable bitcoinxt.service
-systemctl start bitcoinxt.service
+# enable and start bitcoinxt service if systemctl exists and is executable
+if [[ -x "/bin/systemctl" ]]
+then
+    /bin/systemctl enable bitcoinxt.service
+    /bin/systemctl start bitcoinxt.service
+else
+    echo "File '/bin/systemctl' is not executable or found, bitcoinxt not automatically enabled and started."
+fi
+
 EOF
 
 chmod a+x DEBIAN/postinst 
@@ -100,9 +106,14 @@ chmod a+x DEBIAN/postinst
 cat <<EOF >DEBIAN/prerm
 #!/bin/bash
 
-# stop and disable bitcoinxt service
-systemctl stop bitcoinxt.service
-systemctl disable bitcoinxt.service
+# stop and disable bitcoinxt service if systemctl exists and is executable
+if [[ -x "/bin/systemctl" ]]
+then
+    /bin/systemctl stop bitcoinxt.service
+    /bin/systemctl disable bitcoinxt.service
+else
+    echo "File '/bin/systemctl' is not executable or found, bitcoinxt not automatically stopped and disabled."
+fi
 EOF
 
 chmod a+x DEBIAN/prerm

--- a/contrib/gitian-debian/build.sh
+++ b/contrib/gitian-debian/build.sh
@@ -73,8 +73,7 @@ cat <<EOF >DEBIAN/postinst
 #!/bin/bash
 
 # add random rpc password to bitcoin.conf
-echo -n "rpcpassword=" >> /etc/bitcoinxt/bitcoin.conf 
-bash -c 'tr -dc a-zA-Z0-9 < /dev/urandom | head -c32 && echo' >> /etc/bitcoinxt/bitcoin.conf 
+echo "rpcpassword=$(xxd -l 16 -p /dev/urandom)" >> /etc/bitcoinxt/bitcoin.conf 
 
 # add users
 adduser --system --group --quiet bitcoin


### PR DESCRIPTION
This change is based on discussion here:
https://groups.google.com/forum/#!topic/bitcoin-xt/DamcJG4jteY

And on TODO comments in build.sh.

1. removed unneed qt, .h and .so files from being installed by the package
2. added a default bitcoin.conf file with a randomly generated rpc password
3. added a systemd startup bitcoinxt.service file
4. added postinst script to fix file owners and permissions, enable the startup script and auto start the bitcoinxt daemon
5. also via the postinst script create "bitcoin" system account and group (with login shell disabled) to run the daemon under
6. added an uninstall (prerm) script that automatically stops the daemon and removes executable files (config files are not removed by default)
7. created README.md with basic instructions for creating and testing debian installer

New scripts and configs tested on fresh install (in virtual box vm) of debian-8.1.0-amd64.  