### PR TITLE
Increase timeout waiting for pruned blk00000.dat

### DIFF
--- a/qa/rpc-tests/pruning.py
+++ b/qa/rpc-tests/pruning.py
@@ -90,7 +90,7 @@ class PruneTest(BitcoinTestFramework):
         waitstart = time.time()
         while os.path.isfile(self.prunedir+"blk00000.dat"):
             time.sleep(0.1)
-            if time.time() - waitstart > 10:
+            if time.time() - waitstart > 30:
                 raise AssertionError("blk00000.dat not pruned when it should be")
 
         print "Success"


### PR DESCRIPTION
In my ever-growing list of test failures, I was seeing this one intermittently.

```
Running 2nd level testscript pruning.py...
Initializing test directory /tmp/testY5ypCv
Warning! This test requires 4GB of disk space and takes over 30 mins (up to 2 hours)
Mining a big blockchain of 995 blocks
Check that we haven't started pruning yet because we're below PruneAfterHeight
Success
Though we're already using more than 550MB, current usage: 587
Mining 25 more blocks should cause the first block file to be pruned
Assertion failed: blk00000.dat not pruned when it should be
  File "/home/error/bitcoinxt-0.11D/qa/rpc-tests/test_framework/test_framework.py", line 118, in main
    self.run_test()
  File "/home/error/bitcoinxt-0.11D/qa/rpc-tests/pruning.py", line 272, in run_test
    self.test_height_min()
  File "/home/error/bitcoinxt-0.11D/qa/rpc-tests/pruning.py", line 94, in test_height_min
    raise AssertionError("blk00000.dat not pruned when it should be")
Stopping nodes
Failed
```

After digging into the test, I found that the code is waiting 10 seconds for blk00000.dat to be deleted, and then throwing this failure if it still exists after 10 seconds.

I increased this amount, had the script print the actual time taken, and ran the test a few more times. The time taken ranged between 8 to 12 seconds. So, I feel that this timeout is too short.

After changing the timeout to 30 seconds, the test passes consistently.