### PR TITLE
Raise RPC window when opened again.

### DIFF
--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -186,6 +186,8 @@ private slots:
 
     /** Show open dialog */
     void openClicked();
+
+    void showRPCConsoleWindow();
 #endif // ENABLE_WALLET
     /** Show configuration dialog */
     void optionsClicked();


### PR DESCRIPTION
If the RCP console is open, but not visible, raise it and activate it.
Before we just seemed to ignore the user request.