### PR TITLE
Extract curlwrapper from ipgroup for re-use

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -99,6 +99,7 @@ BITCOIN_CORE_H = \
   hash.h \
   init.h \
   ipgroups.h \
+  curl_wrapper.h \
   key.h \
   keystore.h \
   leveldbwrapper.h \
@@ -183,6 +184,7 @@ libbitcoin_server_a_SOURCES = \
   checkpoints.cpp \
   init.cpp \
   ipgroups.cpp \
+  curl_wrapper.cpp \
   leveldbwrapper.cpp \
   main.cpp \
   merkleblock.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -94,12 +94,12 @@ BITCOIN_CORE_H = \
   consensus/params.h \
   consensus/validation.h \
   core_io.h \
+  curl_wrapper.h \
   eccryptoverify.h \
   ecwrapper.h \
   hash.h \
   init.h \
   ipgroups.h \
-  curl_wrapper.h \
   key.h \
   keystore.h \
   leveldbwrapper.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -47,6 +47,7 @@ BITCOIN_TESTS =\
   test/coins_tests.cpp \
   test/compress_tests.cpp \
   test/crypto_tests.cpp \
+  test/curl_tests.cpp \
   test/DoS_tests.cpp \
   test/getarg_tests.cpp \
   test/hash_tests.cpp \

--- a/src/curl_wrapper.cpp
+++ b/src/curl_wrapper.cpp
@@ -1,0 +1,137 @@
+#include "curl_wrapper.h"
+#include "util.h"
+#ifdef WIN32
+#define CURL_STATICLIB
+#endif
+#include <curl/curl.h>
+#include <boost/filesystem.hpp>
+
+using namespace std;
+
+// As of July 2015 the Tor IPs document is only 169kb in size so this is plenty.
+static const size_t MAX_DOWNLOAD_SIZE = 1024 * 1024;
+
+struct CurlInitWrapper {
+    CurlInitWrapper() {
+
+        CURLcode rv = curl_global_init(CURL_GLOBAL_ALL);
+        curlOK = (rv == CURLE_OK);
+
+        if (!curlOK)
+            LogPrintf("libcurl failed to initialize\n");
+    }
+    ~CurlInitWrapper() {
+        curl_global_cleanup();
+    }
+
+    bool curlOK;
+};
+
+static size_t CurlData(void *ptr, size_t size, size_t nmemb, void *user_ptr) {
+    string *data = static_cast<string*>(user_ptr);
+    string buf(static_cast<const char *>(ptr), size*nmemb);
+    size_t realsize = size * nmemb;
+    if (data->size() + realsize > MAX_DOWNLOAD_SIZE)
+        return 0;  // Abort.
+    data->append(buf);
+    return realsize;
+}
+
+std::string statusCodeErrorStr(int code) {
+    std::stringstream ss;
+    ss << "http status code was '" << code << "', wanted 200 OK";
+    return ss.str();
+}
+
+struct CurlWrapperImpl : public CurlWrapper {
+    CurlWrapperImpl(CURL* h) : handle(h) {
+        assert(h);
+
+        // If -curl-verbose is specified, debug info and headers will be printed to stderr.
+        curl_easy_setopt(handle, CURLOPT_VERBOSE, GetBoolArg("-curl-verbose", false) ? 1L : 0L);
+        curl_easy_setopt(handle, CURLOPT_HEADER, 0L);
+        curl_easy_setopt(handle, CURLOPT_NOPROGRESS, 1L);
+        curl_easy_setopt(handle, CURLOPT_NOSIGNAL, 1L);
+        // Follow redirects
+        curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, 1L);
+        curl_easy_setopt(handle, CURLOPT_USERAGENT, "Bitcoin XT");
+        // Don't use up sockets on the target website unnecessarily.
+        curl_easy_setopt(handle, CURLOPT_FORBID_REUSE, 1L);
+
+        // curl/openssl seem to know how to use the platform CA store on win/mac.
+#if !defined(WIN32) && !defined(MAC_OSX)
+        // On Linux/BSD/etc try a couple of places we know CA bundles are often kept.
+        if (boost::filesystem::exists(boost::filesystem::path("/etc/ssl/certs/ca-certificates.crt"))) {
+            curl_easy_setopt(handle, CURLOPT_CAINFO, "/etc/ssl/certs/ca-certificates.crt");
+        } else if (boost::filesystem::exists(boost::filesystem::path("/etc/ssl/certs/ca-bundle.crt"))) {
+            curl_easy_setopt(handle, CURLOPT_CAINFO, "/etc/ssl/certs/ca-bundle.crt");
+        } else {
+            // Disable use of the system CA store :( We can't simply
+            // present our hard coded cert to be used in addition
+            // because the curl API just doesn't support that. It's one or the
+            // other. Our callback function will configure
+            // the cert used by the website as of the time of writing.
+            curl_easy_setopt(handle, CURLOPT_CAPATH, NULL);
+            curl_easy_setopt(handle, CURLOPT_CAINFO, NULL);
+        }
+#endif
+    }
+    ~CurlWrapperImpl() {
+        curl_easy_cleanup(handle);
+    }
+
+    virtual std::string fetchURL(const std::string& url) {
+        std::string data;
+
+        curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, &CurlData);
+        curl_easy_setopt(handle, CURLOPT_WRITEDATA, &data);
+        curl_easy_setopt(handle, CURLOPT_URL, url.c_str());
+
+        CURLcode rv = curl_easy_perform(handle);
+        if (rv != CURLE_OK)
+            throw curl_error(url, curl_easy_strerror(rv));
+
+        long httpCode;
+        curl_easy_getinfo(handle, CURLINFO_RESPONSE_CODE, &httpCode);
+        if (httpCode != 200)
+            throw curl_error(url, statusCodeErrorStr(httpCode));
+
+        return data;
+    }
+
+    virtual CURL* getHandle() { return handle; }
+
+    private:
+        CURL* handle;
+};
+
+struct BrokenCurl : public CurlWrapper {
+    virtual std::string fetchURL(const std::string& url) {
+        throw curl_error(url, "curl failed to initialize");
+    }
+    virtual CURL* getHandle() { return NULL; }
+};
+
+DummyCurlWrapper::DummyCurlWrapper(int statuscode, const std::string& content) :
+    code(statuscode), content(content)
+{
+}
+
+std::string DummyCurlWrapper::fetchURL(const std::string& url) {
+    lastUrl = url;
+    if (code != 200)
+        throw curl_error(url, statusCodeErrorStr(code));
+
+    return content;
+}
+
+std::auto_ptr<CurlWrapper> MakeCurl() {
+    static CurlInitWrapper c;
+    if (!c.curlOK)
+        return std::auto_ptr<CurlWrapper>(new BrokenCurl);
+
+    CURL* curl = curl_easy_init();
+    return curl
+        ? std::auto_ptr<CurlWrapper>(new CurlWrapperImpl(curl))
+        : std::auto_ptr<CurlWrapper>(new BrokenCurl);
+}

