### PR TITLE
Add send receive traffic shaping

### DIFF
--- a/src/leakybucket.h
+++ b/src/leakybucket.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2013 The Bitcoin Core developers
+// Copyright (c) 2015 The Bitcoin XT developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -55,6 +55,22 @@ public:
             // set the initial level to either what is specified by the user or to the maximum  
             level = (startLevel < max) ? startLevel : max;
         }
+
+        // Stop the operation of this leaky bucket (always return available tokens)
+        // use "set" to restart
+        void disable(void)
+	{
+  	  fill = LONG_MAX;
+          max = LONG_MAX;
+	}
+
+        // Access the values in this bucket
+        void get(uint64_t* maxp, uint64_t* fillp, uint64_t* levelp=NULL)
+	{
+	  if (maxp) *maxp = max;
+          if (fillp) *fillp = fill;
+          if (levelp) *levelp = level;
+	}
 
         // Change the settings of the leaky bucket
         void set(uint64_t maxp, uint64_t fillp)

--- a/src/leakybucket.h
+++ b/src/leakybucket.h
@@ -1,0 +1,105 @@
+// Copyright (c) 2009-2013 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_LEAKYBUCKET_H
+#define BITCOIN_LEAKYBUCKET_H
+
+#if defined(HAVE_CONFIG_H)
+#include "config/bitcoin-config.h"
+#endif
+
+/** Default value for the maximum amount of data that can be received in a burst */
+static const int64_t DEFAULT_MAX_RECV_BURST = 100*1024; //*1024;
+/** Default value for the maximum amount of data that can be sent in a burst */
+static const int64_t DEFAULT_MAX_SEND_BURST = 100*1024; // *1024;
+/** Default value for the average amount of data received per second */
+static const int64_t DEFAULT_AVE_RECV = 30*1024; //*1024;
+/** Default value for the average amount of data sent per second */
+static const int64_t DEFAULT_AVE_SEND = 10*1024; // *1024;
+/** If we have to break the transmission up into chunks, this is the minimum send chunk size */
+static const int64_t SEND_SHAPER_MIN_FRAG = 256;
+/** If we have to break the transmission up into chunks, this is the minimum receive chunk size */
+static const int64_t RECV_SHAPER_MIN_FRAG = 256;
+
+
+class CLeakyBucket
+{
+    protected:
+        typedef boost::chrono::steady_clock CClock;
+    
+        int64_t level;  // Current level of the bucket
+        int64_t max;  // Maximum quantity allowed 
+        int64_t fill;  // Average rate per second
+        static CClock clock;
+        boost::chrono::time_point<CClock> lastFill;
+
+        // This function is called internally to fill the leaky bucket based on the time difference between now and the last time the function was called.
+        void fillIt()
+        {            
+          boost::chrono::time_point<CClock>  now = clock.now();
+          CClock::duration elapsed( now - lastFill);
+          int64_t msElapsed = boost::chrono::duration_cast<boost::chrono::milliseconds>(elapsed).count();
+          if (msElapsed > 100) // note in practice msElapsed can be < 0, something to do with hyperthreading so reduce don't eliminate this conditional
+          {
+              lastFill = now;
+              level += (fill*msElapsed)/1000;
+              if (level > max) level = max;
+          }        
+        }
+        
+public:
+        CLeakyBucket(int64_t maxp, int64_t fillp,int64_t startLevel=LONG_MAX):max(maxp),fill(fillp) 
+        {
+            lastFill = clock.now();            
+            // set the initial level to either what is specified by the user or to the maximum  
+            level = (startLevel < max) ? startLevel : max;
+        }
+
+        // Change the settings of the leaky bucket
+        void set(uint64_t maxp, uint64_t fillp)
+        {
+            max = maxp;
+            fill = fillp;
+            if (level > max) level=max;  // if pinching, slow traffic quickly.
+            lastFill = clock.now();  // need to reset the lastFill time in case we are turning on this leaky bucket.
+        }
+
+        // Return the # tokens available if that amount is larger than the cutoff, otherwise return 0
+        int64_t available(int64_t cutoff=0)
+        {
+            if (fill == LONG_MAX) return LONG_MAX;  // shaping is off
+            fillIt();
+            return (level > cutoff) ? level: 0;            
+        }
+        
+        // Try to use amt tokens.  Returns TRUE if the tokens were consumed, false otherwise
+        bool try_leak(int64_t amt)
+        {
+            if (fill == LONG_MAX) return true;  // leaky bucket is turned off.
+            assert(amt >=0);
+            fillIt();
+            if (level >= amt)
+            {
+                level-=amt;
+                return true;                
+            }
+            return false;            
+        }
+        
+        // This function reduces the level in the bucket by amt, even if that makes the level negative, and returns true if the level is >= 0.  This function is useful in a situation like data receipt (with soft limits) where you are not certain how many bytes will be received until after you have received them.
+        bool leak(int64_t amt)
+        {
+            if (fill == LONG_MAX) return true; // leaky bucket is turned off.
+            fillIt();
+            level-=amt;
+            return (level>=0);
+            
+        }
+        
+        
+
+
+};
+
+#endif

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1675,10 +1675,6 @@ void static Discover(boost::thread_group& threadGroup)
 
 void StartNode(boost::thread_group& threadGroup, CScheduler& scheduler)
 {
-    // Init network shapers
-    receiveShaper.set(GetArg("-receiveburst", DEFAULT_MAX_RECV_BURST/1024)*1024, GetArg("-receiveavg", DEFAULT_AVE_RECV/1024)*1024);
-    sendShaper.set(GetArg("-sendburst", DEFAULT_MAX_SEND_BURST/1024)*1024, GetArg("-sendavg", DEFAULT_AVE_SEND/1024)*1024);
-
     uiInterface.InitMessage(_("Loading addresses..."));
     // Load addresses for peers.dat
     int64_t nStart = GetTimeMillis();

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1675,6 +1675,10 @@ void static Discover(boost::thread_group& threadGroup)
 
 void StartNode(boost::thread_group& threadGroup, CScheduler& scheduler)
 {
+    // Init network shapers
+    receiveShaper.set(GetArg("-receiveburst", DEFAULT_MAX_RECV_BURST/1024)*1024, GetArg("-receiveavg", DEFAULT_AVE_RECV/1024)*1024);
+    sendShaper.set(GetArg("-sendburst", DEFAULT_MAX_SEND_BURST/1024)*1024, GetArg("-sendavg", DEFAULT_AVE_SEND/1024)*1024);
+
     uiInterface.InitMessage(_("Loading addresses..."));
     // Load addresses for peers.dat
     int64_t nStart = GetTimeMillis();

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1675,6 +1675,10 @@ void static Discover(boost::thread_group& threadGroup)
 
 void StartNode(boost::thread_group& threadGroup, CScheduler& scheduler)
 {
+    //  Init network shapers
+    receiveShaper.set(GetArg("-receiveburst", DEFAULT_MAX_RECV_BURST/1024)*1024, GetArg("-receiveavg", DEFAULT_AVE_RECV/1024)*1024);
+    sendShaper.set(GetArg("-sendburst", DEFAULT_MAX_SEND_BURST/1024)*1024, GetArg("-sendavg", DEFAULT_AVE_SEND/1024)*1024);
+
     uiInterface.InitMessage(_("Loading addresses..."));
     // Load addresses for peers.dat
     int64_t nStart = GetTimeMillis();

--- a/src/net.h
+++ b/src/net.h
@@ -19,6 +19,7 @@
 #include "uint256.h"
 #include "utilstrencodings.h"
 #include "ipgroups.h"
+#include "leakybucket.h"
 
 #include <deque>
 #include <stdint.h>
@@ -49,6 +50,9 @@ static const int TIMEOUT_INTERVAL = 20 * 60;
 static const unsigned int MAX_INV_SZ = 50000;
 /** The maximum number of new addresses to accumulate before announcing. */
 static const unsigned int MAX_ADDR_TO_SEND = 1000;
+/** The maximum # of bytes to receive at once */
+static const int MAX_RECV_CHUNK = 256*1024;
+
 /** -listen default */
 static const bool DEFAULT_LISTEN = true;
 /** -upnp default */
@@ -59,6 +63,11 @@ static const bool DEFAULT_UPNP = false;
 #endif
 /** The maximum number of entries in mapAskFor */
 static const size_t MAPASKFOR_MAX_SZ = MAX_INV_SZ;
+
+// These variables for traffic shaping need to be globally scoped so the GUI and CLI can adjust the parameters
+extern CLeakyBucket receiveShaper;
+extern CLeakyBucket sendShaper;
+
 
 unsigned int ReceiveFloodSize();
 unsigned int SendBufferSize();

--- a/src/net.h
+++ b/src/net.h
@@ -51,7 +51,7 @@ static const unsigned int MAX_INV_SZ = 50000;
 /** The maximum number of new addresses to accumulate before announcing. */
 static const unsigned int MAX_ADDR_TO_SEND = 1000;
 /** The maximum # of bytes to receive at once */
-static const int MAX_RECV_CHUNK = 256*1024;
+static const int64_t MAX_RECV_CHUNK = 256*1024;
 
 /** -listen default */
 static const bool DEFAULT_LISTEN = true;

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -328,6 +328,12 @@
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
+           <property name="maximumSize">
+            <size>
+             <width>55</width>
+             <height>16777215</height>
+            </size>
+           </property>
            <property name="baseSize">
             <size>
              <width>64</width>
@@ -351,7 +357,14 @@
           </widget>
          </item>
          <item>
-          <widget class="QLineEdit" name="sendAveEdit"/>
+          <widget class="QLineEdit" name="sendAveEdit">
+           <property name="maximumSize">
+            <size>
+             <width>55</width>
+             <height>16777215</height>
+            </size>
+           </property>
+          </widget>
          </item>
          <item>
           <widget class="QSlider" name="sendAveSlider">
@@ -379,7 +392,14 @@
           </widget>
          </item>
          <item>
-          <widget class="QLineEdit" name="recvBurstEdit"/>
+          <widget class="QLineEdit" name="recvBurstEdit">
+           <property name="maximumSize">
+            <size>
+             <width>55</width>
+             <height>16777215</height>
+            </size>
+           </property>
+          </widget>
          </item>
          <item>
           <widget class="QSlider" name="recvBurstSlider">
@@ -396,7 +416,14 @@
           </widget>
          </item>
          <item>
-          <widget class="QLineEdit" name="recvAveEdit"/>
+          <widget class="QLineEdit" name="recvAveEdit">
+           <property name="maximumSize">
+            <size>
+             <width>55</width>
+             <height>16777215</height>
+            </size>
+           </property>
+          </widget>
          </item>
          <item>
           <widget class="QSlider" name="recvAveSlider">
@@ -406,6 +433,13 @@
           </widget>
          </item>
         </layout>
+       </item>
+       <item>
+        <widget class="QLabel" name="errorText">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
        </item>
        <item>
         <spacer name="verticalSpacer_Network">

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -20,7 +20,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="tabMain">
       <attribute name="title">
@@ -294,6 +294,116 @@
             </size>
            </property>
           </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QLabel" name="bandwidth">
+         <property name="text">
+          <string>Bandwidth Restrictions (check to enable):</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="sendShaping">
+         <item>
+          <widget class="QCheckBox" name="sendShapingEnable">
+           <property name="text">
+            <string>Send</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="sendburstlabel">
+           <property name="text">
+            <string>Max</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="sendBurstEdit">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="baseSize">
+            <size>
+             <width>64</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSlider" name="sendBurstSlider">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="sendlabel">
+           <property name="text">
+            <string>Average</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="sendAveEdit"/>
+         </item>
+         <item>
+          <widget class="QSlider" name="sendAveSlider">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="recvShaping">
+         <item>
+          <widget class="QCheckBox" name="recvShapingEnable">
+           <property name="text">
+            <string>Receive</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="recvburstlabel">
+           <property name="text">
+            <string>Max</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="recvBurstEdit"/>
+         </item>
+         <item>
+          <widget class="QSlider" name="recvBurstSlider">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="receivelabel">
+           <property name="text">
+            <string>Average</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="recvAveEdit"/>
+         </item>
+         <item>
+          <widget class="QSlider" name="recvAveSlider">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
          </item>
         </layout>
        </item>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -227,6 +227,13 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->proxyIp, OptionsModel::ProxyIP);
     mapper->addMapping(ui->proxyPort, OptionsModel::ProxyPort);
 
+    mapper->addMapping(ui->sendShapingEnable, OptionsModel::UseSendShaping);
+    mapper->addMapping(ui->sendBurstEdit, OptionsModel::SendBurst);
+    mapper->addMapping(ui->sendAveEdit, OptionsModel::SendAve);
+    mapper->addMapping(ui->recvShapingEnable, OptionsModel::UseReceiveShaping);
+    mapper->addMapping(ui->recvBurstEdit, OptionsModel::ReceiveBurst);
+    mapper->addMapping(ui->recvAveEdit, OptionsModel::ReceiveAve);
+    
     /* Window */
 #ifndef Q_OS_MAC
     mapper->addMapping(ui->minimizeToTray, OptionsModel::MinimizeToTray);
@@ -278,6 +285,8 @@ void OptionsDialog::on_okButton_clicked()
 {
     mapper->submit();
 
+    if (0)  // probably not needed anymore because using options model now
+      {
     if (ui->sendShapingEnable->isChecked())
       {
 	uint64_t burst, ave;
@@ -310,7 +319,8 @@ void OptionsDialog::on_okButton_clicked()
         receiveShaper.set(burst,ave);
       }
     else receiveShaper.disable();
-  
+      }
+    
     accept();
 }
 

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -6,9 +6,12 @@
 #define BITCOIN_QT_OPTIONSDIALOG_H
 
 #include <QDialog>
+#include <QIntValidator>
 
 class OptionsModel;
 class QValidatedLineEdit;
+class QLineEdit;
+class QLabel;
 
 QT_BEGIN_NAMESPACE
 class QDataWidgetMapper;
@@ -17,6 +20,30 @@ QT_END_NAMESPACE
 namespace Ui {
 class OptionsDialog;
 }
+
+/** Ensures that one edit box is always less than another */
+class LessThanValidator: public QIntValidator
+{
+    QLineEdit* other;
+    QLabel* errorDisplay;
+    
+    public:
+    LessThanValidator(int minimum, int maximum, QObject * parent = 0):
+        QIntValidator(minimum, maximum, parent), other(NULL),errorDisplay(NULL)
+        {
+        }
+
+        // This cannot be part of the constructor because these widgets may not be created at construction time.
+        void initialize(QLineEdit* otherp,QLabel* errorDisplayp) 
+        {
+            other=otherp;
+            errorDisplay=errorDisplayp;
+        }
+        
+    
+    virtual State validate(QString & input, int & pos) const;
+    
+};
 
 /** Preferences dialog. */
 class OptionsDialog : public QDialog
@@ -47,8 +74,10 @@ private slots:
     void showRestartWarning(bool fPersistent = false);
     void clearStatusLabel();
     void doProxyIpChecks(QValidatedLineEdit *pUiProxyIp, int nProxyPort);
-    void shapingSliderChanged();
-
+    void shapingSliderChanged();  // Pushes the traffic shaping slider changes into the traffic shaping edit boxes
+    void shapingMaxEditFinished(void);  // auto-corrects cases where max is lower then average
+    void shapingAveEditFinished(void);  // auto-corrects cases where max is lower then average
+    
 signals:
     void proxyIpChecks(QValidatedLineEdit *pUiProxyIp, int nProxyPort);
 
@@ -57,6 +86,11 @@ private:
     OptionsModel *model;
     QDataWidgetMapper *mapper;
     bool fProxyIpValid;
+
+    QIntValidator portValidator;
+    QIntValidator burstValidator;
+    LessThanValidator sendAveValidator;
+    LessThanValidator recvAveValidator;
 };
 
 #endif // BITCOIN_QT_OPTIONSDIALOG_H

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -47,6 +47,7 @@ private slots:
     void showRestartWarning(bool fPersistent = false);
     void clearStatusLabel();
     void doProxyIpChecks(QValidatedLineEdit *pUiProxyIp, int nProxyPort);
+    void shapingSliderChanged();
 
 signals:
     void proxyIpChecks(QValidatedLineEdit *pUiProxyIp, int nProxyPort);

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -97,6 +97,55 @@ void OptionsModel::Init()
 #endif
 
     // Network
+
+    if (!settings.contains("fUseReceiveShaping"))
+        settings.setValue("fUseReceiveShaping", DEFAULT_AVE_RECV != LONG_MAX);
+    if (!settings.contains("fUseSendShaping"))
+        settings.setValue("fUseSendShaping", DEFAULT_AVE_RECV != LONG_MAX);
+    
+    if (!settings.contains("nReceiveBurst"))
+        settings.setValue("nReceiveBurst", DEFAULT_MAX_RECV_BURST/1024);
+    if (!settings.contains("nReceiveAve"))
+        settings.setValue("nReceiveAve", DEFAULT_AVE_RECV == LONG_MAX ? 200 : static_cast<int>(DEFAULT_AVE_RECV / 1024));
+    if (!settings.contains("nSendBurst"))
+        settings.setValue("nSendBurst", DEFAULT_MAX_SEND_BURST/1024);
+    if (!settings.contains("nSendAve"))
+        settings.setValue("nSendAve", DEFAULT_AVE_SEND == LONG_MAX ? 200 : static_cast<int>(DEFAULT_AVE_SEND / 1024));
+
+    // Set the shapers to values loaded from configuration
+    bool inUse = settings.value("fUseReceiveShaping").toBool();
+    int64_t burstArg = GetArg("-receiveburst", -1);
+    int64_t aveArg = GetArg("-receiveave", -1);
+    
+    if (inUse || burstArg >= 0 || aveArg >=0 )  // If configuration says the shaper is used or the user put something on the command line then turn on the shaper
+        {
+          int64_t burstKB = settings.value("nReceiveBurst").toInt();
+          int64_t aveKB = settings.value("nReceiveAve").toInt();
+          // Accept command line overrides
+          if (burstArg >= 0) burstKB = burstArg;
+          if (aveArg >= 0) aveKB = aveArg;
+          if (burstArg < aveArg) burstArg = aveArg;  // Correct improper relationship -- burst must be >= average.
+          receiveShaper.set(burstKB*1024,aveKB*1024);
+        }
+    else receiveShaper.disable();
+
+    inUse = settings.value("fUseSendShaping").toBool();
+    burstArg = GetArg("-sendburst", -1);
+    aveArg = GetArg("-sendave", -1);
+    
+    if (inUse)
+        {
+          int64_t burstKB = settings.value("nSendBurst").toInt();
+          int64_t aveKB = settings.value("nSendAve").toInt();
+          // Accept command line overrides
+          if (burstArg >= 0) burstKB = burstArg;
+          if (aveArg >= 0) aveKB = aveArg;
+          if (burstArg < aveArg) burstArg = aveArg;  // Correct improper relationship -- burst must be >= average.
+          sendShaper.set(burstKB*1024,aveKB*1024);
+        }
+    else sendShaper.disable();
+        
+    
     if (!settings.contains("fUseUPnP"))
         settings.setValue("fUseUPnP", DEFAULT_UPNP);
     if (!SoftSetBoolArg("-upnp", settings.value("fUseUPnP").toBool()))
@@ -196,6 +245,18 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return settings.value("nThreadsScriptVerif");
         case Listen:
             return settings.value("fListen");
+        case UseReceiveShaping:
+            return settings.value("fUseReceiveShaping");
+        case UseSendShaping:
+            return settings.value("fUseSendShaping");          
+        case ReceiveBurst:
+            return settings.value("nReceiveBurst");
+        case ReceiveAve:
+            return settings.value("nReceiveAve");
+        case SendBurst:
+            return settings.value("nSendBurst");
+        case SendAve:
+            return settings.value("nSendAve");
         default:
             return QVariant();
         }
