### PR TITLE
Add a manager for the messages in the form of informationqueuedialog

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -82,6 +82,7 @@ QT_FORMS_UI = \
   qt/forms/editaddressdialog.ui \
   qt/forms/helpmessagedialog.ui \
   qt/forms/intro.ui \
+  qt/forms/informationqueuedialog.ui \
   qt/forms/openuridialog.ui \
   qt/forms/optionsdialog.ui \
   qt/forms/overviewpage.ui \
@@ -91,7 +92,8 @@ QT_FORMS_UI = \
   qt/forms/sendcoinsdialog.ui \
   qt/forms/sendcoinsentry.ui \
   qt/forms/signverifymessagedialog.ui \
-  qt/forms/transactiondescdialog.ui
+  qt/forms/transactiondescdialog.ui \
+  qt/forms/usermessagewidget.ui
 
 QT_MOC_CPP = \
   qt/moc_addressbookpage.cpp \
@@ -108,6 +110,7 @@ QT_MOC_CPP = \
   qt/moc_editaddressdialog.cpp \
   qt/moc_guiutil.cpp \
   qt/moc_intro.cpp \
+  qt/moc_informationqueue.cpp \
   qt/moc_macdockiconhandler.cpp \
   qt/moc_macnotificationhandler.cpp \
   qt/moc_notificator.cpp \
@@ -174,6 +177,7 @@ BITCOIN_QT_H = \
   qt/guiconstants.h \
   qt/guiutil.h \
   qt/intro.h \
+  qt/informationqueue.h \
   qt/macdockiconhandler.h \
   qt/macnotificationhandler.h \
   qt/networkstyle.h \
@@ -268,6 +272,7 @@ BITCOIN_QT_CPP = \
   qt/csvmodelwriter.cpp \
   qt/guiutil.cpp \
   qt/intro.cpp \
+  qt/informationqueue.cpp \
   qt/networkstyle.cpp \
   qt/notificator.cpp \
   qt/optionsdialog.cpp \

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -9,7 +9,8 @@
 #include "config/bitcoin-config.h"
 #endif
 
-#include "amount.h"
+#include "informationqueue.h"
+#include "../amount.h"
 
 #include <QLabel>
 #include <QMainWindow>
@@ -113,6 +114,8 @@ private:
     Notificator *notificator;
     RPCConsole *rpcConsole;
 
+    InformationQueue infoQueue;
+
     /** Keep track of previous number of blocks, to detect progress */
     int prevBlocks;
     int spinnerFrame;
@@ -151,9 +154,8 @@ public slots:
        @param[in] message   the displayed text
        @param[in] style     modality and style definitions (icon and used buttons - buttons only for message boxes)
                             @see CClientUIInterface::MessageBoxFlags
-       @param[in] ret       pointer to a bool that will be modified to whether Ok was clicked (modal only)
     */
