### PR TITLE
gitian: ask user if they want to auto-start bitcoinxtd service during deb pkg installation

### DIFF
--- a/contrib/gitian-debian/README.md
+++ b/contrib/gitian-debian/README.md
@@ -64,3 +64,17 @@
   sudo apt-install purge bitcoinxt
   sudo rm -rf /var/lib/bitcoinxt
   ```
+
+**Non-Interactive Installation**
+
+The bitcoinxt debian package uses debconf to ask the user if they want to automatically enable and start the bitcoinxtd service as part of the package installation. To skip this question for non-interactive installs the following instructions allow you to pre-answer the question. This question is only asked the first time the bitcoinxt package is installed and only if the target system has the systemd systemctl binary present and executable.
+
+1. Install ```debconf-utils```
+ ```
+ % sudo apt-get install debconf-utils
+ ```
+
+2. Pre-answer the question, ***true*** to automatically enable and start the ```bitcoinxtd``` service and ***false*** to not automatically enable and start the service during package install
+ ```
+ % sudo sh -c 'echo "bitcoinxt bitcoinxt/start_service boolean false" | debconf-set-selections'
+ ```

--- a/contrib/gitian-debian/build.sh
+++ b/contrib/gitian-debian/build.sh
@@ -54,7 +54,7 @@ Architecture: amd64
 Description: Bitcoin XT is a fully verifying Bitcoin node implementation, based on the sources of Bitcoin Core.
 Maintainer: Steve Myers <steven.myers@gmail.com>
 Version: $realver
-Depends: adduser, ntp
+Depends: debconf, adduser, ntp
 EOF
 
 cat <<EOF >DEBIAN/install
@@ -69,53 +69,20 @@ etc/bitcoinxt/bitcoin.conf
 var/lib/bitcoinxt/.empty
 EOF
 
-cat <<EOF >DEBIAN/postinst
-#!/bin/bash
+# copy templates file to DEBIAN/templates
+cp ../templates DEBIAN/templates
 
-# add random rpc password to bitcoin.conf
-echo "rpcpassword=$(xxd -l 16 -p /dev/urandom)" >> /etc/bitcoinxt/bitcoin.conf 
+# copy the postinst file to DEBIAN/postinst
+cp ../postinst DEBIAN/postinst
+chmod 0755 DEBIAN/postinst 
 
-# add users
-adduser --system --group --quiet bitcoin
+# copy the prerm file to DEBIAN/prerm
+cp ../prerm DEBIAN/prerm
+chmod 0755 DEBIAN/prerm 
 
-# cleanup permissions
-chown root:root /usr/bin/bitcoinxt*
-chown root:root /lib/systemd/system/bitcoinxtd.service
-chown root:root /etc/bitcoinxt
-chown bitcoin:bitcoin /etc/bitcoinxt/bitcoin.conf
-chmod ug+r /etc/bitcoinxt/bitcoin.conf 
-chmod u+w /etc/bitcoinxt/bitcoin.conf
-chmod o-rw /etc/bitcoinxt/bitcoin.conf 
-chown -R bitcoin:bitcoin /var/lib/bitcoinxt
-chmod u+rwx /var/lib/bitcoinxt
-
-# enable and start bitcoinxtd service if systemctl exists and is executable
-if [[ -x "/bin/systemctl" ]]
-then
-    /bin/systemctl enable bitcoinxtd.service
-    /bin/systemctl start bitcoinxtd.service
-else
-    echo "File '/bin/systemctl' is not executable or found, bitcoinxtd not automatically enabled and started."
-fi
-
-EOF
-
-chmod a+x DEBIAN/postinst 
-
-cat <<EOF >DEBIAN/prerm
-#!/bin/bash
-
-# stop and disable bitcoinxtd service if systemctl exists and is executable
-if [[ -x "/bin/systemctl" ]]
-then
-    /bin/systemctl stop bitcoinxtd.service
-    /bin/systemctl disable bitcoinxtd.service
-else
-    echo "File '/bin/systemctl' is not executable or found, bitcoinxtd not automatically stopped and disabled."
-fi
-EOF
-
-chmod a+x DEBIAN/prerm
+# copy the postrm file to DEBIAN/postrm
+cp ../postrm DEBIAN/postrm
+chmod 0755 DEBIAN/postrm
 
 cd ..
 

--- a/contrib/gitian-debian/postinst
+++ b/contrib/gitian-debian/postinst
@@ -1,0 +1,38 @@
+#!/bin/sh -e
+
+# Source debconf library.
+. /usr/share/debconf/confmodule
+
+# add random rpc password to bitcoin.conf
+echo "rpcpassword=$(xxd -l 16 -p /dev/urandom)" >> /etc/bitcoinxt/bitcoin.conf 
+
+# add users
+adduser --system --group --quiet bitcoin
+
+# cleanup permissions
+chown root:root /usr/bin/bitcoinxt*
+chown root:root /lib/systemd/system/bitcoinxtd.service
+chown root:root /etc/bitcoinxt
+chown bitcoin:bitcoin /etc/bitcoinxt/bitcoin.conf
+chmod ug+r /etc/bitcoinxt/bitcoin.conf 
+chmod u+w /etc/bitcoinxt/bitcoin.conf
+chmod o-rw /etc/bitcoinxt/bitcoin.conf 
+chown -R bitcoin:bitcoin /var/lib/bitcoinxt
+chmod u+rwx /var/lib/bitcoinxt
+
+# enable and start bitcoinxtd service if systemctl exists and is executable
+if [ -x "/bin/systemctl" ]; then
+    db_input high bitcoinxt/start_service || true
+    db_go || true
+    db_get bitcoinxt/start_service 
+    if [ "$RET" = "true" ]; then
+        echo "Enabling bitcoinxtd.service"
+    	/bin/systemctl enable bitcoinxtd.service
+        echo "Starting bitcoinxtd.service"
+    	/bin/systemctl start bitcoinxtd.service
+    else
+        echo "The bitcoinxtd.service NOT enabled or started."
+    fi
+else
+    echo "The file '/bin/systemctl' is not executable or found, bitcoinxtd service not automatically enabled or started" 
+fi

--- a/contrib/gitian-debian/postrm
+++ b/contrib/gitian-debian/postrm
@@ -1,0 +1,9 @@
+#!/bin/sh -e
+
+if [ "$1" = "purge" ] && [ -e /usr/share/debconf/confmodule ]; then
+  # Source debconf library
+  . /usr/share/debconf/confmodule
+  # Remove my changes to the db 
+  echo "Purging debconf for bitcoinxt"
+  db_purge || true
+fi

--- a/contrib/gitian-debian/prerm
+++ b/contrib/gitian-debian/prerm
@@ -1,0 +1,9 @@
+#!/bin/sh -e
+
+# stop and disable bitcoinxtd service if systemctl exists and is executable
+if [ -x "/bin/systemctl" ]; then
+    echo "Stopping bitcoinxtd.service"
+    /bin/systemctl stop bitcoinxtd.service
+    echo "Disabling bitcoinxtd.service"
+    /bin/systemctl disable bitcoinxtd.service
+fi

--- a/contrib/gitian-debian/templates
+++ b/contrib/gitian-debian/templates
@@ -1,0 +1,4 @@
+Template: bitcoinxt/start_service
+Type: boolean
+Default: true
+Description: Automatically enable and start systemd bitcoinxtd.service?


### PR DESCRIPTION
1. moved debian installation scripts (```postinit```, ```prerm```) out of ```build.sh``` file to separate files
2. added ```debconf``` as a package dependency
3.  updated ```postinit``` script to ask user if they want to autostart bitcoinxtd and act accordingly 
4. added debconf ```templates``` file with autostart question verbiage
5. added ```postrm``` script to clear debconf data if package removed with "purge" option

Tested on Debian 8 (with systemd) and Debian 7 (no systemd) systems.

Note: Once user selects Yes or No for autostarting bitcoinxtd during installation they will not be prompted again unless they uninstall bitcoinxt with ```sudo apt-get purge bitcoinxt```. 