--- a/src/curl_wrapper.h
+++ b/src/curl_wrapper.h
@@ -18,10 +18,8 @@ struct CurlWrapper {
     // Returns contents of url.
     // Throws curl_error on curl error, or status code other than "200 OK".
     virtual std::string fetchURL(const std::string& url) = 0;
-
     virtual CURL* getHandle() = 0;
-
-    virtual ~CurlWrapper();
+    virtual ~CurlWrapper() = 0;
 };
 inline CurlWrapper::~CurlWrapper() { }
 

--- a/src/curl_wrapper.h
+++ b/src/curl_wrapper.h
@@ -1,0 +1,43 @@
+#ifndef BITCOIN_CURLWRAPPER_H
+#define BITCOIN_CURLWRAPPER_H
+
+#include <string>
+#include <memory>
+#include <stdexcept>
+
+typedef void CURL;
+
+struct curl_error : public std::runtime_error {
+    curl_error(const std::string& url, const std::string& err) : runtime_error(err), url(url) { }
+    virtual ~curl_error() throw() { }
+    std::string url;
+};
+
+struct CurlWrapper {
+
+    // Returns contents of url.
+    // Throws curl_error on curl error, or status code other than "200 OK".
+    virtual std::string fetchURL(const std::string& url) = 0;
+
+    virtual CURL* getHandle() = 0;
+
+    virtual ~CurlWrapper();
+};
+inline CurlWrapper::~CurlWrapper() { }
+
+// Dummy for unittesting.
+struct DummyCurlWrapper : public CurlWrapper {
+
+    DummyCurlWrapper(int statuscode, const std::string& content);
+
+    virtual std::string fetchURL(const std::string& url);
+    virtual CURL* getHandle() { return NULL; }
+
+    int code;
+    std::string content;
+    std::string lastUrl; // last url used with fetchURL
+};
+
+std::auto_ptr<CurlWrapper> MakeCurl();
+
+#endif

