### PR TITLE
Survey

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -99,6 +99,7 @@ BITCOIN_CORE_H = \
   hash.h \
   init.h \
   ipgroups.h \
+  curl_wrapper.h \
   key.h \
   keystore.h \
   leveldbwrapper.h \
@@ -183,6 +184,7 @@ libbitcoin_server_a_SOURCES = \
   checkpoints.cpp \
   init.cpp \
   ipgroups.cpp \
+  curl_wrapper.cpp \
   leveldbwrapper.cpp \
   main.cpp \
   merkleblock.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -99,6 +99,7 @@ BITCOIN_CORE_H = \
   hash.h \
   init.h \
   ipgroups.h \
+  survey.h \
   curl_wrapper.h \
   key.h \
   keystore.h \
@@ -184,6 +185,7 @@ libbitcoin_server_a_SOURCES = \
   checkpoints.cpp \
   init.cpp \
   ipgroups.cpp \
+  survey.cpp \
   curl_wrapper.cpp \
   leveldbwrapper.cpp \
   main.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -51,6 +51,7 @@ BITCOIN_TESTS =\
   test/getarg_tests.cpp \
   test/hash_tests.cpp \
   test/ipgroups_tests.cpp \
+  test/survey_tests.cpp \
   test/key_tests.cpp \
   test/main_tests.cpp \
   test/mempool_tests.cpp \