@@ -207,6 +268,8 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
 bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, int role)
 {
     bool successful = true; /* set to false on parse error */
+    bool changeSendShaper=false;
+    bool changeReceiveShaper=false;
     if(role == Qt::EditRole)
     {
         QSettings settings;
@@ -306,11 +369,68 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
                 setRestartRequired(true);
             }
             break;
+        case UseReceiveShaping:
+            if (settings.value("fUseReceiveShaping") != value) {
+                settings.setValue("fUseReceiveShaping",value);
+                changeReceiveShaper = true;
+            }
+            break;
+        case UseSendShaping:
+            if (settings.value("fUseSendShaping") != value) {
+                settings.setValue("fUseSendShaping",value);
+                changeSendShaper = true;
+            }
+            break;
+        case ReceiveBurst:
+            if (settings.value("nReceiveBurst") != value) {
+                settings.setValue("nReceiveBurst",value);
+                changeReceiveShaper = true;
+            }
+            break;
+        case ReceiveAve:
+            if (settings.value("nReceiveAve") != value) {
+                settings.setValue("nReceiveAve",value);
+                changeReceiveShaper = true;
+            }
+            break;
+        case SendBurst:
+            if (settings.value("nSendBurst") != value) {
+                settings.setValue("nSendBurst",value);
+                changeSendShaper = true;
+            }
+            break;
+        case SendAve:
+            if (settings.value("nSendAve") != value) {
+                settings.setValue("nSendAve",value);
+                changeSendShaper = true;
+            }
+            break;
         default:
             break;
         }