--- a/src/ipgroups.cpp
+++ b/src/ipgroups.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <boost/foreach.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/algorithm/string.hpp>
 #ifdef WIN32
@@ -21,14 +20,13 @@
 #include "torips.h"
 #include "utilstrencodings.h"
 #include "util.h"
+#include "curl_wrapper.h"
 
 using namespace std;
 
 CCriticalSection cs_groups;
 static vector<CIPGroup> groups;
 
-// As of July 2015 the Tor IPs document is only 169kb in size so this is plenty.
-static const size_t MAX_DOWNLOAD_SIZE = 1024 * 1024;
 static const int OPEN_PROXY_PRIORITY = -10;
 
 
@@ -56,16 +54,6 @@ CIPGroupData FindGroupForIP(CNetAddr ip) {
     return CIPGroupData();
 }
 
-static size_t CurlData(void *ptr, size_t size, size_t nmemb, void *user_ptr) {
-    string *data = static_cast<string*>(user_ptr);
-    string buf(static_cast<const char *>(ptr), size*nmemb);
-    size_t realsize = size * nmemb;
-    if (data->size() + realsize > MAX_DOWNLOAD_SIZE)
-        return 0;  // Abort.
-    data->append(buf);
-    return realsize;
-}
-
 vector<CSubNet> ParseIPData(string input) {
     vector<string> lines;
     vector<CSubNet> results;
@@ -84,27 +72,6 @@ vector<CSubNet> ParseIPData(string input) {
     }
     return results;
 }
-
-struct CurlWrapper {
-    CURL *handle;
-
-    CurlWrapper() {
-        CURLcode rv = curl_global_init(CURL_GLOBAL_ALL);
-        if (rv != CURLE_OK) {
-            LogPrintf("libcurl failed to initialize, cannot load IP priority data: %s\n", curl_easy_strerror(rv));
-            handle = NULL;
-        } else {
-            handle = curl_easy_init();
-        }
-    }
-
-    ~CurlWrapper() {
-        if (handle != NULL) {
-            curl_easy_cleanup(handle);
-            curl_global_cleanup();
-        }
-    }
-};
 
 // Hack around the fact that some platforms, especially on Linux, have root stores
 // that openssl/curl can't find by default. This is the root cert used by check.torproject.org
@@ -163,47 +130,20 @@ static CURLcode ssl_context_setup(CURL *curl, void *sslctx, void *param) {
 }
 
 static CIPGroup *LoadIPDataFromWeb(const string &url, const string &groupname, int priority) {
-    string data;
 
-    CurlWrapper curlWrapper;
-    CURL *curl = curlWrapper.handle;
+    std::auto_ptr<CurlWrapper> curlWrapper = MakeCurl();
+    CURL *curl = curlWrapper->getHandle();
     if (curl == NULL)
         return NULL;
 
-    // If -curl-verbose is specified, debug info and headers will be printed to stderr.
-    curl_easy_setopt(curl, CURLOPT_VERBOSE, GetBoolArg("-curl-verbose", false) ? 1L : 0L);
-    curl_easy_setopt(curl, CURLOPT_HEADER, 0L);
-    curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1L);
-    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
-    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);   // Follow redirects
-    curl_easy_setopt(curl, CURLOPT_USERAGENT, "Bitcoin XT");
-    curl_easy_setopt(curl, CURLOPT_FORBID_REUSE, 1L);   // Don't use up sockets on the target website unnecessarily.
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &CurlData);
-    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &data);
     curl_easy_setopt(curl, CURLOPT_SSL_CTX_FUNCTION, &ssl_context_setup);
-    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
-
-    // curl/openssl seem to know how to use the platform CA store on win/mac.
-#if !defined(WIN32) && !defined(MAC_OSX)
-    // On Linux/BSD/etc try a couple of places we know CA bundles are often kept.
-    if (boost::filesystem::exists(boost::filesystem::path("/etc/ssl/certs/ca-certificates.crt"))) {
-        curl_easy_setopt(curl, CURLOPT_CAINFO, "/etc/ssl/certs/ca-certificates.crt");
-    } else if (boost::filesystem::exists(boost::filesystem::path("/etc/ssl/certs/ca-bundle.crt"))) {
-        curl_easy_setopt(curl, CURLOPT_CAINFO, "/etc/ssl/certs/ca-bundle.crt");
-    } else {
-        // Disable use of the system CA store :( We can't simply present our hard coded cert to be used in addition
-        // because the curl API just doesn't support that. It's one or the other. Our callback function will configure
-        // the cert used by the website as of the time of writing.
-        curl_easy_setopt(curl, CURLOPT_CAPATH, NULL);
-        curl_easy_setopt(curl, CURLOPT_CAINFO, NULL);
-    }
-#endif
 
     // This will block until the download is done.
