### PR TITLE
Fix socket buffer bug

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -978,7 +978,7 @@ void ThreadSocketHandler()
                         // max of min makes sure amt is in a range reasonable for buffer allocation
                         const int amt = max(1, min(amt2Recv, MAX_RECV_CHUNK));
                         char *pchBuf = new char[amt];
-                        int nBytes = recv(pnode->hSocket, pchBuf, sizeof(pchBuf), MSG_DONTWAIT);
+                        int nBytes = recv(pnode->hSocket, pchBuf, amt, MSG_DONTWAIT);
                         if (nBytes > 0)
                         {
                             receiveShaper.consume(nBytes);


### PR DESCRIPTION
Currently in XT the network socket is read in only 8 byte chunks.

The code

    char *pchBuf = new char[amt];
    int nBytes = recv(pnode->hSocket, pchBuf, sizeof(pchBuf), MSG_DONTWAIT);

is equivalent to

    char *pchBuf = new char[amt];
    int nBytes = recv(pnode->hSocket, pchBuf, 8, MSG_DONTWAIT);

This wastes CPU and dramatically reduces transfer speed for all network communication.

Fixing the bug on my LAN testnet setup increases block transfer speed 3 times.

Bug does not affect the other implementation.
