### PR TITLE
Fix blockversion race condition in two regtests

### DIFF
--- a/qa/rpc-tests/bip65-cltv.py
+++ b/qa/rpc-tests/bip65-cltv.py
@@ -14,6 +14,13 @@ import shutil
 
 class BIP65Test(BitcoinTestFramework):
 
+    def __init__(self):
+        self.num_nodes = 3
+
+    def setup_chain(self):
+        print "Initializing test directory "+self.options.tmpdir
+        initialize_chain_clean(self.options.tmpdir, self.num_nodes)
+
     def setup_network(self):
         self.nodes = []
         self.nodes.append(start_node(0, self.options.tmpdir, []))

--- a/qa/rpc-tests/forknotify.py
+++ b/qa/rpc-tests/forknotify.py
@@ -16,6 +16,13 @@ class ForkNotifyTest(BitcoinTestFramework):
 
     alert_filename = None  # Set by setup_network
 
+    def __init__(self):
+        self.num_nodes = 3
+
+    def setup_chain(self):
+        print "Initializing test directory "+self.options.tmpdir
+        initialize_chain_clean(self.options.tmpdir, self.num_nodes)
+
     def setup_network(self):
         self.nodes = []
         self.alert_filename = os.path.join(self.options.tmpdir, "alert.txt")


### PR DESCRIPTION
On some systems, bip65-cltv.py fails because the default 200 BIP101-version blocks are mined before the test begins, causing it to think BIP65 is already in effect.

@error10 does applying this 7-line change fix issue #101 for you?