-    }
+    
 
+        if (changeReceiveShaper) {
+          if (settings.value("fUseReceiveShaping").toBool()) {
+            int64_t burst = 1024 * settings.value("nReceiveBurst").toInt();
+            int64_t ave = 1024 * settings.value("nReceiveAve").toInt();                    
+            receiveShaper.set(burst, ave);
+          }
+          else
+            receiveShaper.disable();
+        }
+
+        if (changeSendShaper) {
+          if (settings.value("fUseSendShaping").toBool()) {
+            int64_t burst = 1024 * settings.value("nSendBurst").toInt();
+            int64_t ave = 1024 * settings.value("nSendAve").toInt();                    
+            sendShaper.set(burst, ave);
+          }
+          else
+            sendShaper.disable();
+        }
+    }
+    
     emit dataChanged(index, index);
 
     return successful;

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -112,6 +112,31 @@ void OptionsModel::Init()
     if (!settings.contains("nSendAve"))
         settings.setValue("nSendAve", DEFAULT_AVE_SEND == LONG_MAX ? 200 : static_cast<int>(DEFAULT_AVE_SEND / 1024));
 
+    bool inUse = settings.value("fUseReceiveShaping").toBool();
+    int64_t burstKB = settings.value("nReceiveBurst").toInt();
+    int64_t aveKB = settings.value("nReceiveAve").toInt();
+
+    std::string avg = QString::number(inUse ? aveKB : LONG_MAX).toStdString();
+    std::string burst = QString::number(inUse ? burstKB : LONG_MAX).toStdString();
+
+    if (!SoftSetArg("-receiveavg", avg))
+        addOverriddenOption("-receiveavg");
+    if (!SoftSetArg("-receiveburst", burst))
+        addOverriddenOption("-receiveburst");
+
+    inUse = settings.value("fUseSendShaping").toBool();
+    burstKB = settings.value("nSendBurst").toInt();
+    aveKB = settings.value("nSendAve").toInt();
+
+    avg = QString::number(inUse ? aveKB : LONG_MAX).toStdString();
+    burst = QString::number(inUse ? burstKB : LONG_MAX).toStdString();
+
+    if (!SoftSetArg("-sendavg", avg))
+        addOverriddenOption("-sendavg");
+    if (!SoftSetArg("-sendburst", burst))
+        addOverriddenOption("-sendburst");
+    
+#if 0    
     // Set the shapers to values loaded from configuration
     bool inUse = settings.value("fUseReceiveShaping").toBool();
     int64_t burstArg = GetArg("-receiveburst", -1);
