### PR TITLE
Trafficshaping

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -101,6 +101,7 @@ BITCOIN_CORE_H = \
   ipgroups.h \
   key.h \
   keystore.h \
+  leakybucket.h \
   leveldbwrapper.h \
   limitedmap.h \
   main.h \
@@ -183,6 +184,7 @@ libbitcoin_server_a_SOURCES = \
   checkpoints.cpp \
   init.cpp \
   ipgroups.cpp \
+  leakybucket.cpp \
   leveldbwrapper.cpp \
   main.cpp \
   merkleblock.cpp \

--- a/src/leakybucket.cpp
+++ b/src/leakybucket.cpp
@@ -1,0 +1,83 @@
+// Copyright (c) 2015 The Bitcoin XT developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "leakybucket.h"
+
+CLeakyBucket::CLeakyBucket(int maxp, int fillp, int startLevel)
+    : max(maxp),
+    fill(fillp)
+{
+    lastFill = clock.now();
+    // set the initial level to either what is specified by the user or to the maximum
+    level = (startLevel < max) ? startLevel : max;
+}
+
+void CLeakyBucket::disable()
+{
+    fill = 0;
+    max = 0;
+}
+
+void CLeakyBucket::fillIt()
+{
+    boost::chrono::time_point<CClock> now = clock.now();
+    CClock::duration elapsed(now - lastFill);
+    int msElapsed = boost::chrono::duration_cast<boost::chrono::milliseconds>(elapsed).count();
+    // note in practice msElapsed can be < 0, something to do with hyperthreading
+    // so don't eliminate this conditional
+    if (msElapsed > 100)
+    {
+        lastFill = now;
+        level += (fill * msElapsed) / 1000;
+        if (level > max)
+            level = max;
+    }
+}
+
+void CLeakyBucket::get(int* maxp, int* fillp, int* levelp)
+{
+    if (maxp) *maxp = max;
+    if (fillp) *fillp = fill;
+    if (levelp) *levelp = level;
+}
+
+void CLeakyBucket::set(int maxp, int fillp)
+{
+    max = maxp;
+    fill = fillp;
+    if (level > max)
+        level=max; // if pinching, slow traffic quickly.
+    lastFill = clock.now(); // need to reset the lastFill time in case we are turning on this leaky bucket.
+}
+
+int CLeakyBucket::available(int cutoff)
+{
+    if (fill == 0)
+        return INT_MAX; // shaping is off
+    fillIt();
+    return (level > cutoff) ? level : 0;
+}
+
+bool CLeakyBucket::try_consume(int amt)
+{
+    if (fill == 0)
+        return true; // leaky bucket is turned off.
+    assert(amt >= 0);
+    fillIt();
+    if (level >= amt)
+    {
+        level-=amt;
+        return true;
+    }
+    return false;
+}
+
+bool CLeakyBucket::consume(int amt)
+{
+    if (fill == 0)
+        return true; // leaky bucket is turned off.
+    fillIt();
+    level -= amt;
+    return (level >= 0);
+}

