### PR TITLE
Fix API issues

### DIFF
--- a/src/qt/addressbookpage.h
+++ b/src/qt/addressbookpage.h
@@ -39,7 +39,7 @@ public:
         ForEditing  /**< Open address book for editing */
     };
 
-    explicit AddressBookPage(Mode mode, Tabs tab, QWidget *parent);
+    explicit AddressBookPage(Mode mode, Tabs tab, QWidget *parent = 0);
     ~AddressBookPage();
 
     void setModel(AddressTableModel *model);

--- a/src/qt/askpassphrasedialog.h
+++ b/src/qt/askpassphrasedialog.h
@@ -27,7 +27,7 @@ public:
         Decrypt     /**< Ask passphrase and decrypt wallet */
     };
 
-    explicit AskPassphraseDialog(Mode mode, QWidget *parent);
+    explicit AskPassphraseDialog(Mode mode, QWidget *parent = 0);
     ~AskPassphraseDialog();
 
     void accept();

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -540,7 +540,10 @@ int main(int argc, char *argv[])
     // but before showing splash screen.
     if (mapArgs.count("-?") || mapArgs.count("-help") || mapArgs.count("-version"))
     {
-        HelpMessageDialog help(NULL, mapArgs.count("-version"));
+        const bool showAbout = mapArgs.count("-version") != 0;
+        HelpMessageDialog help(showAbout ?
+                HelpMessageDialog::ShowAbout :
+                HelpMessageDialog::ShowCommandLineOptions);
         help.showOrPrint();
         return 1;
     }

--- a/src/qt/bitcoinaddressvalidator.h
+++ b/src/qt/bitcoinaddressvalidator.h
@@ -15,7 +15,7 @@ class BitcoinAddressEntryValidator : public QValidator
     Q_OBJECT
 
 public:
-    explicit BitcoinAddressEntryValidator(QObject *parent);
+    explicit BitcoinAddressEntryValidator(QObject *parent = 0);
 
     State validate(QString &input, int &pos) const;
 };
@@ -27,7 +27,7 @@ class BitcoinAddressCheckValidator : public QValidator
     Q_OBJECT
 
 public:
-    explicit BitcoinAddressCheckValidator(QObject *parent);
+    explicit BitcoinAddressCheckValidator(QObject *parent = 0);
 
     State validate(QString &input, int &pos) const;
 };

--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -22,7 +22,7 @@ class AmountSpinBox: public QAbstractSpinBox
     Q_OBJECT
 
 public:
-    explicit AmountSpinBox(QWidget *parent):
+    explicit AmountSpinBox(QWidget *parent = 0):
         QAbstractSpinBox(parent),
         currentUnit(BitcoinUnits::BTC),
         singleStep(100000) // satoshis

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -573,7 +573,7 @@ void BitcoinGUI::optionsClicked()
     if(!clientModel || !clientModel->getOptionsModel())
         return;
 
-    OptionsDialog dlg(this, enableWallet);
+    OptionsDialog dlg(enableWallet, this);
     dlg.setModel(clientModel->getOptionsModel());
     dlg.exec();
 }
@@ -583,13 +583,13 @@ void BitcoinGUI::aboutClicked()
     if(!clientModel)
         return;
 
-    HelpMessageDialog dlg(this, true);
+    HelpMessageDialog dlg(HelpMessageDialog::ShowAbout, this);
     dlg.exec();
 }
 
 void BitcoinGUI::showHelpMessageClicked()
 {
-    HelpMessageDialog *help = new HelpMessageDialog(this, false);
+    HelpMessageDialog *help = new HelpMessageDialog(HelpMessageDialog::ShowCommandLineOptions, this);
     help->setAttribute(Qt::WA_DeleteOnClose);
     help->show();
 }

--- a/src/qt/bitcoinunits.h
+++ b/src/qt/bitcoinunits.h
@@ -49,7 +49,7 @@ class BitcoinUnits: public QAbstractListModel
     Q_OBJECT
 
 public:
-    explicit BitcoinUnits(QObject *parent);
+    explicit BitcoinUnits(QObject *parent = 0);
 
     /** Bitcoin units.
       @note Source: https://en.bitcoin.it/wiki/Units . Please add only sensible ones

--- a/src/qt/editaddressdialog.h
+++ b/src/qt/editaddressdialog.h
@@ -31,7 +31,7 @@ public:
         EditSendingAddress
     };
 
-    explicit EditAddressDialog(Mode mode, QWidget *parent);
+    explicit EditAddressDialog(Mode mode, QWidget *parent = 0);
     ~EditAddressDialog();
 
     void setModel(AddressTableModel *model);

--- a/src/qt/openuridialog.h
+++ b/src/qt/openuridialog.h
@@ -16,7 +16,7 @@ class OpenURIDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit OpenURIDialog(QWidget *parent);
+    explicit OpenURIDialog(QWidget *parent = 0);
     ~OpenURIDialog();
 
     QString getURI();

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -30,7 +30,7 @@
 #include <QMessageBox>
 #include <QTimer>
 
-OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
+OptionsDialog::OptionsDialog(bool enableWallet, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::OptionsDialog),
     model(0),

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -24,7 +24,7 @@ class OptionsDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit OptionsDialog(QWidget *parent, bool enableWallet);
+    explicit OptionsDialog(bool enableWallet, QWidget *parent = 0);
     ~OptionsDialog();
 
     void setModel(OptionsModel *model);

--- a/src/qt/qvalidatedlineedit.h
+++ b/src/qt/qvalidatedlineedit.h
@@ -15,7 +15,7 @@ class QValidatedLineEdit : public QLineEdit
     Q_OBJECT
 
 public:
-    explicit QValidatedLineEdit(QWidget *parent);
+    explicit QValidatedLineEdit(QWidget *parent = 0);
     void clear();
     void setCheckValidator(const QValidator *v);
 

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -28,7 +28,7 @@ class RPCConsole: public QWidget
     Q_OBJECT
 
 public:
-    explicit RPCConsole(QWidget *parent);
+    explicit RPCConsole(QWidget *parent = 0);
     ~RPCConsole();
 
     void setClientModel(ClientModel *model);

--- a/src/qt/signverifymessagedialog.h
+++ b/src/qt/signverifymessagedialog.h
@@ -18,7 +18,7 @@ class SignVerifyMessageDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit SignVerifyMessageDialog(QWidget *parent);
+    explicit SignVerifyMessageDialog(QWidget *parent = 0);
     ~SignVerifyMessageDialog();
 
     void setModel(WalletModel *model);

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -24,7 +24,7 @@
 #include <QVBoxLayout>
 
 /** "Help message" or "About" dialog box */
-HelpMessageDialog::HelpMessageDialog(QWidget *parent, bool about) :
+HelpMessageDialog::HelpMessageDialog(HelpMessageDialog::Type type, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::HelpMessageDialog)
 {
@@ -40,7 +40,7 @@ HelpMessageDialog::HelpMessageDialog(QWidget *parent, bool about) :
     version += " " + tr("(%1-bit)").arg(32);
 #endif
 
-    if (about)
+    if (type == ShowAbout)
     {
         setWindowTitle(tr("About Bitcoin XT"));
 

--- a/src/qt/utilitydialog.h
+++ b/src/qt/utilitydialog.h
@@ -21,7 +21,12 @@ class HelpMessageDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit HelpMessageDialog(QWidget *parent, bool about);
+    enum Type {
+        ShowAbout,
+        ShowCommandLineOptions
+    };
+
+    explicit HelpMessageDialog(Type type, QWidget *parent = 0);
     ~HelpMessageDialog();
 
     void printToConsole();

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -34,7 +34,7 @@ class WalletView : public QStackedWidget
     Q_OBJECT
 
 public:
-    explicit WalletView(QWidget *parent);
+    explicit WalletView(QWidget *parent = 0);
     ~WalletView();
 
     void setBitcoinGUI(BitcoinGUI *gui);


### PR DESCRIPTION
Follow the Qt standard for memory management; pass the QObject
inheriting object as the last argument and default it to zero.

Also remove one place where we use a boolean to an enum, which helps
reading code.