@@ -144,7 +169,7 @@ void OptionsModel::Init()
           sendShaper.set(burstKB*1024,aveKB*1024);
         }
     else sendShaper.disable();
-        
+#endif        
     
     if (!settings.contains("fUseUPnP"))
         settings.setValue("fUseUPnP", DEFAULT_UPNP);

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -42,6 +42,12 @@ public:
         DatabaseCache,          // int
         SpendZeroConfChange,    // bool
         Listen,                 // bool
+        UseReceiveShaping,      // bool
+        UseSendShaping,         // bool
+        ReceiveBurst,           // int
+        ReceiveAve,             // int
+        SendBurst,              // int
+        SendAve,                // int
         OptionIDRowCount,
     };
 

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -282,6 +282,7 @@ static const CRPCCommand vRPCCommands[] =
     { "network",            "getpeerinfo",            &getpeerinfo,            true  },
     { "network",            "ping",                   &ping,                   true  },
     { "network",            "settrafficshaping",      &settrafficshaping,      true  },
+    { "network",            "gettrafficshaping",      &gettrafficshaping,      true  },
 
     /* Block chain and UTXO */
     { "blockchain",         "getblockchaininfo",      &getblockchaininfo,      true  },

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -281,6 +281,7 @@ static const CRPCCommand vRPCCommands[] =
     { "network",            "getnettotals",           &getnettotals,           true  },
     { "network",            "getpeerinfo",            &getpeerinfo,            true  },
     { "network",            "ping",                   &ping,                   true  },
