### PR TITLE
Fix for busy wait loop in SendShaper

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -658,7 +658,11 @@ void SocketSendData(CNode *pnode)
 
         int amt2Send = min((int)(data.size() - pnode->nSendOffset),
                 sendShaper.available(SEND_SHAPER_MIN_FRAG));
-        if (amt2Send==0) break;
+        if (amt2Send == 0) {
+            if (sendShaper.available(SEND_SHAPER_MIN_FRAG) != INT_MAX) //Sleep if traffic shaping is turned on
+                MilliSleep(10);
+            break;
+        }
         int nBytes = send(pnode->hSocket, &data[pnode->nSendOffset], amt2Send, MSG_NOSIGNAL | MSG_DONTWAIT);
         if (nBytes > 0) {
             pnode->nLastSend = GetTime();


### PR DESCRIPTION
When the sendshaper is on and the outgoing
traffic is pegged to the upper speed limit
then cpu will go to 90% on one core.

The best way I've found to see this is to:

1) get the node running first with no traffic shaping and let it stabilize for about 15 minutes
2) set the outbound traffic shaping way down to about 10 or 15KB but have no inbound traffic shaping
3)  wait for the outbound traffic to be pegged at the upper limit you've set.  Once it's pegged there the cpu will start to race, using up about 90% on one core.

The system must be busy to see this.  ( It's harder on a sunday afternoon to get this problem to appear)
