### PR TITLE
IP priority improvements

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -58,6 +58,7 @@ BITCOIN_TESTS =\
   test/mruset_tests.cpp \
   test/multisig_tests.cpp \
   test/netbase_tests.cpp \
+  test/p2p_protocol_tests.cpp \
   test/pmt_tests.cpp \
   test/policyestimator_tests.cpp \
   test/pow_tests.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -295,6 +295,7 @@ std::string HelpMessage(HelpMessageMode mode)
 #if !defined(WIN32)
     strUsage += HelpMessageOpt("-sysperms", _("Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)"));
 #endif
+    strUsage += HelpMessageOpt("-trustsystemclock", _("Trust, and depend solely on, the local system clock. Do not use peer time offset adjustments. (default: 1)"));
     strUsage += HelpMessageOpt("-txindex", strprintf(_("Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)"), 0));
 
     strUsage += HelpMessageGroup(_("Connection options:"));

--- a/src/ipgroups.cpp
+++ b/src/ipgroups.cpp
@@ -159,8 +159,8 @@ static CURLcode ssl_context_setup(CURL *curl, void *sslctx, void *param) {
     return CURLE_OK;
 }
 
-static CIPGroup *LoadIPDataFromWeb(const std::string &url, const std::string &groupname, int priority) {
-    std::string data;
+static CIPGroup *LoadIPDataFromWeb(const string &url, const string &groupname, int priority) {
+    string data;
 
     CurlWrapper curlWrapper;
     CURL *curl = curlWrapper.handle;
@@ -200,7 +200,7 @@ static CIPGroup *LoadIPDataFromWeb(const std::string &url, const std::string &gr
     CURLcode rv = curl_easy_perform(curl);
     if (rv == CURLE_OK) {
         LogPrintf("IP list download succeeded from %s\n", url.c_str());
-        std::vector<CSubNet> subnets = ParseIPData(data);
+        vector<CSubNet> subnets = ParseIPData(data);
         if (subnets.size() > 0) {
             CIPGroup *ipGroup = new CIPGroup;
             ipGroup->header.name = groupname;
@@ -216,7 +216,7 @@ static CIPGroup *LoadIPDataFromWeb(const std::string &url, const std::string &gr
 
 static CIPGroup *LoadTorIPsFromWeb() {
     // Just use the first IPv4 address for now. We could try all of them later on.
-    std::string ourip;
+    string ourip;
     {
         LOCK(cs_mapLocalHost);
         BOOST_FOREACH(const PAIRTYPE(CNetAddr, LocalServiceInfo) &item, mapLocalHost)
@@ -232,7 +232,7 @@ static CIPGroup *LoadTorIPsFromWeb() {
         // No routeable IPs so don't bother downloading: we can't receive connections from the outside anyway.
         return NULL;
     }
-    std::string url = strprintf("https://check.torproject.org/torbulkexitlist?ip=%s&port=8333", ourip);
+    string url = strprintf("https://check.torproject.org/torbulkexitlist?ip=%s&port=8333", ourip);
     return LoadIPDataFromWeb(url, "tor", OPEN_PROXY_PRIORITY);
 }
 

--- a/src/ipgroups.h
+++ b/src/ipgroups.h
@@ -7,6 +7,8 @@
 
 #include "netbase.h"
 
+#define IP_PRIO_SRC_FLAG_NAME "-ip-priority-source"
+
 class CScheduler;
 
 // A group of logically related IP addresses. Useful for banning or deprioritising
@@ -31,6 +33,7 @@ struct CIPGroup {
 // Returns NULL if the IP does not belong to any group.
 CIPGroupData FindGroupForIP(CNetAddr ip);
 
+void InitIPGroupsFromCommandLine();
 void InitIPGroups(CScheduler *scheduler);
 
 #endif //BITCOIN_CIPGROUPS_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4355,7 +4355,8 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
         if (fLogIPs)
             remoteAddr = ", peeraddr=" + pfrom->addr.ToString();
 
-        string group = pfrom->ipgroup.name != "" ? tfm::format(", ipgroup=%s", pfrom->ipgroup.name) : "";
+        CIPGroupData ipgroup = FindGroupForIP(pfrom->addr);
+        string group = ipgroup.name != "" ? tfm::format(", ipgroup=%s", ipgroup.name) : "";
 
         LogPrintf("receive version message: %s: version %d, blocks=%d, us=%s, peerid=%d%s%s\n",
                   pfrom->cleanSubVer, pfrom->nVersion,

--- a/src/main.h
+++ b/src/main.h
@@ -185,6 +185,8 @@ bool LoadBlockIndex();
 void UnloadBlockIndex();
 /** Process protocol messages received from a given node */
 bool ProcessMessages(CNode* pfrom);
+/** Process a single message from a given node */
+bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, int64_t nTimeReceived);
 /**
  * Send queued protocol messages to be sent to a give node.
  *

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1659,8 +1659,6 @@ void StartNode(boost::thread_group& threadGroup, CScheduler& scheduler)
     if (pnodeLocalHost == NULL)
         pnodeLocalHost = new CNode(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), nLocalServices));
 
-    InitIPGroups(&scheduler);
-
     Discover(threadGroup);
 
     //
@@ -1674,6 +1672,9 @@ void StartNode(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     // Map ports with UPnP
     MapPort(GetBoolArg("-upnp", DEFAULT_UPNP));
+
+    // Download or load data that's useful for prioritising traffic by IP address.
+    InitIPGroups(&scheduler);
 
     // Send and receive from sockets, accept connections
     threadGroup.create_thread(boost::bind(&TraceThread<void (*)()>, "net", &ThreadSocketHandler));

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -875,10 +875,11 @@ void ThreadSocketHandler()
                         LOCK(cs_vNodes);
                         BOOST_FOREACH(CNode *n, vNodes)
                         {
-                            int nodePriority = n->ipgroup.priority;
+                            CIPGroupData ngroup = FindGroupForIP(n->addr);
+                            int nodePriority = ngroup.priority;
                             if (nodePriority < ipgroup.priority) {
                                 LogPrintf("Connection slots exhausted, evicting peer %d with priority %d (group %s) to free up resources\n",
-                                          n->id, nodePriority, n->ipgroup.name == "" ? string("default") : n->ipgroup.name);
+                                          n->id, nodePriority, ngroup.name == "" ? string("default") : ngroup.name);
                                 n->fDisconnect = true;
                                 disconnected = true;
                                 // Leave shouldConnect = true to allow this socket through.
@@ -1997,7 +1998,7 @@ CNode::CNode(SOCKET hSocketIn, CAddress addrIn, std::string addrNameIn, bool fIn
         id = nLastNodeId++;
     }
 
-    ipgroup = FindGroupForIP(CNetAddr(addr.ToStringIP()));
+    CIPGroupData ipgroup = FindGroupForIP(CNetAddr(addr.ToStringIP()));
     std::string strIpGroup = ipgroup.name != "" ? tfm::format("(group %s)", ipgroup.name) : "";
     if (fLogIPs)
         LogPrint("net", "Added connection to %s peer=%d %s\n", addrName, id, strIpGroup);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -868,6 +868,11 @@ void ThreadSocketHandler()
                 {
                     // Calculate the priority of the new IP to see if we should drop it immediately (normal) or kick
                     // one of the other peers out to make room for it.
+
+                    // TODO: Lower the priority of an IP as it establishes more connections.
+                    // The goal is to force an attacker to spread out in order to get lots of priority.
+
+                    // See if this IP has static prio data from a group.
                     CIPGroupData ipgroup = FindGroupForIP(addr);
 
                     bool disconnected = false;

--- a/src/net.h
+++ b/src/net.h
@@ -287,10 +287,6 @@ public:
     CBloomFilter* pfilter;
     int nRefCount;
     NodeId id;
-
-    // IP group
-    CIPGroupData ipgroup;
-
 protected:
 
     // Denial-of-service detection/prevention

--- a/src/test/ipgroups_tests.cpp
+++ b/src/test/ipgroups_tests.cpp
@@ -6,7 +6,7 @@
 #include <boost/test/unit_test_suite.hpp>
 #include <boost/test/test_tools.hpp>
 
-extern std::vector<CSubNet> ParseTorData(std::string input);
+extern std::vector<CSubNet> ParseIPData(std::string input);
 
 BOOST_AUTO_TEST_SUITE(ipgroups_tests);
 
@@ -19,39 +19,34 @@ BOOST_AUTO_TEST_CASE(ipgroup)
     // If/when we have the ability to load labelled subnets from a file or persisted datastore, test that here.
 }
 
-BOOST_AUTO_TEST_CASE(parse_tor_data_ok)
+BOOST_AUTO_TEST_CASE(parse_ip_data_ok)
 {
     std::string data =
-            "ExitNode 0011BD2485AD45D984EC4159C88FC066E5E3300E\n"
-            "Published 2015-07-22 10:12:31\n"
-            "LastStatus 2015-07-22 11:02:47\n"
-            "ExitAddress 162.247.72.201 2015-07-22 11:09:35\n"
-            "ExitNode 0098C475875ABC4AA864738B1D1079F711C38287\n"
-            "Published 2015-07-22 02:00:35\n"
-            "LastStatus 2015-07-22 03:02:56\n"
-            "ExitAddress 162.248.160.151 2015-07-22 03:03:36";
+            "# You can update this list by visiting https://check.torproject.org/cgi-bin/TorBulkExitList.py?ip=185.25.95.132&port=8333 #\n"
+            "# This file was generated on Thu Aug 27 14:04:18 UTC 2015 #\n"
+            "1.160.81.87\n"
+            "1.160.87.94\n"
+            "1.2.3.4/24";
 
-    std::vector<CSubNet> subnets = ParseTorData(data);
-    BOOST_CHECK(subnets[0] == CSubNet("162.247.72.201/32"));
-    BOOST_CHECK(subnets[1] == CSubNet("162.248.160.151/32"));
-
-    BOOST_CHECK_EQUAL(ParseTorData("ExitAddress [2a00:1450:400a:805::1007]")[0].ToString(), "2a00:1450:400a:805::1007/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
+    std::vector<CSubNet> subnets = ParseIPData(data);
+    BOOST_CHECK(subnets[0] == CSubNet("1.160.81.87/32"));
+    BOOST_CHECK(subnets[1] == CSubNet("1.160.87.94/32"));
+    BOOST_CHECK(subnets[2] == CSubNet("1.2.3.4/24"));
 }
 
-BOOST_AUTO_TEST_CASE(parse_tor_data_bad)
+BOOST_AUTO_TEST_CASE(parse_ip_data_bad)
 {
-    BOOST_CHECK_EQUAL(ParseTorData("").size(), 0);
-    BOOST_CHECK_EQUAL(ParseTorData("Blah blah blah\t\t").size(), 0);
-    BOOST_CHECK_EQUAL(ParseTorData("ExitAddress").size(), 0);
-    BOOST_CHECK_EQUAL(ParseTorData("ExitAddress 256.0.0.0").size(), 0);
-    BOOST_CHECK_EQUAL(ParseTorData("ExitAddress -1.0.0.0").size(), 0);
-    BOOST_CHECK_EQUAL(ParseTorData("ExitAddress 1.2.3.4/24").size(), 0);
-    BOOST_CHECK_EQUAL(ParseTorData("ExitAddress 1.2.").size(), 0);
+    BOOST_CHECK_EQUAL(ParseIPData("").size(), 0);
+    BOOST_CHECK_EQUAL(ParseIPData("Blah blah blah\t\t").size(), 0);
+    BOOST_CHECK_EQUAL(ParseIPData("   #").size(), 0);
+    BOOST_CHECK_EQUAL(ParseIPData("256.0.0.0").size(), 0);
+    BOOST_CHECK_EQUAL(ParseIPData("-1.0.0.0").size(), 0);
+    BOOST_CHECK_EQUAL(ParseIPData("1.2.").size(), 0);
 
     // These tests reveal that the CSubNet parser can sometimes fail to spot that a subnet specification is invalid.
     // If/when CSubNet("") is tightened up we can have more aggressive testing of junk here.
-    // BOOST_CHECK_EQUAL(ParseTorData("ExitAddress 1.2.3")[0].ToString(), "1.2.3.0/24");
-    // BOOST_CHECK_EQUAL(ParseTorData("ExitAddress [2a00:1450:400a:805::").size(), 0);   // truncated
+    // BOOST_CHECK_EQUAL(ParseIPData("1.2.3")[0].ToString(), "1.2.3.0/24");
+    // BOOST_CHECK_EQUAL(ParseIPData("[2a00:1450:400a:805::").size(), 0);   // truncated
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/p2p_protocol_tests.cpp
+++ b/src/test/p2p_protocol_tests.cpp
@@ -1,0 +1,111 @@
+// Copyright (c) 2011-2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "main.h"
+
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(p2p_protocol_tests, TestingSetup)
+
+BOOST_AUTO_TEST_CASE(MaxSizeVersionMessage)
+{
+    CNode n(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    nLocalHostNonce = 2; // this trips the version message logic to end shortly after reading the data (which is the focus of this test)
+    s << PROTOCOL_VERSION;
+    s << n.nServices;
+    s << GetTime();
+    s << CAddress(CService("0.0.0.0", 0));
+    s << CAddress(CService("0.0.0.0", 0));
+    s << nLocalHostNonce;
+    s << std::string(256, 'a'); // 256 is the max allowed length in the Bitcoin Core/XT protocol processing code
+    s << n.nStartingHeight;
+    s << n.fRelayTxes;
+    BOOST_CHECK_EQUAL(352, s.size());
+    BOOST_CHECK(ProcessMessage(&n, "version", s, 0));
+}
+
+BOOST_AUTO_TEST_CASE(OverMaxSizeVersionMessage)
+{
+    CNode n(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    nLocalHostNonce = 2; // this trips the version message logic to end shortly after reading the data (which is the focus of this test)
+    s << PROTOCOL_VERSION;
+    s << n.nServices;
+    s << GetTime();
+    s << CAddress(CService("0.0.0.0", 0));
+    s << CAddress(CService("0.0.0.0", 0));
+    s << nLocalHostNonce;
+    s << std::string(257, 'a'); // invalid, max is 256
+    s << n.nStartingHeight;
+    s << n.fRelayTxes;
+    BOOST_CHECK_EQUAL(353, s.size());
+    BOOST_CHECK_THROW(ProcessMessage(&n, "version", s, 0), std::ios_base::failure);
+}
+
+BOOST_AUTO_TEST_CASE(MaxSizeWeirdRejectMessage)
+{
+    CNode n(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    n.nVersion = PROTOCOL_VERSION;
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    s << std::string(12, 'a'); // not a real command, but it uses the max of 12 here.
+    s << (uint8_t)0x10;
+    s << std::string(111, 'a');
+    BOOST_CHECK_EQUAL(126, s.size());
+    bool temp = fDebug;
+    fDebug = true;
+    BOOST_CHECK(ProcessMessage(&n, "reject", s, 0));
+    fDebug = temp;
+}
+
+BOOST_AUTO_TEST_CASE(MaxSizeValidRejectMessage)
+{
+    CNode n(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    n.nVersion = PROTOCOL_VERSION;
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    s << std::string("block"); // does not use the max of 12, but "block" is the longest command that has a defined extension of 32 bytes
+    s << (uint8_t)0x10;
+    s << std::string(111, 'a');
+    s << uint256();
+    BOOST_CHECK_EQUAL(151, s.size());
+    bool temp = fDebug;
+    fDebug = true;
+    BOOST_CHECK(ProcessMessage(&n, "reject", s, 0));
+    fDebug = temp;
+}
+
+BOOST_AUTO_TEST_CASE(OverMaxSizeWeirdRejectMessage)
+{
+    CNode n(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    n.nVersion = PROTOCOL_VERSION;
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    s << std::string(13, 'a'); // invalid, max is 12
+    s << (uint8_t)0x10;
+    s << std::string(111, 'a');
+    BOOST_CHECK_EQUAL(127, s.size());
+    bool temp = fDebug;
+    fDebug = true;
+    BOOST_CHECK(!ProcessMessage(&n, "reject", s, 0)); // check this way since the reject message processing swallows the exception
+    fDebug = temp;
+}
+
+BOOST_AUTO_TEST_CASE(OverMaxSizeValidRejectMessage)
+{
+    CNode n(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    n.nVersion = PROTOCOL_VERSION;
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    s << std::string("block");
+    s << (uint8_t)0x10;
+    s << std::string(112, 'a'); // invalid, max is 111
+    s << uint256();
+    BOOST_CHECK_EQUAL(152, s.size());
+    bool temp = fDebug;
+    fDebug = true;
+    BOOST_CHECK(!ProcessMessage(&n, "reject", s, 0)); // check this way since the reject message processing swallows the exception
+    fDebug = temp;
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -32,7 +32,11 @@ int64_t GetTimeOffset()
 
 int64_t GetAdjustedTime()
 {
-    return GetTime() + GetTimeOffset();
+    if (GetBoolArg("-trustsystemclock", true)) {
+        return GetTime();
+    } else {
+        return GetTime() + GetTimeOffset();
+    }
 }
 
 static int64_t abs64(int64_t n)


### PR DESCRIPTION
* Can now load IP prio data from local files, specified via a new -ip-priority-source command line flag. It's not currently documented as the whole framework is still quite young and the flag will probably get new features in future like the ability to use a URL as well as a file.
* Switch the Tor URL used based on feedback from Isis Lovecruft. This also means we can use a simple unified IP format now where comment lines start with a hash and the rest are just IPs or netblock specifications.
* Tor data is no longer fetched if we don't have any routeable IPs. This means if you're behind a firewall and can't listen anyway, it won't put any load on the Tor servers even if the node itself doesn't have listening disabled or a proxy configured.
* Prio data is now calculated on demand instead of being cached, so reducing memory usage and making the framework more adaptive.
* Added a TODO comment to the network code about handling IPs that make many connections.

There are still many other things that can be improved.