-    CURLcode rv = curl_easy_perform(curl);
-    if (rv == CURLE_OK) {
+    try {
+        std::string res = curlWrapper->fetchURL(url);
         LogPrintf("IP list download succeeded from %s\n", url.c_str());
-        vector<CSubNet> subnets = ParseIPData(data);
+
+        vector<CSubNet> subnets = ParseIPData(res);
         if (subnets.size() > 0) {
             CIPGroup *ipGroup = new CIPGroup;
             ipGroup->header.name = groupname;
@@ -211,8 +151,10 @@ static CIPGroup *LoadIPDataFromWeb(const string &url, const string &groupname, i
             ipGroup->subnets.assign(subnets.begin(), subnets.end());
             return ipGroup;
         }
-    } else {
-        LogPrintf("Failed to download IP priority data from %s: %s\n", url.c_str(), curl_easy_strerror(rv));
+    }
+    catch (const curl_error& e) {
+        LogPrintf("Failed to download IP priority data from %s: %s\n",
+                e.url.c_str(), e.what());
     }
     return NULL;
 }

--- a/src/ipgroups.cpp
+++ b/src/ipgroups.cpp
@@ -130,16 +130,11 @@ static CURLcode ssl_context_setup(CURL *curl, void *sslctx, void *param) {
 }
 
 static CIPGroup *LoadIPDataFromWeb(const string &url, const string &groupname, int priority) {
-
-    std::auto_ptr<CurlWrapper> curlWrapper = MakeCurl();
-    CURL *curl = curlWrapper->getHandle();
-    if (curl == NULL)
-        return NULL;
-
-    curl_easy_setopt(curl, CURLOPT_SSL_CTX_FUNCTION, &ssl_context_setup);
-
-    // This will block until the download is done.
     try {
+        std::auto_ptr<CurlWrapper> curlWrapper = MakeCurl();
+        curl_easy_setopt(curlWrapper->getHandle(), CURLOPT_SSL_CTX_FUNCTION, &ssl_context_setup);
+
+        // This will block until the download is done.
         std::string res = curlWrapper->fetchURL(url);
         LogPrintf("IP list download succeeded from %s\n", url.c_str());
 

--- a/src/test/curl_tests.cpp
+++ b/src/test/curl_tests.cpp
@@ -1,0 +1,35 @@
+// Copyright (c) 2015- The Bitcoin XT developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <boost/test/unit_test_suite.hpp>
+#include <boost/test/test_tools.hpp>
+
+#include <curl_wrapper.h>
+
+BOOST_AUTO_TEST_SUITE(curl_tests);
+
+BOOST_AUTO_TEST_CASE(dummy_curl)
+{
+    {
+        std::auto_ptr<CurlWrapper> curl(new DummyCurlWrapper(200, "some data"));
+        BOOST_CHECK_EQUAL(curl->fetchURL("http://example.org"), "some data");
+    }
+    {
+        DummyCurlWrapper* dcurl = new DummyCurlWrapper(200, "more data");
+        std::auto_ptr<CurlWrapper> curl(dcurl);
+        curl->fetchURL("http://example.org/2");
+        BOOST_CHECK_EQUAL(dcurl->lastUrl, "http://example.org/2");
+        curl->fetchURL("http://example.org/3");
+        BOOST_CHECK_EQUAL(dcurl->lastUrl, "http://example.org/3");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(dummy_curl_throws) {
+    // Throw if not HTTP status 200 OK
+    std::auto_ptr<CurlWrapper> curl(new DummyCurlWrapper(404, "some data"));
+    BOOST_CHECK_THROW(curl->fetchURL("http://example.lrg"), curl_error);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+


### PR DESCRIPTION
This PR has fixes for issues pointed out by Mike in review. I squashed the fixes into the previous commit, to see just the changes see this commit: https://github.com/dagurval/bitcoinxt/commit/9b5de8d94b139fdbe91dd4d17ec38913bfe30ea3

Changes:
- Handle errors from curl_easy_perform
- Throw errors when status code is not 200 OK
- Expose DummyCurlWrapper to simplify the main interface