### PR TITLE
Allow building out-of-source

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,8 +5,8 @@ AM_LDFLAGS = $(PTHREAD_CFLAGS) $(LIBTOOL_LDFLAGS)
 if EMBEDDED_LEVELDB
 LEVELDB_CPPFLAGS += -I$(srcdir)/leveldb/include
 LEVELDB_CPPFLAGS += -I$(srcdir)/leveldb/helpers/memenv
-LIBLEVELDB += $(builddir)/leveldb/libleveldb.a
-LIBMEMENV  += $(builddir)/leveldb/libmemenv.a
+LIBLEVELDB += $(top_srcdir)/src/leveldb/libleveldb.a
+LIBMEMENV  += $(top_srcdir)/src/leveldb/libmemenv.a
 
 # NOTE: This dependency is not strictly necessary, but without it make may try to build both in parallel, which breaks the LevelDB build system in a race
 $(LIBLEVELDB): $(LIBMEMENV)

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -149,6 +149,10 @@ QT_MOC = \
   qt/overviewpage.moc \
   qt/rpcconsole.moc
 
+if ENABLE_WALLET
+MOC_DEFS += -DENABLE_WALLET=1
+endif
+
 QT_QRC_CPP = qt/qrc_bitcoin.cpp
 QT_QRC = qt/bitcoin.qrc
 QT_QRC_LOCALE_CPP = qt/qrc_bitcoin_locale.cpp


### PR DESCRIPTION
Its quite nice to have a with-wallet and a disable-wallet build tree
that come from the same directory. So lets make sure we can build
out of source (mostly) again.

Seems that levelDB is not able to, so that one will be shared. But
levelDB development should not happen inside of bitcoin anyway, so
thats fine.