### PR TITLE
Add bandwith limiting to options-dialog

### DIFF
--- a/src/leakybucket.h
+++ b/src/leakybucket.h
@@ -1,0 +1,105 @@
+// Copyright (c) 2009-2013 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_LEAKYBUCKET_H
+#define BITCOIN_LEAKYBUCKET_H
+
+#if defined(HAVE_CONFIG_H)
+#include "config/bitcoin-config.h"
+#endif
+
+/** Default value for the maximum amount of data that can be received in a burst */
+static const int64_t DEFAULT_MAX_RECV_BURST = 100*1024; //*1024;
+/** Default value for the maximum amount of data that can be sent in a burst */
+static const int64_t DEFAULT_MAX_SEND_BURST = 100*1024; // *1024;
+/** Default value for the average amount of data received per second */
+static const int64_t DEFAULT_AVE_RECV = 30*1024; //*1024;
+/** Default value for the average amount of data sent per second */
+static const int64_t DEFAULT_AVE_SEND = 10*1024; // *1024;
+/** If we have to break the transmission up into chunks, this is the minimum send chunk size */
+static const int64_t SEND_SHAPER_MIN_FRAG = 256;
+/** If we have to break the transmission up into chunks, this is the minimum receive chunk size */
+static const int64_t RECV_SHAPER_MIN_FRAG = 256;
+
+
+class CLeakyBucket
+{
+    protected:
+        typedef boost::chrono::steady_clock CClock;
+    
+        int64_t level;  // Current level of the bucket
+        int64_t max;  // Maximum quantity allowed 
+        int64_t fill;  // Average rate per second
+        static CClock clock;
+        boost::chrono::time_point<CClock> lastFill;
+
+        // This function is called internally to fill the leaky bucket based on the time difference between now and the last time the function was called.
+        void fillIt()
+        {            
+          boost::chrono::time_point<CClock>  now = clock.now();
+          CClock::duration elapsed( now - lastFill);
+          int64_t msElapsed = boost::chrono::duration_cast<boost::chrono::milliseconds>(elapsed).count();
+          if (msElapsed > 100) // note in practice msElapsed can be < 0, something to do with hyperthreading so reduce don't eliminate this conditional
+          {
+              lastFill = now;
+              level += (fill*msElapsed)/1000;
+              if (level > max) level = max;
+          }        
+        }
+        
+public:
+        CLeakyBucket(int64_t maxp, int64_t fillp,int64_t startLevel=LONG_MAX):max(maxp),fill(fillp) 
+        {
+            lastFill = clock.now();            
+            // set the initial level to either what is specified by the user or to the maximum  
+            level = (startLevel < max) ? startLevel : max;
+        }
+
+        // Change the settings of the leaky bucket
+        void set(uint64_t maxp, uint64_t fillp)
+        {
+            max = maxp;
+            fill = fillp;
+            if (level > max) level=max;  // if pinching, slow traffic quickly.
+            lastFill = clock.now();  // need to reset the lastFill time in case we are turning on this leaky bucket.
+        }
+
+        // Return the # tokens available if that amount is larger than the cutoff, otherwise return 0
+        int64_t available(int64_t cutoff=0)
+        {
+            if (fill == LONG_MAX) return LONG_MAX;  // shaping is off
+            fillIt();
+            return (level > cutoff) ? level: 0;            
+        }
+        
+        // Try to use amt tokens.  Returns TRUE if the tokens were consumed, false otherwise
+        bool try_leak(int64_t amt)
+        {
+            if (fill == LONG_MAX) return true;  // leaky bucket is turned off.
+            assert(amt >=0);
+            fillIt();
+            if (level >= amt)
+            {
+                level-=amt;
+                return true;                
+            }
+            return false;            
+        }
+        
+        // This function reduces the level in the bucket by amt, even if that makes the level negative, and returns true if the level is >= 0.  This function is useful in a situation like data receipt (with soft limits) where you are not certain how many bytes will be received until after you have received them.
+        bool leak(int64_t amt)
+        {
+            if (fill == LONG_MAX) return true; // leaky bucket is turned off.
+            fillIt();
+            level-=amt;
+            return (level>=0);
+            
+        }
+        
+        
+
+
+};
+
+#endif

--- a/src/net.h
+++ b/src/net.h
@@ -19,6 +19,7 @@
 #include "uint256.h"
 #include "utilstrencodings.h"
 #include "ipgroups.h"
+#include "leakybucket.h"
 
 #include <deque>
 #include <stdint.h>
@@ -49,6 +50,9 @@ static const int TIMEOUT_INTERVAL = 20 * 60;
 static const unsigned int MAX_INV_SZ = 50000;
 /** The maximum number of new addresses to accumulate before announcing. */
 static const unsigned int MAX_ADDR_TO_SEND = 1000;