--- a/src/leakybucket.h
+++ b/src/leakybucket.h
@@ -1,0 +1,64 @@
+// Copyright (c) 2015 The Bitcoin XT developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_LEAKYBUCKET_H
+#define BITCOIN_LEAKYBUCKET_H
+
+#include <boost/chrono/include.hpp>
+
+/** Default value for the maximum amount of data that can be received in a burst */
+static const int DEFAULT_MAX_RECV_BURST = 100 * 1024;
+/** Default value for the maximum amount of data that can be sent in a burst */
+static const int DEFAULT_MAX_SEND_BURST = 100 * 1024;
+/** Default value for the average amount of data received per second */
+static const int DEFAULT_AVE_RECV = 30 * 1024;
+/** Default value for the average amount of data sent per second */
+static const int DEFAULT_AVE_SEND = 10 * 1024;
+/** If we have to break the transmission up into chunks, this is the minimum send chunk size */
+static const int SEND_SHAPER_MIN_FRAG = 256;
+/** If we have to break the transmission up into chunks, this is the minimum receive chunk size */
+static const int RECV_SHAPER_MIN_FRAG = 256;
+
+class CLeakyBucket
+{
+public:
+    CLeakyBucket(int maxp, int fillp, int startLevel = INT_MAX);
+
+    // Stop the operation of this leaky bucket (always return available tokens)
+    // use "set" to restart
+    void disable();
+
+    // Access the values in this bucket
+    void get(int* maximum, int* fillAmount, int *current = NULL);
+
+    // Change the settings of the leaky bucket
+    void set(int maximum, int fillAmount);
+
+    // Return the # tokens available if that amount is larger than the cutoff, otherwise return 0
+    int available(int cutoff = 0);
+
+    // Try to use \a amount tokens.  Returns true if the tokens can be consumed, false otherwise
+    bool try_consume(int amount);
+
+    // This function reduces the level in the bucket by amt, even if that makes the
+    // level negative, and returns true if the level is >= 0. This function is useful
+    // in a situation like data receipt (with soft limits) where you are not certain
+    // how many bytes will be received until after you have received them.
+    bool consume(int amount);
+
+protected:
+    typedef boost::chrono::steady_clock CClock;
+
+    int level; // Current level of the bucket
+    int max; // Maximum quantity allowed
+    int fill; // Average rate per second
+    static CClock clock;
+    boost::chrono::time_point<CClock> lastFill;
+
+    // This function is called internally to fill the leaky bucket based on
+    // the time difference between now and the last time the function was called.
+    void fillIt();
+};
+
+#endif

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -108,6 +108,11 @@ boost::condition_variable messageHandlerCondition;
 static CNodeSignals g_signals;
 CNodeSignals& GetNodeSignals() { return g_signals; }
 