+    { "network",            "settrafficshaping",      &settrafficshaping,      true  },
 
     /* Block chain and UTXO */
     { "blockchain",         "getblockchaininfo",      &getblockchaininfo,      true  },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -150,6 +150,7 @@ extern json_spirit::Value getconnectioncount(const json_spirit::Array& params, b
 extern json_spirit::Value getpeerinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value ping(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value settrafficshaping(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value gettrafficshaping(const json_spirit::Array& params, bool fHelp);
 
 extern json_spirit::Value addnode(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getaddednodeinfo(const json_spirit::Array& params, bool fHelp);

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -149,6 +149,8 @@ extern void EnsureWalletIsUnlocked();
 extern json_spirit::Value getconnectioncount(const json_spirit::Array& params, bool fHelp); // in rpcnet.cpp
 extern json_spirit::Value getpeerinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value ping(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value settrafficshaping(const json_spirit::Array& params, bool fHelp);
+
 extern json_spirit::Value addnode(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getaddednodeinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getnettotals(const json_spirit::Array& params, bool fHelp);


### PR DESCRIPTION
Includes QT GUI support.  The GUI support works fine but "stuff" is not perfect.  For example, the edit boxes are not aligned and too large relative to the sliders.  Also, I like how Dagur's example GUI says "kB/s".  Also it would be nice to have "validators".  I'm not sure if QT has these explicitly but basically they are a small routine that runs whenever the user makes a change in the edit box, and the box will (for example) be light pink if the value is impossible (text in a numeric field, or average > burst for example).

So in sum, I think that you might want to take this pull request since it is fully functional and then have someone better at QT than I am firm up my work there (or if there are no takers, I'll figure it out eventually).