-    void message(const QString &title, const QString &message, unsigned int style, bool *ret = NULL);
+    void message(const QString &title, const QString &message, unsigned int style);
 
 #ifdef ENABLE_WALLET
     /** Set the encryption status as shown in the UI.

--- a/src/qt/forms/informationqueuedialog.ui
+++ b/src/qt/forms/informationqueuedialog.ui
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FeedbackDialog</class>
+ <widget class="QDialog" name="feedbackDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>304</width>
+    <height>171</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Bitcoin Notifications</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="tabPosition">
+      <enum>QTabWidget::West</enum>
+     </property>
+     <property name="tabShape">
+      <enum>QTabWidget::Rounded</enum>
+     </property>
+     <property name="currentIndex">
+      <number>-1</number>
+     </property>
+     <property name="usesScrollButtons">
+      <bool>false</bool>
+     </property>
+     <property name="documentMode">
+      <bool>true</bool>
+     </property>
+     <property name="movable">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="closeButtonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
+     </property>
+     <property name="centerButtons">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>closeButtonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>feedbackDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>closeButtonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>feedbackDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/qt/forms/usermessagewidget.ui
+++ b/src/qt/forms/usermessagewidget.ui
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>UserMessageWidget</class>
+ <widget class="QWidget" name="UserMessageWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>100</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="mainLayout">
+   <item>
+    <widget class="QLabel" name="title">
+     <property name="text">
+      <string notr="true"/>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::RichText</enum>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="wordWrap">
+      <bool>false</bool>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/informationqueue.cpp
+++ b/src/qt/informationqueue.cpp
@@ -1,0 +1,278 @@
+// Copyright (C) 2015 The Bitcoin XT developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "informationqueue.h"
+#include "../ui_interface.h"
+
+#include <forms/ui_informationqueuedialog.h>
+#include <forms/ui_usermessagewidget.h>
+
+#include <QWidget>
+#include <QDebug>
+#include <QTimer>
+#include <QVBoxLayout>
+#include <QResizeEvent>
+
+namespace {
+
+struct TextItem {
+    TextItem() : repeated(0) {}
+    QString text;
+    int repeated;
+};
+
+
+class MyScrollArea : public QScrollArea {
+public:
+    MyScrollArea(QWidget *parent) : QScrollArea(parent) {}
+
+    void resizeEvent(QResizeEvent *event) {
+        QWidget *viewPort = widget();
+        if (viewPort) {
+            viewPort->setMinimumSize(QSize(event->size().width() - 5, 0));
+            // viewPort->setMaximumSize(QSize(event->size().width() - 5, 1E5));
+        }
+    }
+};
+}
+
+
+InformationQueue::InformationQueue(QWidget *parent)
+    : QObject(parent),
+    m_parent(parent),
+    m_infoDialog(0),
+    m_updateScheduled(false),
+    m_lastMessageId(0)
+{
+}
+
+void InformationQueue::addMessage(const UserMessage &incoming)
+{
+    Q_ASSERT(!incoming.message.isEmpty());
+    QList<Message>::Iterator iter = m_messageQueue.begin();
+    while (iter != m_messageQueue.end()) {
+        const Message &message(*iter);
+        if (incoming.flags == message.flags && message.title == incoming.title) {
+            QString main(incoming.message);
+            if (iter->messages.last() == incoming.message) // if identical, just increase refcount with one.
+                main = iter->messages.last();
+            iter->messages.append(main);
+            UserMessageWidget *widget = message.widget;
+            if (widget)
+                widget->refresh();
+            return;
+        }
+
+        ++iter;
+    }
+
+    Message m;
+    m.flags = incoming.flags;
+    m.title = incoming.title;
+    m.messages.append(incoming.message);
+    m_messageQueue.append(m);
+
+    if (!m_updateScheduled) {
+        m_updateScheduled = true;
+        QTimer::singleShot(200, this, SLOT(updateUI()));
+    }
+}
+
+
+
+void InformationQueue::updateUI()
+{
+    m_updateScheduled = false;
+    if (m_messageQueue.isEmpty())
+        return;
+    if (m_infoDialog == 0)
+        m_infoDialog = new InformationDialog(this, m_parent);
+
+    for (int i = 0; i < m_messageQueue.count(); ++i) {
+        if (m_messageQueue.at(i).widget.isNull()) {
+            m_messageQueue[i].id = ++m_lastMessageId;
+            UserMessageWidget *widget = new UserMessageWidget(this, m_lastMessageId);
+            m_messageQueue[i].widget = widget;
+            m_infoDialog->addWidget(widget);
+        }
+    }
+
+    m_infoDialog->show();
+}
+
+void InformationQueue::hideDialog()
+{
+    if (m_infoDialog)
+        m_infoDialog->hide();
+}
+
+void InformationQueue::removeMessages(const QSet<int> &messageIds)
+{
+    for (int i = 0; i < m_messageQueue.count(); ++i) {
+        if (messageIds.contains(m_messageQueue.at(i).id)) {
+            m_messageQueue.takeAt(i--);
+        }
+    }
+}
+
+UserMessageWidget::UserMessageWidget(InformationQueue *queue, int messageId)
+    : m_parent(queue),
+      m_messageId(messageId)
+{
+    m_widget.setupUi(this);
+    foreach (const InformationQueue::Message &message, m_parent->m_messageQueue) {
+        if (message.id == m_messageId) {
+            m_widget.title->setText(QString("<b>%1</b>").arg(message.title));
+            break;
+        }
+    }
+
+    refresh();
+}
+
+void UserMessageWidget::refresh()
+{
+    foreach (const InformationQueue::Message &message, m_parent->m_messageQueue) {
+        if (message.id == m_messageId) {
+            QList<TextItem> list;
+            TextItem last;
+            foreach (const QString &text, message.messages) {
+                Q_ASSERT(!text.isEmpty());
+                if (last.text == text) {
+                    last.repeated++;
+                } else {
+                    list.append(last);
+                    last = TextItem();
+                    last.text = text;
+                }
+            }
+            if (!last.text.isEmpty())
+                list.append(last);
+
+            int i = -1;
+            foreach (QObject *object, children()) {
+                if (object->isWidgetType()) {
+                    if (i++ == -1) // title
+                        continue;
+                    Q_ASSERT(list.count() > i);
+                    const TextItem &textItem = list.at(i);
+                    if (object->property("repeat").toInt() == textItem.repeated)
+                        continue;
+                    // one got added, change text.
+                    QLabel *label = qobject_cast<QLabel*>(object);
+                    Q_ASSERT(label);
+                    label->setText(tr("%1 (repeated %2 times)")
+                                   .arg(textItem.text)
+                                   .arg(textItem.repeated + 1));
+                    label->setProperty("repeat", textItem.repeated);
+                }
+            }
+            while (++i < list.count()) {
+                QLabel *message = new QLabel(this);
+                message->setWordWrap(true);
+                message->setTextInteractionFlags(Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse);
+                const TextItem &textItem = list.at(i);
+                if (textItem.repeated == 0) {
+                    message->setText(textItem.text);
+                } else {
+                    message->setText(tr("%1 (repeated %2 times)")
+                                   .arg(textItem.text)
+                                   .arg(textItem.repeated));
+                    message->setProperty("repeat", textItem.repeated);
+                }
+                m_widget.mainLayout->addWidget(message);
+            }
+            return;
+        }
+    }
+}
+
+unsigned int UserMessageWidget::flags() const
+{
+    foreach (const InformationQueue::Message &message, m_parent->m_messageQueue) {
+        if (message.id == m_messageId)
+            return message.flags;
+    }
+    Q_ASSERT(false);
+    return 0;
+}
+
+
+InformationDialog::InformationDialog(InformationQueue *queue, QWidget *parent)
+    : QDialog(parent),
+      m_queue(queue),
+      m_infoPage(0),
+      m_warningPage(0),
+      m_errorPage(0)
+{
+    Q_ASSERT(queue);
+    m_widget.setupUi(this);
+
+    connect (m_widget.closeButtonBox, SIGNAL(clicked(QAbstractButton*)), this, SLOT(closePressed()));
+}
+
+void InformationDialog::closePressed()
+{
+    m_queue->removeMessages(m_messages);
+
+    // delete tabs
+    delete m_infoPage;
+    m_infoPage = 0;
+    delete m_errorPage;
+    m_errorPage = 0;
+    delete m_warningPage;
+    m_warningPage = 0;
+
+    m_messages.clear();
+}
+
+void InformationDialog::addWidget(UserMessageWidget *widget)
+{
+    m_messages.insert(widget->messageId());
+
+
+    QScrollArea **parent;
+    QStyle::StandardPixmap type;
+    QString tabName;
+    const unsigned int flags = widget->flags();
+    if (flags & CClientUIInterface::ICON_ERROR) {
+        parent = &m_errorPage;
+        type = QStyle::SP_MessageBoxCritical;
+        tabName = tr("Error");
+    } else if (flags & CClientUIInterface::ICON_WARNING) {
+        parent = &m_warningPage;
+        type = QStyle::SP_MessageBoxWarning;
+        tabName = tr("Warning");
+    } else { // information
+        parent = &m_infoPage;
+        type = QStyle::SP_MessageBoxInformation;
+        tabName = tr("Information");
+    }
+
+    if (*parent == 0) {
+        QScrollArea *area = new MyScrollArea(m_widget.tabWidget);
+        area->setFrameShape(QScrollArea::NoFrame);
+        area->setWidgetResizable(true);
+
+        QWidget *viewport = new QWidget();
+        QVBoxLayout *layout = new QVBoxLayout(viewport);
+        viewport->setLayout(layout);
+
+        widget->setParent(viewport);
+        layout->addWidget(widget);
+        layout->addStretch(1);
+
+        QIcon icon(m_widget.tabWidget->style()->standardIcon(type));
+        m_widget.tabWidget->addTab(area, icon, tabName);
+        area->setWidget(viewport);
+        *parent = area;
+    }
+    else {
+        QWidget *viewport = (*parent)->widget();
+        widget->setParent(viewport);
+        QBoxLayout *layout = qobject_cast<QBoxLayout*>(viewport->layout());
+        Q_ASSERT(layout);
+        layout->insertWidget(layout->count() - 2, widget);
+    }
+}

--- a/src/qt/informationqueue.h
+++ b/src/qt/informationqueue.h
@@ -1,0 +1,109 @@
+// Copyright (C) 2015 The Bitcoin XT developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef INFORMATIONQUEUE_H
+#define INFORMATIONQUEUE_H
+
+#include <QObject>
+#include <QPointer>
+#include <QStringList>
+#include <QScrollArea>
+
+#include <forms/ui_informationqueuedialog.h>
+#include <forms/ui_usermessagewidget.h>
+
+class QWidget;
+
+struct UserMessage {
+    UserMessage() : flags(0) {}
+    QString title;
+    QString message;
+    unsigned int flags;  // flags from CClientUIInterface::MessageBoxFlags (ui_interface.h)
+};
+
+class InformationQueue;
+class InformationDialog;
+
+class UserMessageWidget : public QWidget
+{
+    Q_OBJECT
+public:
+    UserMessageWidget(InformationQueue *queue, int messageId);
+
+    void refresh();
+
+    int messageId() const {
+        return m_messageId;
+    }
+
+    unsigned int flags() const;
+
+private:
+    Ui::UserMessageWidget m_widget;
+    InformationQueue *m_parent;
+    int m_messageId;
+};
+
+/**
+ * this class gathers up all the messages that are send by different
+ * components to be shown to the user.  The queue may get long if the
+ * use doesn't respond, this class takes care that it doesn't grow
+ * out of proportion.   For instance by merging duplicate messages.
+ */
+class InformationQueue : public QObject
+{
+    Q_OBJECT
+public:
+    InformationQueue(QWidget *parent = 0);
+
+    void removeMessages(const QSet<int> &messageIds);
+
+public slots:
+    void addMessage(const UserMessage &message);
+    void hideDialog();
+
+private slots:
+    void updateUI();
+
+private:
+    struct Message {
+        QString title;
+        QStringList messages;
+        unsigned int flags;
+        QPointer<UserMessageWidget> widget;
+        int id;
+    };
+    friend class UserMessageWidget;
+
+    QWidget *m_parent;
+    InformationDialog *m_infoDialog;
+
+    QList<Message> m_messageQueue;
+    bool m_updateScheduled;
+    int m_lastMessageId;
+};
+
+class InformationDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    InformationDialog(InformationQueue *queue, QWidget *parent = 0);
+
+    void addWidget(UserMessageWidget *widget);
+
+private slots:
+    void closePressed();
+
+private:
+    Ui::FeedbackDialog m_widget;
+    InformationQueue *m_queue;
+    QSet<int> m_messages;
+
+    QScrollArea *m_infoPage;
+    QScrollArea *m_warningPage;
+    QScrollArea *m_errorPage;
+};
+
+
+#endif

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -765,7 +765,7 @@ void PaymentServer::setOptionsModel(OptionsModel *optionsModel)
 void PaymentServer::handlePaymentACK(const QString& paymentACKMsg)
 {
     // currently we don't futher process or store the paymentACK message
-    emit message(tr("Payment acknowledged"), paymentACKMsg, CClientUIInterface::ICON_INFORMATION | CClientUIInterface::MODAL);
+    emit message(tr("Payment acknowledged"), paymentACKMsg, CClientUIInterface::ICON_INFORMATION);
 }
 
 bool PaymentServer::verifyNetwork(const payments::PaymentDetails& requestDetails)

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -213,6 +213,7 @@ void SendCoinsDialog::on_sendButton_clicked()
             {
                 valid = false;
             }
+            break;
         }
     }
 

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -19,7 +19,7 @@
 #include "transactionview.h"
 #include "walletmodel.h"
 
-#include "ui_interface.h"
+#include "../ui_interface.h"
 
 #include <QAction>
 #include <QActionGroup>


### PR DESCRIPTION
All messages from any of our subcomponents would end up being
its own message box. This could cause some issues, as seen in the
latest "attack" where private keys were given away and people using
them would see hundreds of dialogs popping up about double spent
attacks.

This commit adds a manager in between that gathers up the messages
and sorts them and displays them in one dialog. In the special
case of the core spamming us with messages we just get the original
message updated with "repeated X times".

This addresses bugreport;
https://github.com/bitcoinxt/bitcoinxt/issues/63