+/** The maximum # of bytes to receive at once */
+static const int MAX_RECV_CHUNK = 256*1024;
+
 /** -listen default */
 static const bool DEFAULT_LISTEN = true;
 /** -upnp default */
@@ -59,6 +63,11 @@ static const bool DEFAULT_UPNP = false;
 #endif
 /** The maximum number of entries in mapAskFor */
 static const size_t MAPASKFOR_MAX_SZ = MAX_INV_SZ;
+
+// These variables for traffic shaping need to be globally scoped so the GUI and CLI can adjust the parameters
+extern CLeakyBucket receiveShaper;
+extern CLeakyBucket sendShaper;
+
 
 unsigned int ReceiveFloodSize();
 unsigned int SendBufferSize();

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -298,6 +298,98 @@
         </layout>
        </item>
        <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2_Network">
+         <item>
+          <widget class="QCheckBox" name="limitDownload">
+           <property name="minimumSize">
+            <size>
+             <width>150</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>Limit use of download bandwidth</string>
+           </property>
+           <property name="text">
+            <string>Limit download</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="limitDownloadSpinbox">
+           <property name="suffix">
+            <string> KB/s</string>
+           </property>
+           <property name="minimum">
+            <number>10</number>
+           </property>
+           <property name="maximum">
+            <number>100000</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="limitDownloadSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_3_Network">
+         <item>
+          <widget class="QCheckBox" name="limitUpload">
+           <property name="minimumSize">
+            <size>
+             <width>150</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>Limit use of upload bandwidth</string>
+           </property>
+           <property name="text">
+            <string>Limit upload</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="limitUploadSpinbox">
+           <property name="suffix">
+            <string> KB/s</string>
+           </property>
+           <property name="minimum">
+            <number>10</number>
+           </property>
+           <property name="maximum">
+            <number>100000</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="limitUploadSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
         <spacer name="verticalSpacer_Network">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -173,6 +173,11 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->proxyIp, OptionsModel::ProxyIP);
     mapper->addMapping(ui->proxyPort, OptionsModel::ProxyPort);
 
+    mapper->addMapping(ui->limitDownload, OptionsModel::DownloadLimitUse);
+    mapper->addMapping(ui->limitDownloadSpinbox, OptionsModel::DownloadLimit);
+    mapper->addMapping(ui->limitUpload, OptionsModel::UploadLimitUse);
+    mapper->addMapping(ui->limitUploadSpinbox, OptionsModel::UploadLimit);
+
     /* Window */
 #ifndef Q_OS_MAC
     mapper->addMapping(ui->minimizeToTray, OptionsModel::MinimizeToTray);

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -42,7 +42,11 @@ public:
         DatabaseCache,          // int
         SpendZeroConfChange,    // bool
         Listen,                 // bool
-        OptionIDRowCount,
+        DownloadLimitUse,       // bool
+        DownloadLimit,          // int
+        UploadLimitUse,         // bool
+        UploadLimit,            // int
+        OptionIDRowCount
     };
 
     void Init();

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -281,6 +281,7 @@ static const CRPCCommand vRPCCommands[] =
     { "network",            "getnettotals",           &getnettotals,           true  },
     { "network",            "getpeerinfo",            &getpeerinfo,            true  },
     { "network",            "ping",                   &ping,                   true  },
+    { "network",            "settrafficshaping",      &settrafficshaping,      true  },
 
     /* Block chain and UTXO */
     { "blockchain",         "getblockchaininfo",      &getblockchaininfo,      true  },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -149,6 +149,8 @@ extern void EnsureWalletIsUnlocked();
 extern json_spirit::Value getconnectioncount(const json_spirit::Array& params, bool fHelp); // in rpcnet.cpp
 extern json_spirit::Value getpeerinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value ping(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value settrafficshaping(const json_spirit::Array& params, bool fHelp);
+
 extern json_spirit::Value addnode(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getaddednodeinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getnettotals(const json_spirit::Array& params, bool fHelp);


### PR DESCRIPTION
This adds bandwidth limiting elements to the Options-dialog in QT. This is based on the leaky bucket bandwidth limiter created by @gandrewstone, his work is cherry picked into this PR.

I think changing amt2Recv from int to int64_t also fixed an issue where I got disconnected from all peers if I disabled bandwidth limiting.

![image](https://cloud.githubusercontent.com/assets/92707/9970132/9cf93c4e-5e53-11e5-82c7-99d19d32f07e.png)

I think we need more sane defaults for bandwidth limiting, probably them off by default would be for the best.

Changing limits with RPC does not sync with GUI though. Not sure how to fix that. Do we need bandwidth limiting through RPC? 