--- a/src/curl_wrapper.cpp
+++ b/src/curl_wrapper.cpp
@@ -1,0 +1,152 @@
+#include "curl_wrapper.h"
+#include "util.h"
+#ifdef WIN32
+#define CURL_STATICLIB
+#endif
+#include <curl/curl.h>
+#include <boost/filesystem.hpp>
+
+using namespace std;
+typedef void CURL;
+
+// As of July 2015 the Tor IPs document is only 169kb in size so this is plenty.
+static const size_t MAX_DOWNLOAD_SIZE = 1024 * 1024;
+
+namespace {
+
+    struct CurlInitWrapper {
+        
+        CurlInitWrapper() {
+
+            CURLcode rv = curl_global_init(CURL_GLOBAL_ALL);
+            curlOK = (rv == CURLE_OK);
+
+            if (!curlOK)
+                LogPrintf("libcurl failed to initialize\n");
+        }
+        ~CurlInitWrapper() {
+            curl_global_cleanup();
+        }
+
+        bool curlOK;
+    };
+
+    
+    static size_t CurlData(void *ptr, size_t size, size_t nmemb, void *user_ptr) {
+        string *data = static_cast<string*>(user_ptr);
+        string buf(static_cast<const char *>(ptr), size*nmemb);
+        size_t realsize = size * nmemb;
+        if (data->size() + realsize > MAX_DOWNLOAD_SIZE)
+            return 0;  // Abort.
+        data->append(buf);
+        return realsize;
+    }
+}
+
+
+struct CurlWrapperImpl : public CurlWrapper {
+
+    CurlWrapperImpl(CURL* h) : handle(h) {
+        assert(h);
+
+        // If -curl-verbose is specified, debug info and headers will be printed to stderr.
+        curl_easy_setopt(handle, CURLOPT_VERBOSE, GetBoolArg("-curl-verbose", false) ? 1L : 0L);
+        curl_easy_setopt(handle, CURLOPT_HEADER, 0L);
+        curl_easy_setopt(handle, CURLOPT_NOPROGRESS, 1L);
+        curl_easy_setopt(handle, CURLOPT_NOSIGNAL, 1L);
+        // Follow redirects
+        curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, 1L); 
+        curl_easy_setopt(handle, CURLOPT_USERAGENT, "Bitcoin XT");
+        // Don't use up sockets on the target website unnecessarily.
+        curl_easy_setopt(handle, CURLOPT_FORBID_REUSE, 1L);   
+        
+        // curl/openssl seem to know how to use the platform CA store on win/mac.
+#if !defined(WIN32) && !defined(MAC_OSX)
+        // On Linux/BSD/etc try a couple of places we know CA bundles are often kept.
+        if (boost::filesystem::exists(boost::filesystem::path("/etc/ssl/certs/ca-certificates.crt"))) {
+            curl_easy_setopt(handle, CURLOPT_CAINFO, "/etc/ssl/certs/ca-certificates.crt");
+        } else if (boost::filesystem::exists(boost::filesystem::path("/etc/ssl/certs/ca-bundle.crt"))) {
+            curl_easy_setopt(handle, CURLOPT_CAINFO, "/etc/ssl/certs/ca-bundle.crt");
+        } else {
+            // Disable use of the system CA store :( We can't simply 
+            // present our hard coded cert to be used in addition
+            // because the curl API just doesn't support that. It's one or the 
+            // other. Our callback function will configure
+            // the cert used by the website as of the time of writing.
+            curl_easy_setopt(handle, CURLOPT_CAPATH, NULL);
+            curl_easy_setopt(handle, CURLOPT_CAINFO, NULL);
+    }
+#endif
+    }
+
+    virtual std::pair<int, std::string> fetchURL(const std::string& url) {
+        lastUrl = url;
+        std::string data;
+
+        curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, &CurlData);
+        curl_easy_setopt(handle, CURLOPT_WRITEDATA, &data);
+        curl_easy_setopt(handle, CURLOPT_URL, url.c_str());
+
+        CURLcode rv = curl_easy_perform(handle);
+        if (rv != CURLE_OK && GetBoolArg("-curl-verbose", false))
+            LogPrintf("Curl failed to fetch '%s': %s\n", url.c_str(), curl_easy_strerror(rv));
+        
+        long httpCode;
+        curl_easy_getinfo(handle, CURLINFO_RESPONSE_CODE, &httpCode);
+        return std::make_pair(httpCode, data);
+    }
+
+    virtual CURL* getHandle() { return handle; } 
+
+    virtual std::string getLastURL() const { return lastUrl; }
+
+    private:
+        std::string lastUrl;
+        CURL* handle;
+};
+
+struct BrokenCurl : public CurlWrapper {
+    virtual std::pair<int, std::string> fetchURL(const std::string& url) {
+        lastUrl = url;
+        LogPrintf(std::string("Cannot fetch '" + url + "', curl failed to init.\n").c_str());
+        return std::make_pair(-1, std::string());
+    }
+
+    virtual CURL* getHandle() { return NULL; }
+    virtual std::string getLastURL() const { return lastUrl; }
+        
+    std::string lastUrl;
+};
+
+/// For unittests.
+struct DummyCurlWrapper : public CurlWrapper {
+    
+    DummyCurlWrapper(int c, const std::string& resp) : code(c), content(resp) 
+    {
+    }
+    
+    virtual std::pair<int, std::string> fetchURL(const std::string& url) {
+        lastUrl = url;
+        return std::make_pair(code, content);
+    }
+    virtual CURL* getHandle() { return NULL; }
+    virtual std::string getLastURL() const { return lastUrl; }
+    int code;
+    std::string content;
+    std::string lastUrl;
+};
+
+std::auto_ptr<CurlWrapper> MakeCurl() {
+    static CurlInitWrapper c;
+    if (!c.curlOK)
+        return std::auto_ptr<CurlWrapper>(new BrokenCurl);
+
+    CURL* curl = curl_easy_init();
+    return curl
+        ? std::auto_ptr<CurlWrapper>(new CurlWrapperImpl(curl))
+        : std::auto_ptr<CurlWrapper>(new BrokenCurl);
+}
+
+std::auto_ptr<CurlWrapper> MakeDummyCurl(int code, const std::string& resp) {
+    return std::auto_ptr<CurlWrapper>(new DummyCurlWrapper(code, resp));
+}

--- a/src/curl_wrapper.h
+++ b/src/curl_wrapper.h
@@ -1,0 +1,27 @@
+#ifndef BITCOIN_CURLWRAPPER_H
+#define BITCOIN_CURLWRAPPER_H
+
+#include <string>
+#include <utility>
+#include <memory>
+
+typedef void CURL;
+
+struct CurlWrapper {
+    
+    virtual std::pair<int, std::string> fetchURL(const std::string&) = 0;
+
+    virtual CURL* getHandle() = 0;
+    
+    // for unit testing
+    virtual std::string getLastURL() const = 0;
+    
+    virtual ~CurlWrapper();
+
+};
+inline CurlWrapper::~CurlWrapper() { }
+
+std::auto_ptr<CurlWrapper> MakeCurl();
+std::auto_ptr<CurlWrapper> MakeDummyCurl(int retcode, const std::string& resp);
+
+#endif

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1451,5 +1451,11 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     }
 #endif
 
