### PR TITLE
Limit number of transactions in the memory pool

### DIFF
--- a/qa/rpc-tests/mempool_limit.py
+++ b/qa/rpc-tests/mempool_limit.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python2
+# Copyright (c) 2014 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test -maxmempooltx limit-number-of-transactions-in-mempool
+# code
+#
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+import os
+import shutil
+import time
+
+class MempoolCoinbaseTest(BitcoinTestFramework):
+
+    def setup_network(self):
+        # Three nodes
+        args = ["-maxmempooltx=11", "-checkmempool", "-debug=mempool"]
+        self.nodes = []
+        self.nodes.append(start_node(0, self.options.tmpdir, args))
+        self.nodes.append(start_node(1, self.options.tmpdir, args))
+        self.nodes.append(start_node(2, self.options.tmpdir, args))
+        connect_nodes_bi(self.nodes, 0, 1)
+        connect_nodes_bi(self.nodes, 0, 2)
+        self.is_network_split = False
+
+    def create_tx(self, from_txid, to_address, amount, node=0):
+        inputs = [{ "txid" : from_txid, "vout" : 0}]
+        outputs = { to_address : amount }
+        rawtx = self.nodes[node].createrawtransaction(inputs, outputs)
+        signresult = self.nodes[node].signrawtransaction(rawtx)
+        assert_equal(signresult["complete"], True)
+        return signresult["hex"]
+
+    def run_test(self):
+        node0_address = self.nodes[0].getnewaddress()
+        node1_address = self.nodes[1].getnewaddress()
+
+        # 20 transactions
+        b = [ self.nodes[0].getblockhash(n) for n in range(1, 21) ]
+        coinbase_txids = [ self.nodes[0].getblock(h)['tx'][0] for h in b ]
+        spends1_raw = [ self.create_tx(txid, node0_address, 50) for txid in coinbase_txids ]
+        spends1_id = [ self.nodes[0].sendrawtransaction(tx) for tx in spends1_raw ]
+
+        # -maxmempooltx doesn't evict transactions submitted via sendrawtransaction:
+        assert_equal(len(self.nodes[0].getrawmempool()), 20)
+
+        # ... and doesn't evict sendtoaddress() transactions:
+        spends1_id.append(self.nodes[0].sendtoaddress(node0_address, 50))
+        assert_equal(len(self.nodes[0].getrawmempool()), 21)
+
+        time.sleep(1) # wait just a bit for node0 to send transactions to node1
+
+        # ... node1's mempool should be limited
+        assert(len(self.nodes[1].getrawmempool()) <= 11)
+
+        # have other node create five transactions...
+        node1_txids = []
+        for i in range(5):
+            node1_txids.append(self.nodes[1].sendtoaddress(node1_address, 50))
+
+        # it's mempool should be limited, but should contain those txids:
+        node1_txs = set(self.nodes[1].getrawmempool())
+        assert(node1_txs.issuperset(node1_txids))
+        # The first send-to-self is guaranteed to evict another of node0's transaction.
+        # The second (and subsequent) might try (and fail) to evict the first
+        # send-to-self, in which case the mempool size can be bigger than -maxmempooltx
+        assert(len(self.nodes[1].getrawmempool()) <= 11+4)
+
+        time.sleep(1)
+
+        # node0's mempool should still have all its transactions:
+        node0_txs = set(self.nodes[0].getrawmempool())
+        assert(node0_txs.issuperset(spends1_id))
+
+
+        # Have each node mine a block, should empty mempools:
+        blocks = []
+        blocks.extend(self.nodes[0].generate(1))
+        sync_blocks(self.nodes)      
+        blocks.extend(self.nodes[1].generate(1))
+        sync_blocks(self.nodes)      
+
+        assert_equal(len(self.nodes[0].getrawmempool()), 0)
+        assert_equal(len(self.nodes[1].getrawmempool()), 0)
+
+        # Second test:
+        #    eviction of long chains of dependent transactions
+        parent_ids = [spends1_id[0], node1_txids[0]]
+        send_addresses = [node0_address, node1_address]
+        chained_ids = [[],[]]
+        send_amount = 50
+        for i in range(5):
+            send_amount = send_amount-0.001 # send with sufficient fee
+            for node in range(2):
+                raw = self.create_tx(parent_ids[node], send_addresses[node], send_amount, node)
+                parent_ids[node] = self.nodes[node].sendrawtransaction(raw)
+                chained_ids[node].append(parent_ids[node])
+
+        sync_mempools(self.nodes) # Wait for all ten txns in all mempools
+        assert_equal(len(self.nodes[2].getrawmempool()), 10)
+
+        # Have both nodes generate high-priority transactions to exercise chained-transaction-eviction
+        # code
+        tx_ids = [[],[]]
+        for i in range(3):
+            for node in range(2):
+                tx_ids[node].append(self.nodes[node].sendtoaddress(send_addresses[node], 25))
+
+        # Give a little time for transactions to make their way to node2, it's mempool should
+        # remain under limit
+        time.sleep(1)
+        assert(len(self.nodes[2].getrawmempool()) <= 11)
+
+if __name__ == '__main__':
+    MempoolCoinbaseTest().main()

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -313,6 +313,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-maxconnections=<n>", strprintf(_("Maintain at most <n> connections to peers (default: %u)"), 125));
     strUsage += HelpMessageOpt("-maxreceivebuffer=<n>", strprintf(_("Maximum per-connection receive buffer, <n>*1000 bytes (default: %u)"), 5000));
     strUsage += HelpMessageOpt("-maxsendbuffer=<n>", strprintf(_("Maximum per-connection send buffer, <n>*1000 bytes (default: %u)"), 1000));
