### PR TITLE
evictRandomBytewise with worst-of-2 eviction

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -314,7 +314,8 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-maxconnections=<n>", strprintf(_("Maintain at most <n> connections to peers (default: %u)"), 125));
     strUsage += HelpMessageOpt("-maxreceivebuffer=<n>", strprintf(_("Maximum per-connection receive buffer, <n>*1000 bytes (default: %u)"), 5000));
     strUsage += HelpMessageOpt("-maxsendbuffer=<n>", strprintf(_("Maximum per-connection send buffer, <n>*1000 bytes (default: %u)"), 1000));
-    strUsage += HelpMessageOpt("-maxmempooltx=<n>", ("Maximum number of transactions in memory pool (default: enough to fill about 25 blocks)"));
+    strUsage += HelpMessageOpt("-maxmempooltx=<n>", ("Maximum number of transactions in memory pool (default: enough to fill about 25 blocks with 500 byte transactions)"));
+    strUsage += HelpMessageOpt("-maxmempoolbytes=<n>", ("Maximum size (in bytes) of transactions in memory pool (default: enough to fill 50 blocks)"));
     strUsage += HelpMessageOpt("-onion=<ip:port>", strprintf(_("Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)"), "-proxy"));
     strUsage += HelpMessageOpt("-onlynet=<net>", _("Only connect to nodes in network <net> (ipv4, ipv6 or onion)"));
     strUsage += HelpMessageOpt("-permitbaremultisig", strprintf(_("Relay non-P2SH multisig (default: %u)"), 1));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -315,7 +315,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-maxreceivebuffer=<n>", strprintf(_("Maximum per-connection receive buffer, <n>*1000 bytes (default: %u)"), 5000));
     strUsage += HelpMessageOpt("-maxsendbuffer=<n>", strprintf(_("Maximum per-connection send buffer, <n>*1000 bytes (default: %u)"), 1000));
     strUsage += HelpMessageOpt("-maxmempooltx=<n>", ("Maximum number of transactions in memory pool (default: enough to fill about 25 blocks with 500 byte transactions)"));
-    strUsage += HelpMessageOpt("-maxmempoolbytes=<n>", ("Maximum size (in bytes) of transactions in memory pool (default: enough to fill 50 blocks)"));
+    strUsage += HelpMessageOpt("-maxmempoolbytes=<n>", ("Maximum in-memory size of transactions in memory pool (default: enough to fill 50 blocks)"));
     strUsage += HelpMessageOpt("-onion=<ip:port>", strprintf(_("Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)"), "-proxy"));
     strUsage += HelpMessageOpt("-onlynet=<net>", _("Only connect to nodes in network <net> (ipv4, ipv6 or onion)"));
     strUsage += HelpMessageOpt("-permitbaremultisig", strprintf(_("Relay non-P2SH multisig (default: %u)"), 1));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1196,7 +1196,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
             int64_t nMaxPoolTx = GetArg("-maxmempooltx", nDefaultMax);
 
             // Default max mempool size: 50 blocks-worth of transactions
-            int64_t nDefaultMaxBytes = 50 * (int64_t)(maxBlockSize) * 100 / 275;
+            int64_t nDefaultMaxBytes = 50 * (int64_t)(maxBlockSize) * 275 / 100;
             // approx 2.75 in-memory bytes per serialized tx byte
             int64_t nMaxPoolBytes = GetArg("-maxmempoolbytes", nDefaultMaxBytes) * 100 / 275; 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1196,7 +1196,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
             int64_t nMaxPoolTx = GetArg("-maxmempooltx", nDefaultMax);
 
             // Default max mempool size: 50 blocks-worth of transactions
