### PR TITLE
Dynamically Adjusting Spam Blocker

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1012,7 +1012,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
     if (pfMissingInputs)
         *pfMissingInputs = false;
 
-    int64_t maxBlockSize = Params().GetConsensus().MaxBlockSize(GetAdjustedTime(), sizeForkTime.load());
+    uint64_t maxBlockSize = Params().GetConsensus().MaxBlockSize(GetAdjustedTime(), sizeForkTime.load());
 
     if (!CheckTransaction(tx, state, maxBlockSize))
         return error("AcceptToMemoryPool: CheckTransaction failed");
@@ -1162,7 +1162,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         }
         else if(poolBytes < maxBlockSize * MAX_BLOCK_SIZE_MULTIPLYER){
             // Gradually choke off what is considered a free transaction
-            feeCutoff = (minRelayTxFee/1000) * (poolBytes-maxBlockSize)/(maxBlockSize * (MAX_BLOCK_SIZE_MULTIPLYER-1));
+            feeCutoff = (minRelayTxFee/1000) * (poolBytes - maxBlockSize) / (maxBlockSize * (MAX_BLOCK_SIZE_MULTIPLYER-1));
 
             // Gradually choke off the nFreeLimit as well but leave at least minFreeLimit
             // So that some free transactions can still get through
@@ -1175,7 +1175,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
             nFreeLimit = MIN_LIMIT_FREE_RELAY;
         }
 
-        double satoshiPerByte = nFees/nSize;
+        double satoshiPerByte = ((double)nFees)/nSize;
         LogPrint("mempool",
                  "MempoolBytes:%d  LimitFreeRelay:%d  FeeCutOff:%.4g  FeesSatoshiPerByte:%.4g  TxBytes:%d  TxFees:%d\n",
                   poolBytes,nFreeLimit,feeCutoff,satoshiPerByte, nSize, nFees);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,6 +34,10 @@
 #include <boost/math/distributions/poisson.hpp>
 #include <boost/thread.hpp>
 
+#include <boost/lexical_cast.hpp>
+#include <iostream>
+#include <string>
+
 using namespace std;
 
 #if defined(NDEBUG)
@@ -1136,21 +1140,55 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
             return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "insufficient priority");
         }
 