+    strUsage += HelpMessageOpt("-maxmempooltx=<n>", ("Maximum number of transactions in memory pool (default: enough to fill about 25 blocks)"));
     strUsage += HelpMessageOpt("-onion=<ip:port>", strprintf(_("Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)"), "-proxy"));
     strUsage += HelpMessageOpt("-onlynet=<net>", _("Only connect to nodes in network <net> (ipv4, ipv6 or onion)"));
     strUsage += HelpMessageOpt("-permitbaremultisig", strprintf(_("Relay non-P2SH multisig (default: %u)"), 1));

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -219,6 +219,24 @@ void CTxMemPool::removeForBlock(const std::vector<CTransaction>& vtx, unsigned i
     minerPolicyEstimator->processBlock(nBlockHeight, entries, fCurrentEstimate);
 }
 
+void CTxMemPool::evictRandom(std::list<CTransaction>& evicted)
+{
+    LOCK(cs);
+    if (mapTx.empty())
+        return;
+    for (int i = 0; i < 11; i++) {
+        map<uint256, CTxMemPoolEntry>::iterator it = mapTx.lower_bound(GetRandHash());
+        if (it == mapTx.end())
+            it = mapTx.begin();
+        if (mapDeltas.find(it->first) != mapDeltas.end())
+            continue;  // prioritised: try again
+        remove(it->second.GetTx(), evicted, true);
+        return;
+    }
+    // There is a small chance nothing will be evicted if the mempool is mostly
+    // prioritised transactions. That's OK.
+}
+
 void CTxMemPool::clear()
 {
     LOCK(cs);
@@ -373,7 +391,7 @@ void CTxMemPool::PrioritiseTransaction(const uint256 hash, const string strHash,
         deltas.first += dPriorityDelta;
         deltas.second += nFeeDelta;
     }
-    LogPrintf("PrioritiseTransaction: %s priority += %f, fee += %d\n", strHash, dPriorityDelta, FormatMoney(nFeeDelta));
+    LogPrint("mempool", "PrioritiseTransaction: %s priority += %f, fee += %d\n", strHash, dPriorityDelta, FormatMoney(nFeeDelta));
 }
 
 void CTxMemPool::ApplyDeltas(const uint256 hash, double &dPriorityDelta, CAmount &nFeeDelta)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -118,6 +118,11 @@ public:
     void removeConflicts(const CTransaction &tx, std::list<CTransaction>& removed);
     void removeForBlock(const std::vector<CTransaction>& vtx, unsigned int nBlockHeight,
                         std::list<CTransaction>& conflicts, bool fCurrentEstimate = true);
+    // Try to evict a random transaction and its descendants,
+    // BUT will not evict prioritised transactions. Returns list of transactions
+    // evicted. If the memory pool is full of prioritised transactions, there is
+    // a chance it will evict nothing.
+    void evictRandom(std::list<CTransaction>& evicted);
     void clear();
     void queryHashes(std::vector<uint256>& vtxid);
     void pruneSpent(const uint256& hash, CCoins &coins);


### PR DESCRIPTION
Implement a simple strategy to keep the memory pool from consuming
all of memory, by limiting the number of tranasctions stored in
the memory pool.

By default, the limit is 6-blocks-worth of average-sized (500-byte)
transactionsl (12,000 transactions for 1MB blocks). Command-line
option -maxmempooltx overrides the default (and is useful for testing).

When the limit is hit, low-priority transactions are dropped
immediately. Higher priority transactions are added, and
a random transaction (and their descendants) are evicted
from the mempool.

BUT, transactions generated or submitted by ourselves (via
sendtoaddress/sendmany/sendrawtransation) are always allowed into
the mempool and are never evicted. And transactions marked as
important via the prioritsetransaction RPC call are also never
evicted.

To test:

Run with -maxmempooltx=500 -debug=mempool
example debug.log output:
```
2015-09-02 13:17:55 mempool full, dropped tx 0185aa01c280e5bf47fc5e586c1beb712bed3a3ce0f3ac57251bbc49ed786d79
2015-09-02 13:17:55 mempool full, dropped tx e852c5f2430357ee7485f927f189218fffb73368715e5b884afb31a10ccdac68
2015-09-02 13:17:55 mempool full, dropped tx 0185aa01c280e5bf47fc5e586c1beb712bed3a3ce0f3ac57251bbc49ed786d79
2015-09-02 13:17:56 mempool full, dropped tx 30badbcc9721e2d78c480c8b81a4de2274daf6a95b7ff3b32ab40d00dbd2070f
2015-09-02 13:17:56 mempool full, evicted tx e388638f6fb34dc072a4526ba2a5cd34a6e8169bb3d75c083a16d0990667921d
2015-09-02 13:17:56 AcceptToMemoryPool: peer=3 /Satoshi:0.11.0/: accepted 7a8bee60593727b4e74033ace208fa463400d7d269b514b7ff2beca31890957b (poolsz 500)
```