+// Variables for traffic shaping
+CLeakyBucket receiveShaper(0 ,0);
+CLeakyBucket sendShaper(0, 0);
+boost::chrono::steady_clock CLeakyBucket::clock;
+
 void AddOneShot(string strDest)
 {
     LOCK(cs_vOneShots);
@@ -650,12 +655,17 @@ void SocketSendData(CNode *pnode)
     while (it != pnode->vSendMsg.end()) {
         const CSerializeData &data = *it;
         assert(data.size() > pnode->nSendOffset);
-        int nBytes = send(pnode->hSocket, &data[pnode->nSendOffset], data.size() - pnode->nSendOffset, MSG_NOSIGNAL | MSG_DONTWAIT);
+
+        int amt2Send = min((int)(data.size() - pnode->nSendOffset),
+                sendShaper.available(SEND_SHAPER_MIN_FRAG));
+        if (amt2Send==0) break;
+        int nBytes = send(pnode->hSocket, &data[pnode->nSendOffset], amt2Send, MSG_NOSIGNAL | MSG_DONTWAIT);
         if (nBytes > 0) {
             pnode->nLastSend = GetTime();
             pnode->nSendBytes += nBytes;
             pnode->nSendOffset += nBytes;
             pnode->RecordBytesSent(nBytes);
+            bool empty = !sendShaper.consume(nBytes);
             if (pnode->nSendOffset == data.size()) {
                 pnode->nSendOffset = 0;
                 pnode->nSendSize -= data.size();
@@ -664,6 +674,7 @@ void SocketSendData(CNode *pnode)
                 // could not send full message; stop sending more
                 break;
             }
+            if (empty) break;  // Exceeded our send budget, stop sending more
         } else {
             if (nBytes < 0) {
                 // error
@@ -691,8 +702,17 @@ static list<CNode*> vNodesDisconnected;
 void ThreadSocketHandler()
 {
     unsigned int nPrevNodeCount = 0;
+
+
+    /*
+     * int progress is incremented if something happens.  If it is zero at the bottom
+     * of the loop, we delay.  This solves spin loop issues where the select does not
+     * block but no bytes can be transferred (traffic shaping limited, for example).
+     */
+    int progress;
     while (true)
     {
+        progress = 0;
         //
         // Disconnect nodes
         //
@@ -950,14 +970,18 @@ void ThreadSocketHandler()
             if (FD_ISSET(pnode->hSocket, &fdsetRecv) || FD_ISSET(pnode->hSocket, &fdsetError))
             {
                 TRY_LOCK(pnode->cs_vRecvMsg, lockRecv);
-                if (lockRecv)
+                const int amt2Recv = receiveShaper.available(RECV_SHAPER_MIN_FRAG);
+                if (lockRecv && amt2Recv > 0)
                 {
                     {
-                        // typical socket buffer is 8K-64K
-                        char pchBuf[0x10000];
+                        progress++;
+                        // max of min makes sure amt is in a range reasonable for buffer allocation
+                        const int amt = max(1, min(amt2Recv, MAX_RECV_CHUNK));
+                        char *pchBuf = new char[amt];
                         int nBytes = recv(pnode->hSocket, pchBuf, sizeof(pchBuf), MSG_DONTWAIT);
                         if (nBytes > 0)
                         {
+                            receiveShaper.consume(nBytes);
                             if (!pnode->ReceiveMsgBytes(pchBuf, nBytes))
                                 pnode->CloseSocketDisconnect();
                             pnode->nLastRecv = GetTime();
@@ -982,6 +1006,8 @@ void ThreadSocketHandler()
                                 pnode->CloseSocketDisconnect();
                             }
                         }
+
+                        delete[] pchBuf;
                     }
                 }
             }
@@ -994,8 +1020,11 @@ void ThreadSocketHandler()
             if (FD_ISSET(pnode->hSocket, &fdsetSend))
             {
                 TRY_LOCK(pnode->cs_vSend, lockSend);
-                if (lockSend)
+                if (lockSend && sendShaper.try_consume(0))
+                {
+                    progress++;
                     SocketSendData(pnode);
+                }
             }
 
             //
@@ -1031,6 +1060,9 @@ void ThreadSocketHandler()
             BOOST_FOREACH(CNode* pnode, vNodesCopy)
                 pnode->Release();
         }
+
+        if (progress == 0)  // We didn't consume as much as was available, select will just return immediately.
+            MilliSleep(50); // sleep a little. (50 decided by holding thumb in the air)
     }
 }
 
@@ -1652,6 +1684,10 @@ void static Discover(boost::thread_group& threadGroup)
 
 void StartNode(boost::thread_group& threadGroup, CScheduler& scheduler)
 {
+    //  Init network shapers
+    receiveShaper.set(GetArg("-receiveburst", 0) * 1000, GetArg("-receiveavg", 0) * 1000);
+    sendShaper.set(GetArg("-sendburst", 0) * 1000, GetArg("-sendavg", 0) * 1000);
+
     uiInterface.InitMessage(_("Loading addresses..."));
     // Load addresses for peers.dat
     int64_t nStart = GetTimeMillis();

--- a/src/net.h
+++ b/src/net.h
@@ -9,6 +9,7 @@
 #include "bloom.h"
 #include "compat.h"
 #include "hash.h"
+#include "leakybucket.h"
 #include "limitedmap.h"
 #include "mruset.h"
 #include "netbase.h"
@@ -49,6 +50,9 @@ static const int TIMEOUT_INTERVAL = 20 * 60;
 static const unsigned int MAX_INV_SZ = 50000;
 /** The maximum number of new addresses to accumulate before announcing. */
 static const unsigned int MAX_ADDR_TO_SEND = 1000;
+/** The maximum # of bytes to receive at once */
+static const int MAX_RECV_CHUNK = 256*1024;
+
 /** -listen default */
 static const bool DEFAULT_LISTEN = true;
 /** -upnp default */
@@ -59,6 +63,7 @@ static const bool DEFAULT_UPNP = false;
 #endif
 /** The maximum number of entries in mapAskFor */
 static const size_t MAPASKFOR_MAX_SZ = MAX_INV_SZ;
+
 
 unsigned int ReceiveFloodSize();
 unsigned int SendBufferSize();

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -298,6 +298,124 @@
         </layout>
        </item>
        <item>
+        <widget class="QGroupBox" name="groupBox_2">
+         <property name="title">
+          <string>Speed limits</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout">
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="recvShapingEnable">
+            <property name="text">
+             <string>Incoming</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="sendShapingEnable">
+            <property name="text">
+             <string>Outgoing</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QSpinBox" name="sendBurstSpinbox">
+            <property name="suffix">
+             <string>%</string>
+            </property>
+            <property name="minimum">
+             <number>100</number>
+            </property>
+            <property name="maximum">
+             <number>1000</number>
+            </property>
+            <property name="singleStep">
+             <number>10</number>
+            </property>
+            <property name="value">
+             <number>160</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2" rowspan="2">
+           <widget class="QLabel" name="recvburstlabel_2">
+            <property name="text">
+             <string>KB/s</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="3">
+           <widget class="QSpinBox" name="receiveBurstSpinbox">
+            <property name="suffix">
+             <string>%</string>
+            </property>
+            <property name="minimum">
+             <number>100</number>
+            </property>
+            <property name="maximum">
+             <number>1000</number>
+            </property>
+            <property name="singleStep">
+             <number>10</number>
+            </property>
+            <property name="value">
+             <number>160</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="4">
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="3" column="3">
+           <widget class="QLabel" name="recvburstlabel">
+            <property name="text">
+             <string>Burst</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="sendAveSpinbox">
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>9999</number>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QSpinBox" name="recvAveSpinbox">
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>9999</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="errorText">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_Network">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -305,7 +423,7 @@
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>40</height>
+           <height>1</height>
           </size>
          </property>
         </spacer>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2013 The Bitcoin Core developers
+// Copyright (c) 2015 The Bitcoin XT developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -22,6 +23,7 @@
 #endif
 
 #include <boost/thread.hpp>
+#include <boost/lexical_cast.hpp>
 
 #include <QDataWidgetMapper>
 #include <QDir>
@@ -172,6 +174,13 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->connectSocks, OptionsModel::ProxyUse);
     mapper->addMapping(ui->proxyIp, OptionsModel::ProxyIP);
     mapper->addMapping(ui->proxyPort, OptionsModel::ProxyPort);
+
+    mapper->addMapping(ui->sendShapingEnable, OptionsModel::UseSendShaping);
+    mapper->addMapping(ui->sendBurstSpinbox, OptionsModel::SendBurst);
+    mapper->addMapping(ui->sendAveSpinbox, OptionsModel::SendAve);
+    mapper->addMapping(ui->recvShapingEnable, OptionsModel::UseReceiveShaping);
+    mapper->addMapping(ui->receiveBurstSpinbox, OptionsModel::ReceiveBurst);
+    mapper->addMapping(ui->recvAveSpinbox, OptionsModel::ReceiveAve);
 
     /* Window */
 #ifndef Q_OS_MAC

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -42,6 +42,12 @@ public:
         DatabaseCache,          // int
         SpendZeroConfChange,    // bool
         Listen,                 // bool
+        UseReceiveShaping,      // bool
+        UseSendShaping,         // bool
+        ReceiveBurst,           // int
+        ReceiveAve,             // int
+        SendBurst,              // int
+        SendAve,                // int
         OptionIDRowCount,
     };
 

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -281,6 +281,8 @@ static const CRPCCommand vRPCCommands[] =
     { "network",            "getnettotals",           &getnettotals,           true  },
     { "network",            "getpeerinfo",            &getpeerinfo,            true  },
     { "network",            "ping",                   &ping,                   true  },
+    { "network",            "settrafficshaping",      &settrafficshaping,      true  },
+    { "network",            "gettrafficshaping",      &gettrafficshaping,      true  },
 
     /* Block chain and UTXO */
     { "blockchain",         "getblockchaininfo",      &getblockchaininfo,      true  },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -149,6 +149,9 @@ extern void EnsureWalletIsUnlocked();
 extern json_spirit::Value getconnectioncount(const json_spirit::Array& params, bool fHelp); // in rpcnet.cpp
 extern json_spirit::Value getpeerinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value ping(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value settrafficshaping(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value gettrafficshaping(const json_spirit::Array& params, bool fHelp);
+
 extern json_spirit::Value addnode(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getaddednodeinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getnettotals(const json_spirit::Array& params, bool fHelp);


### PR DESCRIPTION
Cleanup and squash the traffic-shaping commits to prepare them for fast-forward merging.

For easier review, I removed any changes that were not relevant to the functionality.

There is one 'issue' I noticed in that if you set the speed to a rather low speed (like 80KB/s up) the client takes 2 minutes to download a block, but the network layer (of my OS) says its done much much faster.  So maybe there is some buffering being done in this code that negates the effect on quite slow throughput.

Other than that, it works well. I've been running it for a day now with no ill effects.
Will update when I notice anything more.