+    // Enable survey if user is in stealth mode - unless user explicitly disables it. This way we 
+    // can still track how many XT nodes are out there.
+    if (GetBoolArg("-stealth-mode", false))
+        if (SoftSetBoolArg("-survey", true))
+            LogPrintf("%s: parameter interaction: -stealth-mode=1 -> setting -survey=1\n", __func__);
+
     return !fRequestShutdown;
 }

--- a/src/ipgroups.cpp
+++ b/src/ipgroups.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <boost/foreach.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/algorithm/string.hpp>
 #ifdef WIN32
@@ -21,14 +20,13 @@
 #include "torips.h"
 #include "utilstrencodings.h"
 #include "util.h"
+#include "curl_wrapper.h"
 
 using namespace std;
 
 CCriticalSection cs_groups;
 static vector<CIPGroup> groups;
 
-// As of July 2015 the Tor IPs document is only 169kb in size so this is plenty.
-static const size_t MAX_DOWNLOAD_SIZE = 1024 * 1024;
 static const int OPEN_PROXY_PRIORITY = -10;
 
 
@@ -56,16 +54,6 @@ CIPGroupData FindGroupForIP(CNetAddr ip) {
     return CIPGroupData();
 }
 
-static size_t CurlData(void *ptr, size_t size, size_t nmemb, void *user_ptr) {
-    string *data = static_cast<string*>(user_ptr);
-    string buf(static_cast<const char *>(ptr), size*nmemb);
-    size_t realsize = size * nmemb;
-    if (data->size() + realsize > MAX_DOWNLOAD_SIZE)
-        return 0;  // Abort.
-    data->append(buf);
-    return realsize;
-}
-
 vector<CSubNet> ParseIPData(string input) {
     vector<string> lines;
     vector<CSubNet> results;
@@ -84,27 +72,6 @@ vector<CSubNet> ParseIPData(string input) {
     }
     return results;
 }
-
-struct CurlWrapper {
-    CURL *handle;
-
-    CurlWrapper() {
-        CURLcode rv = curl_global_init(CURL_GLOBAL_ALL);
-        if (rv != CURLE_OK) {
-            LogPrintf("libcurl failed to initialize, cannot load IP priority data: %s\n", curl_easy_strerror(rv));
-            handle = NULL;
-        } else {
-            handle = curl_easy_init();
-        }
-    }
-
-    ~CurlWrapper() {
-        if (handle != NULL) {
-            curl_easy_cleanup(handle);
-            curl_global_cleanup();
-        }
-    }
-};
 
 // Hack around the fact that some platforms, especially on Linux, have root stores
 // that openssl/curl can't find by default. This is the root cert used by check.torproject.org
@@ -163,47 +130,19 @@ static CURLcode ssl_context_setup(CURL *curl, void *sslctx, void *param) {
 }
 
 static CIPGroup *LoadIPDataFromWeb(const string &url, const string &groupname, int priority) {
-    string data;
 
-    CurlWrapper curlWrapper;
-    CURL *curl = curlWrapper.handle;
+    std::auto_ptr<CurlWrapper> curlWrapper = MakeCurl();
+    CURL *curl = curlWrapper->getHandle();
     if (curl == NULL)
         return NULL;
 
-    // If -curl-verbose is specified, debug info and headers will be printed to stderr.
-    curl_easy_setopt(curl, CURLOPT_VERBOSE, GetBoolArg("-curl-verbose", false) ? 1L : 0L);
-    curl_easy_setopt(curl, CURLOPT_HEADER, 0L);
-    curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1L);
-    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
-    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);   // Follow redirects
-    curl_easy_setopt(curl, CURLOPT_USERAGENT, "Bitcoin XT");
-    curl_easy_setopt(curl, CURLOPT_FORBID_REUSE, 1L);   // Don't use up sockets on the target website unnecessarily.
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &CurlData);
-    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &data);
     curl_easy_setopt(curl, CURLOPT_SSL_CTX_FUNCTION, &ssl_context_setup);