-            int64_t nDefaultMaxBytes = 50 * (int64_t)(maxBlockSize);
+            int64_t nDefaultMaxBytes = 50 * (int64_t)(maxBlockSize) * 100 / 275;
             // approx 2.75 in-memory bytes per serialized tx byte
             int64_t nMaxPoolBytes = GetArg("-maxmempoolbytes", nDefaultMaxBytes) * 100 / 275; 
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -276,11 +276,6 @@ void CTxMemPool::evictRandomBytewise(std::list<CTransaction>& evicted)
         bool pr1 = (mapDeltas.find(tx1.first) != mapDeltas.end());
         bool pr2 = (mapDeltas.find(tx2.first) != mapDeltas.end());
 
-        LogPrint("mempool", "Eviction candidate 1: %i byte %i satoshi %s\n", 
-                        tx1.second.GetTxSize(), tx1.second.GetFee(), tx1.first.ToString());
-        LogPrint("mempool", "Eviction candidate 2: %i byte %i satoshi %s\n", 
-                        tx2.second.GetTxSize(), tx2.second.GetFee(), tx2.first.ToString());
-
         if (pr1 && pr2) continue; // prioritized, try again
         if (!tx1.second.GetTxSize() || !tx2.second.GetTxSize()) continue; // probably unnecessary
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -14,6 +14,7 @@
 #include "util.h"
 #include "utilmoneystr.h"
 #include "version.h"
+#include "random.h"
 
 using namespace std;
 
@@ -236,6 +237,42 @@ void CTxMemPool::evictRandom(std::list<CTransaction>& evicted)
     // There is a small chance nothing will be evicted if the mempool is mostly
     // prioritised transactions. That's OK.
 }
+
+void CTxMemPool::evictRandomBytewise(std::list<CTransaction>& evicted)
+    // Find random transaction, weighted by size
+    // This code uses a hack to avoid searching through the whole mempool.
+    // It picks a random transaction, then scans for a random number of bytes
+    // (not to exceed 1 MB or the mempool size) and evicts the transaction 
+    // that is the random number of bytes away from the start
+{
+    uint64_t maxScanBytes;
+    uint64_t target;
+    uint64_t cursor;
+    // maxScanBytes should be larger than the biggest transaction
+    // but small enough to not slow down this method
+    maxScanBytes = 100000ull < GetTotalTxSize() ? 100000ull : GetTotalTxSize();
+    target = GetRand(maxScanBytes);
+
+    LOCK(cs);
+    if (mapTx.empty())
+        return;
+    for (int i = 0; i < 11; i++) {
+        cursor = 0;
+        map<uint256, CTxMemPoolEntry>::iterator it = mapTx.lower_bound(GetRandHash());
+        while (cursor < target)
+        {
+            if (it == mapTx.end())
+                it = mapTx.begin();
+            it++;
+            cursor += it->second.GetTxSize();
+        }
+        if (mapDeltas.find(it->first) != mapDeltas.end())
+            continue;  // prioritised: try again
+        remove(it->second.GetTx(), evicted, true);
+        return;
+    }
+}
+
 
 void CTxMemPool::clear()
 {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -123,6 +123,7 @@ public:
     // evicted. If the memory pool is full of prioritised transactions, there is
     // a chance it will evict nothing.
     void evictRandom(std::list<CTransaction>& evicted);
+    void evictRandomBytewise(std::list<CTransaction>& evicted);
     void clear();
     void queryHashes(std::vector<uint256>& vtxid);
     void pruneSpent(const uint256& hash, CCoins &coins);


### PR DESCRIPTION
This PR adds the ability to limit the mempool size to a number of bytes, using the -maxmempoolbytes command line option. It adds a method to pick two random transactions from the mempool, weighted by the transactions' sizes, and evict the transaction with the lowest fee/kB. Transactions that are prioritized will be skipped.

The -maxmempoolbytes option defaults to 50 blocks' worth of transactions. It uses the transaction's serialized size, not the in-memory size. The in-memory size is typically 2.5x higher. Thus, with 1 MB blocks, the default setting allows for approximately 2.5 * 50 * 1 MB = 125 MB of memory usage by the mempool.

Performance-wise, each eviction typically takes less than 200 us on a Core i7 4790k. Performance should be roughly O(1) vs mempool size. 