-        // Continuously rate-limit free (really, very-low-fee) transactions
-        // This mitigates 'penny-flooding' -- sending thousands of free transactions just to
-        // be annoying or make others' transactions take longer to confirm.
-        if (fLimitFree && nFees < ::minRelayTxFee.GetFee(nSize))
+        /* Continuously rate-limit free (really, very-low-fee) transactions
+         * This mitigates 'penny-flooding' -- sending thousands of free transactions just to
+         * be annoying or make others' transactions take longer to confirm. */
+
+        static uint8_t nLimitFreeRelay = GetArg("-limitfreerelay", 15);
+        static double minRelayTxFee = boost::lexical_cast<double>(GetArg("-minrelaytxfee","0.00007501")) * 100000000;
+        
+        // get current memory pool size
+        uint64_t poolBytes = pool.GetTotalTxSize();
+
+	// Calculate feeCutoff in satoshis per byte:
+	//   When the feeCutoff is larger than the satoshiPerByte of the 
+	//   current transaction then spam blocking will be in effect. However
+	//   Some free transactions will still get through based on -limitfreerelay
+        float feeCutoff;
+        uint8_t nFreeLimit;
+        if (poolBytes < maxBlockSize){
+            feeCutoff = 0;
+            nFreeLimit = nLimitFreeRelay;
+        }
+        else if(poolBytes < maxBlockSize * MAX_BLOCK_SIZE_MULTIPLYER){
+            // Gradually choke off what is considered a free transaction
+            feeCutoff = (minRelayTxFee/1000) * (poolBytes-maxBlockSize)/(maxBlockSize * (MAX_BLOCK_SIZE_MULTIPLYER-1));
+
+            // Gradually choke off the nFreeLimit as well but leave at least minFreeLimit
+            // So that some free transactions can still get through
+            nFreeLimit = nLimitFreeRelay - ((nLimitFreeRelay - MIN_LIMIT_FREE_RELAY) * (poolBytes-maxBlockSize) / (maxBlockSize * (MAX_BLOCK_SIZE_MULTIPLYER-1)));
+            if (nFreeLimit < MIN_LIMIT_FREE_RELAY)
+                nFreeLimit = MIN_LIMIT_FREE_RELAY;
+        }
+        else{
+            feeCutoff = minRelayTxFee/1000;
+            nFreeLimit = MIN_LIMIT_FREE_RELAY;
+        }
+
+        double satoshiPerByte = nFees/nSize;
+        LogPrint("mempool",
+                 "MempoolBytes:%d  LimitFreeRelay:%d  FeeCutOff:%.4g  FeesSatoshiPerByte:%.4g  TxBytes:%d  TxFees:%d\n",
+                  poolBytes,nFreeLimit,feeCutoff,satoshiPerByte, nSize, nFees);
+        if (fLimitFree && (satoshiPerByte < feeCutoff))
         {
             static double dFreeCount;
             static int64_t nLastFreeTime;
-            static int64_t nFreeLimit = GetArg("-limitfreerelay", 15);
-
             // At default rate it would take over a month to fill 1GB
             if (RateLimitExceeded(dFreeCount, nLastFreeTime, nFreeLimit, nSize))
                 return state.DoS(0, error("AcceptToMemoryPool : free transaction rejected by rate limiter"),
-                                 REJECT_INSUFFICIENTFEE, "rate limited free transaction");
-
+                       REJECT_INSUFFICIENTFEE, "rate limited free transaction");
             LogPrint("mempool", "Rate limit dFreeCount: %g => %g\n", dFreeCount, dFreeCount+nSize);
+            dFreeCount += nSize;
         }
 
         if (fRejectAbsurdFee && nFees > ::minRelayTxFee.GetFee(nSize) * 10000)

--- a/src/main.h
+++ b/src/main.h
@@ -96,7 +96,7 @@ static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 2 * 1024 * 1024;
 /** The number of block heights to choke spam transactions over */
 static const unsigned int MAX_BLOCK_SIZE_MULTIPLYER = 3;
 /** The minimum value possible for -limitfreerelay when rate limiting */
-static unsigned int MIN_LIMIT_FREE_RELAY = 2;
+static const unsigned int MIN_LIMIT_FREE_RELAY = 2;
 
 struct BlockHasher
 {

--- a/src/main.h
+++ b/src/main.h
@@ -93,6 +93,10 @@ static const unsigned int DATABASE_FLUSH_INTERVAL = 24 * 60 * 60;
 static const unsigned int MAX_REJECT_MESSAGE_LENGTH = 111;
 /** Maximum length of incoming protocol messages (no message over 2 MiB is currently acceptable). */
 static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 2 * 1024 * 1024;
+/** The number of block heights to choke spam transactions over */
+static const unsigned int MAX_BLOCK_SIZE_MULTIPLYER = 3;
+/** The minimum value possible for -limitfreerelay when rate limiting */
+static unsigned int MIN_LIMIT_FREE_RELAY = 2;
 
 struct BlockHasher
 {


### PR DESCRIPTION
As the memory pool fills up to more than one
block height the limitfreerelay and minrelaytxfee
are dynamically adjusted to gradually choke off low fee spam.  

The minrelaytxfee is used as an upper bounds and is gradually increased from zero to the minrelaytxfee value as the choking is invoked.  limitfreerelay is also gradually choked off but will not go below 5.

If/when the spamming ends and the memory pool begins to fall in size the choke is also gradually removed.

Spam transaction are never accepted into the memory pool and therefore not
relayed stopping the spam from traversing the network, saving CPU , memory and bandwidth.

Currently it will reach maximum choke after a 3 block height in the memory pool but even then 
some free transactions will still get through.

Awaiting comments...