-    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
-
-    // curl/openssl seem to know how to use the platform CA store on win/mac.
-#if !defined(WIN32) && !defined(MAC_OSX)
-    // On Linux/BSD/etc try a couple of places we know CA bundles are often kept.
-    if (boost::filesystem::exists(boost::filesystem::path("/etc/ssl/certs/ca-certificates.crt"))) {
-        curl_easy_setopt(curl, CURLOPT_CAINFO, "/etc/ssl/certs/ca-certificates.crt");
-    } else if (boost::filesystem::exists(boost::filesystem::path("/etc/ssl/certs/ca-bundle.crt"))) {
-        curl_easy_setopt(curl, CURLOPT_CAINFO, "/etc/ssl/certs/ca-bundle.crt");
-    } else {
-        // Disable use of the system CA store :( We can't simply present our hard coded cert to be used in addition
-        // because the curl API just doesn't support that. It's one or the other. Our callback function will configure
-        // the cert used by the website as of the time of writing.
-        curl_easy_setopt(curl, CURLOPT_CAPATH, NULL);
-        curl_easy_setopt(curl, CURLOPT_CAINFO, NULL);
-    }
-#endif
 
     // This will block until the download is done.
-    CURLcode rv = curl_easy_perform(curl);
-    if (rv == CURLE_OK) {
+    std::pair<int, string> ret = curlWrapper->fetchURL(url);
+    if (ret.first == 200) {
         LogPrintf("IP list download succeeded from %s\n", url.c_str());
-        vector<CSubNet> subnets = ParseIPData(data);
+        vector<CSubNet> subnets = ParseIPData(ret.second);
         if (subnets.size() > 0) {
             CIPGroup *ipGroup = new CIPGroup;
             ipGroup->header.name = groupname;
@@ -212,7 +151,7 @@ static CIPGroup *LoadIPDataFromWeb(const string &url, const string &groupname, i
             return ipGroup;
         }
     } else {
-        LogPrintf("Failed to download IP priority data from %s: %s\n", url.c_str(), curl_easy_strerror(rv));
+        LogPrintf("Failed to download IP priority data from %s: %d\n", url.c_str(), ret.first);
     }
     return NULL;
 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -17,6 +17,8 @@
 #include "ui_interface.h"
 #include "crypto/common.h"
 #include "ipgroups.h"
+#include "survey.h"
+#include "curl_wrapper.h"
 
 #ifdef WIN32
 #include <string.h>
@@ -1696,6 +1698,12 @@ void StartNode(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     // Dump network addresses
     scheduler.scheduleEvery(&DumpAddresses, DUMP_ADDRESSES_INTERVAL);
+
+    if (GetBoolArg("-survey", false))
+    {
+        static Survey s(scheduler, std::auto_ptr<VersionNotifier>(
+                    new VersionNotifier()), MakeCurl());
+    }
 }
 
 bool StopNode()

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -45,14 +45,14 @@ public:
     void schedule(Function f, boost::chrono::system_clock::time_point t);
 
     // Convenience method: call f once deltaSeconds from now
-    void scheduleFromNow(Function f, int64_t deltaSeconds);
+    virtual void scheduleFromNow(Function f, int64_t deltaSeconds);
 
     // Another convenience method: call f approximately
     // every deltaSeconds forever, starting deltaSeconds from now.
     // To be more precise: every time f is finished, it
     // is rescheduled to run deltaSeconds later. If you
     // need more accurate scheduling, don't use this method.
-    void scheduleEvery(Function f, int64_t deltaSeconds);
+    virtual void scheduleEvery(Function f, int64_t deltaSeconds);
 
     // To keep things as simple as possible, there is no unschedule.
 

--- a/src/survey.cpp
+++ b/src/survey.cpp
@@ -1,0 +1,96 @@
+#include "survey.h"
+#include "clientversion.h"
+#include "chainparams.h"
+#include "curl_wrapper.h"
+#include "scheduler.h"
+#include "ui_interface.h"
+#include "util.h"
+#include "utilstrencodings.h"
+#include <boost/algorithm/string.hpp>
+
+static const std::string SURVEY_URL = "https://survey.bitcoinxt.software/v1/hello";
+static const int DEFAULT_SURVEY_POLL_INTERVAL = 60 * 60 * 24;  // Once per day
+
+void VersionNotifier::Notify(const std::string& newver, bool isImportant)
+{
+
+    std::string msg = _("Info: A new version of Bitcoin XT is available.");
+    std::string important = _("This version is an important upgrade! Please upgrade now!");
+    std::string verstr = _("New version is: ");
+    verstr += newver;
+
+    Log("*** " + msg + " " + (isImportant ? important + " " : " ") + verstr + "\n");
+
+    static bool popupShown = false;
+ 
+    if (!isImportant && !popupShown)
+        ShowUIInfo(msg + " " + verstr);
+
+    if (isImportant) {
+        // Ignore popupShown. Bug the user every day.
+        ShowUIWarning(msg + " " + important + " " + verstr);
+
+        // We only replace misc warning if it's important.
+        // We don't want to replace what might be an important warning needlessly.
+        SetMiscWarning(msg + " " + important);
+    }
+    popupShown = true;
+}
+
+void VersionNotifier::ShowUIWarning(const std::string& msg) {
+    uiInterface.ThreadSafeMessageBox(msg, "", CClientUIInterface::MSG_WARNING);
+}
+
+void VersionNotifier::ShowUIInfo(const std::string& msg) {
+    uiInterface.ThreadSafeMessageBox(msg, "", CClientUIInterface::MSG_INFORMATION);
+}
+
+void VersionNotifier::SetMiscWarning(const std::string& w) { strMiscWarning = w; }
+void VersionNotifier::Log(const std::string& s) { LogPrintf(s.c_str()); }
+
+Survey::Survey(CScheduler& scheduler, 
+        std::auto_ptr<VersionNotifier> v, 
+        std::auto_ptr<CurlWrapper> c) :
+    verNotifier(v), curl(c) {
+
+    scheduler.scheduleFromNow(boost::bind(&Survey::pollSurvey, this), 0);
+    scheduler.scheduleEvery(boost::bind(&Survey::pollSurvey, this),
+            GetArg("-poll-survey-seconds", DEFAULT_SURVEY_POLL_INTERVAL));
+}
+
+Survey::~Survey() { }
+
+void Survey::pollSurvey() {
+
+    bool listening = GetBoolArg("-listen", false);
+    int port = GetArg("-port", Params().GetDefaultPort());
+    std::stringstream url;
+    url << SURVEY_URL << "?v=" << CLIENT_VERSION << "&listening=" 
+        << (listening ? "true" : "false");
+    if (listening)
+        url << "&port=" << port;
+
+    std::pair<int, std::string> res = curl->fetchURL(url.str());
+    if (res.first != 200) {
+        LogPrintf("Failed to poll '%s': %d\n", url.str().c_str(), res.first);
+        return;
+    }
+
+    bool important = false;
+    bool newAvailable = false;
+    std::string newVersion;
+    
+    std::vector<std::string> vars;
+    boost::split(vars, res.second, boost::is_any_of(";"));
+    if (vars.size() < 3) 
+    {
+        LogPrintf("Failed to parse survey response\n");
+        return;
+    }
+    newAvailable = bool(atoi(vars[0]));
+    important = bool(atoi(vars[1]));
+    newVersion = vars[2];
+
+    if (newAvailable)
+        verNotifier->Notify(newVersion, important);
+}

--- a/src/survey.h
+++ b/src/survey.h
@@ -1,0 +1,32 @@
+#ifndef BITCOIN_SURVEY_H
+#define BITCOIN_SURVEY_H
+
+#include <string>
+#include <memory>
+
+class CScheduler;
+class CurlWrapper;
+
+struct VersionNotifier {
+    void Notify(const std::string& newver, bool isImportant);
+
+    private:
+        virtual void ShowUIWarning(const std::string&);
+        virtual void ShowUIInfo(const std::string&);
+        virtual void SetMiscWarning(const std::string&);
+        virtual void Log(const std::string&);
+};
+
+class Survey {
+    public:
+        Survey(CScheduler&, std::auto_ptr<VersionNotifier>, std::auto_ptr<CurlWrapper>);
+        ~Survey();
+
+    private:
+        std::auto_ptr<VersionNotifier> verNotifier;
+        std::auto_ptr<CurlWrapper> curl;
+
+        void pollSurvey();
+};
+
+#endif

--- a/src/test/survey_tests.cpp
+++ b/src/test/survey_tests.cpp
@@ -1,0 +1,187 @@
+// Copyright (c) 2015- The Bitcoin XT developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
+#include <boost/test/unit_test_suite.hpp>
+#include <boost/test/test_tools.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+
+#include "curl_wrapper.h"
+#include "clientversion.h"
+#include "ipgroups.h"
+#include "scheduler.h"
+#include "survey.h"
+#include "util.h"
+
+#include <memory>
+//#include "test/test_bitcoin.h"
+
+
+extern std::vector<CSubNet> ParseIPData(std::string input);
+
+BOOST_AUTO_TEST_SUITE(survey_tests);
+
+namespace {
+    std::string surveyResp(bool newVerison, bool isImportant) {
+        // new version available;is important;latest version string
+        std::stringstream ss;
+        ss << (newVerison ? 1 : 0) << ";"
+           << (isImportant ? 1 : 0) << ";"
+           << "latest and greatest!";
+        return ss.str();
+    }
+
+    struct DummyScheduler : public CScheduler {
+        DummyScheduler() : scheduledEvery(-1) { }
+
+        void scheduleFromNow(Function f, int64_t) {
+            f();
+        }
+        void scheduleEvery(Function f, int64_t deltaSeconds) {
+            scheduledEvery = deltaSeconds;
+        }
+
+        int64_t scheduledEvery;
+    };
+
+    struct DummyVersionNotifier : public VersionNotifier {
+        virtual void ShowUIWarning(const std::string&) { uiwarn++; }
+        virtual void ShowUIInfo(const std::string&) { uiinfo++; }
+        virtual void SetMiscWarning(const std::string&) { miscwarn++; }
+        virtual void Log(const std::string&) { log++; }
+
+        int uiwarn;
+        int uiinfo;
+        int miscwarn;
+        int log;
+    };
+
+    std::auto_ptr<VersionNotifier> MakeDummyVer() {
+        return std::auto_ptr<VersionNotifier>(new DummyVersionNotifier());
+    }
+
+} // ns anon
+
+BOOST_AUTO_TEST_CASE(survey_no_new_version)
+{
+    DummyScheduler s;
+    DummyVersionNotifier *v = new DummyVersionNotifier();
+    Survey survey(s, std::auto_ptr<VersionNotifier>(v),
+            MakeDummyCurl(200, surveyResp(false, false)));
+
+    // Should not have notified the user of anything.
+    BOOST_CHECK_EQUAL(v->uiwarn, 0);
+    BOOST_CHECK_EQUAL(v->uiinfo, 0);
+    BOOST_CHECK_EQUAL(v->miscwarn, 0);
+    BOOST_CHECK_EQUAL(v->log, 0);
+}
+
+BOOST_AUTO_TEST_CASE(survey_new_version)
+{
+    DummyScheduler s;
+    DummyVersionNotifier *v = new DummyVersionNotifier();
+    Survey survey(s, std::auto_ptr<VersionNotifier>(v),
+            MakeDummyCurl(200, surveyResp(true, false)));
+
+    // Should have notified the user, but not warned.
+    BOOST_CHECK_EQUAL(v->uiwarn, 0);
+    BOOST_CHECK_EQUAL(v->uiinfo, 1);
+    BOOST_CHECK_EQUAL(v->miscwarn, 0);
+    BOOST_CHECK_EQUAL(v->log, 1);
+}
+
+BOOST_AUTO_TEST_CASE(survey_new_important_version)
+{
+    DummyScheduler s;
+    DummyVersionNotifier *v = new DummyVersionNotifier();
+    Survey survey(s, std::auto_ptr<VersionNotifier>(v),
+            MakeDummyCurl(200, surveyResp(true, true)));
+
+    // Should have warned the user.
+    BOOST_CHECK_EQUAL(v->uiwarn, 1);
+    BOOST_CHECK_EQUAL(v->uiinfo, 0);
+    BOOST_CHECK_EQUAL(v->miscwarn, 1);
+    BOOST_CHECK_EQUAL(v->log, 1);
+}
+
+BOOST_AUTO_TEST_CASE(survey_important_not_new)
+{
+    DummyScheduler s;
+    DummyVersionNotifier *v = new DummyVersionNotifier();
+    Survey survey(s, std::auto_ptr<VersionNotifier>(v),
+            MakeDummyCurl(200, surveyResp(false, true)));
+
+    // Important but not new? Does not make sense. Don't notify.
+    BOOST_CHECK_EQUAL(v->uiwarn, 0);
+    BOOST_CHECK_EQUAL(v->uiinfo, 0);
+    BOOST_CHECK_EQUAL(v->miscwarn, 0);
+    BOOST_CHECK_EQUAL(v->log, 0);
+}
+
+BOOST_AUTO_TEST_CASE(survey_404s) {
+    DummyScheduler s;
+    DummyVersionNotifier *v = new DummyVersionNotifier();
+    Survey survey(s, std::auto_ptr<VersionNotifier>(v),
+            MakeDummyCurl(404, ""));
+
+    BOOST_CHECK_EQUAL(v->uiwarn, 0);
+    BOOST_CHECK_EQUAL(v->uiinfo, 0);
+    BOOST_CHECK_EQUAL(v->miscwarn, 0);
+    BOOST_CHECK_EQUAL(v->log, 0);
+
+}
+
+BOOST_AUTO_TEST_CASE(url_correct_params) {
+    DummyScheduler s;
+    {
+        std::stringstream exp;
+        exp << "?v=" << CLIENT_VERSION << "&listening=false";
+        
+        std::auto_ptr<CurlWrapper> c = MakeDummyCurl(200, "");
+        CurlWrapper* cptr = c.get();
+
+        const char *argv[] = {"ignored", "-listen=0"};
+        ParseParameters(2, argv);
+
+        Survey survey(s, MakeDummyVer(), c);
+        BOOST_CHECK(boost::algorithm::ends_with(cptr->getLastURL(), exp.str()));
+    }
+
+    { 
+        std::stringstream exp;
+        exp << "?v=" << CLIENT_VERSION << "&listening=true&port=1234";
+        
+        const char *argv[] = {"ignored", "-listen=1", "-port=1234"};
+        ParseParameters(3, argv);
+        
+        std::auto_ptr<CurlWrapper> c = MakeDummyCurl(200, "");
+        CurlWrapper* cptr = c.get();
+
+        Survey survey(s, MakeDummyVer(), c);
+
+        BOOST_CHECK(boost::algorithm::ends_with(cptr->getLastURL(), exp.str()));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(garbage_does_nothing) {
+    DummyScheduler s;
+    DummyVersionNotifier *v = new DummyVersionNotifier();
+    Survey survey(s, std::auto_ptr<VersionNotifier>(v),
+            MakeDummyCurl(200, "garbage response"));
+
+    BOOST_CHECK_EQUAL(v->uiwarn, 0);
+    BOOST_CHECK_EQUAL(v->uiinfo, 0);
+    BOOST_CHECK_EQUAL(v->miscwarn, 0);
+    BOOST_CHECK_EQUAL(v->log, 0);
+}
+
+BOOST_AUTO_TEST_CASE(scheduled_once_per_day) {
+    DummyScheduler s;
+    Survey survey(s, MakeDummyVer(), MakeDummyCurl(200, ""));
+
+    BOOST_CHECK_EQUAL(s.scheduledEvery, 60 * 60 * 24);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This is an opt-in for XT survey that users can enable to poll our website and tell us they are running an XT node. This was suggested on the mailing list (not by me) as a method of knowing how many XT nodes are out there while still in stealth mode.

If _in_ stealth mode, I've made it an opt-out. The defaults can be discussed.

As a bonus, as also suggested on the mailing list, this can be used to notify users that a new version is available.

For now I have not implemented a backend for this (the website). It's only tested with the unittests I've written. I don't have a place to host such backend. I'm willing to work on the backend if this is to-be-merged.