### PR TITLE
implement uacomment config parameter

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -975,6 +975,17 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     RegisterNodeSignals(GetNodeSignals());
 
+    // format user agent, check total size
+    if (IsStealthMode()) {
+        strSubVersion = FormatSubVersion("Satoshi", CLIENT_VERSION, mapMultiArgs.count("-uacomment") ? mapMultiArgs["-uacomment"] : std::vector<string>(),"");
+    } else {
+        strSubVersion = FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, mapMultiArgs.count("-uacomment") ? mapMultiArgs["-uacomment"] : std::vector<string>(), CLIENT_VERSION_XT_SUBVER);
+    }    
+    if (strSubVersion.size() > MAX_SUBVERSION_LENGTH) {
+        return InitError(strprintf("Total length of network version string %i exceeds maximum of %i characters. Reduce the number and/or size of uacomments.",
+            strSubVersion.size(), MAX_SUBVERSION_LENGTH));
+    }
+
     if (mapArgs.count("-onlynet")) {
         std::set<enum Network> nets;
         BOOST_FOREACH(std::string snet, mapMultiArgs["-onlynet"]) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4323,7 +4323,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
         if (!vRecv.empty())
             vRecv >> addrFrom >> nNonce;
         if (!vRecv.empty()) {
-            vRecv >> LIMITED_STRING(pfrom->strSubVer, 256);
+            vRecv >> LIMITED_STRING(pfrom->strSubVer, MAX_SUBVERSION_LENGTH);
             pfrom->cleanSubVer = SanitizeString(pfrom->strSubVer);
         }
         if (!vRecv.empty())

--- a/src/main.h
+++ b/src/main.h
@@ -91,8 +91,6 @@ static const unsigned int DATABASE_WRITE_INTERVAL = 60 * 60;
 static const unsigned int DATABASE_FLUSH_INTERVAL = 24 * 60 * 60;
 /** Maximum length of reject messages. */
 static const unsigned int MAX_REJECT_MESSAGE_LENGTH = 111;
-/** Maximum length of incoming protocol messages (no message over 2 MiB is currently acceptable). */
-static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 2 * 1024 * 1024;
 
 struct BlockHasher
 {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -81,6 +81,7 @@ static std::vector<ListenSocket> vhListenSocket;
 CAddrMan addrman;
 int nMaxConnections = 125;
 bool fAddressesInitialized = false;
+std::string strSubVersion;
 
 vector<CNode*> vNodes;
 CCriticalSection cs_vNodes;
@@ -432,10 +433,10 @@ void CNode::PushVersion()
     if (IsStealthMode()) {
         uint64_t services = NODE_NETWORK;
         PushMessage("version", 70002, services, nTime, addrYou, addrMe,
-                nLocalHostNonce, FormatSubVersion("Satoshi", CLIENT_VERSION, std::vector<string>(), ""), nBestHeight, true);        
+                nLocalHostNonce, strSubVersion, nBestHeight, true);
     } else {
         PushMessage("version", PROTOCOL_VERSION, nLocalServices, nTime, addrYou, addrMe,
-                nLocalHostNonce, FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, std::vector<string>(), CLIENT_VERSION_XT_SUBVER), nBestHeight, true);
+                nLocalHostNonce, strSubVersion, nBestHeight, true);
     }
 }
 

--- a/src/net.h
+++ b/src/net.h
@@ -49,6 +49,10 @@ static const int TIMEOUT_INTERVAL = 20 * 60;
 static const unsigned int MAX_INV_SZ = 50000;
 /** The maximum number of new addresses to accumulate before announcing. */
 static const unsigned int MAX_ADDR_TO_SEND = 1000;
+/** Maximum length of incoming protocol messages (no message over 2 MiB is currently acceptable). */
+static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 2 * 1024 * 1024;
+/** Maximum length of strSubVer in `version` message */
+static const unsigned int MAX_SUBVERSION_LENGTH = 256;
 /** -listen default */
 static const bool DEFAULT_LISTEN = true;
 /** -upnp default */
@@ -158,6 +162,9 @@ extern CCriticalSection cs_vAddedNodes;
 
 extern NodeId nLastNodeId;
 extern CCriticalSection cs_nLastNodeId;
+
+/** Subversion as sent to the P2P network in `version` messages */
+extern std::string strSubVersion;
 
 struct LocalServiceInfo {
     int nScore;

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -420,8 +420,7 @@ Value getnetworkinfo(const Array& params, bool fHelp)
 
     Object obj;
     obj.push_back(Pair("version",       CLIENT_VERSION));
-    obj.push_back(Pair("subversion",
-        FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, std::vector<string>())));
+    obj.push_back(Pair("subversion",    strSubVersion));
     obj.push_back(Pair("protocolversion",PROTOCOL_VERSION));
     obj.push_back(Pair("localservices",       strprintf("%016x", nLocalServices)));
     obj.push_back(Pair("timeoffset",    GetTimeOffset()));


### PR DESCRIPTION
which can add comments to user agent as per BIP-0014

limit total length of user agent comments
Reworked-By: Wladimir J. van der Laan <laanwj@gmail.com>

Cherry Picked from 7b79cbd722d35b8113d5136b06d4a8e5fd569fc6
merged into StealthMode by SoreGums <nicholas.orr@zxgen.net>