### PR TITLE
Implement uacomment (alternative to #69)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -113,6 +113,7 @@ BITCOIN_CORE_H = \
   net.h \
   netbase.h \
   noui.h \
+  options.h \
   policy/fees.h \
   pow.h \
   primitives/block.h \
@@ -193,6 +194,7 @@ libbitcoin_server_a_SOURCES = \
   miner.cpp \
   net.cpp \
   noui.cpp \
+  options.cpp \
   policy/fees.cpp \
   pow.cpp \
   rest.cpp \
@@ -288,6 +290,7 @@ libbitcoin_util_a_SOURCES = \
   compat/glibc_sanity.cpp \
   compat/glibcxx_sanity.cpp \
   compat/strnlen.cpp \
+  options.cpp \
   random.cpp \
   rpcprotocol.cpp \
   support/cleanse.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -44,6 +44,7 @@ BITCOIN_TESTS =\
   test/bloom_tests.cpp \
   test/checkblock_tests.cpp \
   test/Checkpoints_tests.cpp \
+  test/clientversion_tests.cpp \
   test/coins_tests.cpp \
   test/compress_tests.cpp \
   test/crypto_tests.cpp \

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -152,12 +152,15 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const 
  */
 std::string XTSubVersion()
 {
-    if (Opt().IsStealthMode())
-        return FormatSubVersion("Satoshi", CLIENT_VERSION, std::vector<std::string>(), "");
+    std::vector<std::string> comments = Opt().UAComment();
 
-    std::vector<std::string> comments;
-    if (!Opt().HidePlatform())
-        comments = GetPlatformDetails();
+    if (Opt().IsStealthMode())
+        return FormatSubVersion("Satoshi", CLIENT_VERSION, comments, "");
+
+    if (!Opt().HidePlatform()) {
+        std::vector<std::string> p = GetPlatformDetails();
+        comments.insert(comments.end(), p.begin(), p.end());
+    }
 
     return FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, comments, CLIENT_VERSION_XT_SUBVER);
 }

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -65,6 +65,8 @@ extern const std::string CLIENT_DATE;
 std::string FormatFullVersion();
 std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments, const char *releaseCharacter = "");
 
+std::string XTSubVersion();
+
 #endif // WINDRES_PREPROC
 
 #endif // BITCOIN_CLIENTVERSION_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -310,6 +310,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-dnsseed", _("Query for peer addresses via DNS lookup, if low on addresses (default: 1 unless -connect)"));
     strUsage += HelpMessageOpt("-externalip=<ip>", _("Specify your own public address"));
     strUsage += HelpMessageOpt("-forcednsseed", strprintf(_("Always query for peer addresses via DNS lookup (default: %u)"), 0));
+    strUsage += HelpMessageOpt("-hide-platform", _("Don't show platform information in the client string"));
     strUsage += HelpMessageOpt("-listen", _("Accept connections from outside (default: 1 if no -proxy or -connect)"));
     strUsage += HelpMessageOpt("-maxconnections=<n>", strprintf(_("Maintain at most <n> connections to peers (default: %u)"), 125));
     strUsage += HelpMessageOpt("-maxreceivebuffer=<n>", strprintf(_("Maximum per-connection receive buffer, <n>*1000 bytes (default: %u)"), 5000));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@
 #include "util.h"
 #include "utilmoneystr.h"
 #include "validationinterface.h"
+#include "options.h"
 
 #include <sstream>
 
@@ -192,10 +193,6 @@ static CBloomFilter doubleSpendFilter;
 void InitRespendFilter() {
     seed_insecure_rand();
     doubleSpendFilter = CBloomFilter(MAX_DOUBLESPEND_BLOOM, 0.01, insecure_rand(), BLOOM_UPDATE_NONE);
-}
-
-bool IsStealthMode() {
-    return GetBoolArg("-stealth-mode", false);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -1186,7 +1183,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
                 doubleSpendFilter.clear();
             doubleSpendFilter.insert(relayForOutpoint);
 
-            if (!IsStealthMode())
+            if (!Opt().IsStealthMode())
                 RelayTransaction(tx);
         }
         else
@@ -4540,7 +4537,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
             // Ignore duplicate advertisements for the same item from the same peer. This check
             // prevents a peer from constantly promising to deliver an item that it never does,
             // thus blinding us to new transactions and blocks.
-            if (!IsStealthMode() && !pfrom->AddInventoryKnown(inv))
+            if (!Opt().IsStealthMode() && !pfrom->AddInventoryKnown(inv))
                 continue;
 
             bool fAlreadyHave = AlreadyHave(inv);
@@ -4688,7 +4685,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
 
     else if (strCommand == "getutxos")
     {
-        if (!IsStealthMode()) {
+        if (!Opt().IsStealthMode()) {
             bool fCheckMemPool;
             vector<COutPoint> vOutPoints;
             vRecv >> fCheckMemPool;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4332,7 +4332,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
         if (!vRecv.empty())
             vRecv >> addrFrom >> nNonce;
         if (!vRecv.empty()) {
-            vRecv >> LIMITED_STRING(pfrom->strSubVer, 256);
+            vRecv >> LIMITED_STRING(pfrom->strSubVer, MAX_SUBVERSION_LENGTH);
             pfrom->cleanSubVer = SanitizeString(pfrom->strSubVer);
         }
         if (!vRecv.empty())

--- a/src/main.h
+++ b/src/main.h
@@ -555,7 +555,4 @@ private:
 };
 extern SizeForkTime sizeForkTime;
 
-// In stealth mode, pretend to be Bitcoin Core to hide from DoS attackers.
-bool IsStealthMode();
-
 #endif // BITCOIN_MAIN_H

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -8,7 +8,6 @@
 #endif
 
 #include "net.h"
-#include "main.h"
 #include "addrman.h"
 #include "chainparams.h"
 #include "clientversion.h"
@@ -17,6 +16,7 @@
 #include "ui_interface.h"
 #include "crypto/common.h"
 #include "ipgroups.h"
+#include "options.h"
 
 #ifdef WIN32
 #include <string.h>
@@ -434,13 +434,13 @@ void CNode::PushVersion()
         LogPrint("net", "send version message: version %d, blocks=%d, us=%s, peer=%d\n", PROTOCOL_VERSION, nBestHeight, addrMe.ToString(), id);
 
     // Stealth mode: pretend to be like Bitcoin Core to hide from DoS attackers.
-    if (IsStealthMode()) {
+    if (Opt().IsStealthMode()) {
         uint64_t services = NODE_NETWORK;
         PushMessage("version", 70002, services, nTime, addrYou, addrMe,
-                nLocalHostNonce, FormatSubVersion("Satoshi", CLIENT_VERSION, std::vector<string>(), ""), nBestHeight, true);        
+                nLocalHostNonce, XTSubVersion(), nBestHeight, true);
     } else {
         PushMessage("version", PROTOCOL_VERSION, nLocalServices, nTime, addrYou, addrMe,
-                nLocalHostNonce, FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, std::vector<string>(), CLIENT_VERSION_XT_SUBVER), nBestHeight, true);
+                nLocalHostNonce, XTSubVersion(), nBestHeight, true);
     }
 }
 

--- a/src/net.h
+++ b/src/net.h
@@ -52,6 +52,8 @@ static const unsigned int MAX_INV_SZ = 50000;
 static const unsigned int MAX_ADDR_TO_SEND = 1000;
 /** The maximum # of bytes to receive at once */
 static const int MAX_RECV_CHUNK = 256*1024;
+/** Maximum length of strSubVer in `version` message */
+static const unsigned int MAX_SUBVERSION_LENGTH = 256;
 
 /** -listen default */
 static const bool DEFAULT_LISTEN = true;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1,0 +1,34 @@
+#include "options.h"
+#include "util.h"
+
+static std::auto_ptr<ArgGetter> Args;
+
+struct DefaultGetter : public ArgGetter {
+    virtual bool GetBool(const std::string& arg, bool def) {
+        return ::GetBoolArg(arg, def);
+    }
+};
+
+Opt::Opt() {
+    if (!bool(Args.get()))
+        Args.reset(new DefaultGetter());
+}
+
+bool Opt::IsStealthMode() {
+    return Args->GetBool("-stealth-mode", false);
+}
+
+bool Opt::HidePlatform() {
+    return Args->GetBool("-hide-platform", false);
+}
+
+
+std::auto_ptr<ArgReset> SetDummyArgGetter(std::auto_ptr<ArgGetter> getter) {
+    Args.reset(getter.release());
+    return std::auto_ptr<ArgReset>(new ArgReset);
+}
+
+ArgReset::~ArgReset() {
+    Args.reset(new DefaultGetter());
+}
+

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1,11 +1,18 @@
 #include "options.h"
 #include "util.h"
+#include <stdexcept>
 
 static std::auto_ptr<ArgGetter> Args;
 
 struct DefaultGetter : public ArgGetter {
     virtual bool GetBool(const std::string& arg, bool def) {
         return ::GetBoolArg(arg, def);
+    }
+    virtual std::vector<std::string> GetMultiArgs(const std::string& arg) {
+        if (!mapMultiArgs.count(arg))
+            return std::vector<std::string>();
+
+        return mapMultiArgs[arg];
     }
 };
 
@@ -22,6 +29,24 @@ bool Opt::HidePlatform() {
     return Args->GetBool("-hide-platform", false);
 }
 
+std::vector<std::string> Opt::UAComment(bool validate) {
+    std::vector<std::string> uacomments = Args->GetMultiArgs("-uacomment");
+    if (!validate)
+        return uacomments;
+
+    typedef std::vector<std::string>::const_iterator auto_;
+    for (auto_ c = uacomments.begin(); c != uacomments.end(); ++c) {
+        size_t pos = c->find_first_of("/:()");
+        if (pos == std::string::npos)
+            continue;
+        std::stringstream ss;
+        ss << "-uacomment '" << *c << "' contains the reserved character '"
+            << c->at(pos) << "'.The following characters are reserved: / : ( )";
+        throw std::invalid_argument(ss.str());
+    }
+
+    return uacomments;
+}
 
 std::auto_ptr<ArgReset> SetDummyArgGetter(std::auto_ptr<ArgGetter> getter) {
     Args.reset(getter.release());

--- a/src/options.h
+++ b/src/options.h
@@ -3,13 +3,14 @@
 
 #include <string>
 #include <memory>
+#include <vector>
 
 struct Opt {
     Opt();
 
     bool IsStealthMode();
     bool HidePlatform();
-
+    std::vector<std::string> UAComment(bool validate = false);
 };
 
 //
@@ -18,6 +19,7 @@ struct Opt {
 
 struct ArgGetter {
     virtual bool GetBool(const std::string& arg, bool def) = 0;
+    virtual std::vector<std::string> GetMultiArgs(const std::string& arg) = 0;
 };
 
 struct ArgReset {

--- a/src/options.h
+++ b/src/options.h
@@ -1,0 +1,32 @@
+#ifndef BITCOIN_OPTIONS_H
+#define BITCOIN_OPTIONS_H
+
+#include <string>
+#include <memory>
+
+struct Opt {
+    Opt();
+
+    bool IsStealthMode();
+    bool HidePlatform();
+
+};
+
+//
+// For unit testing
+//
+
+struct ArgGetter {
+    virtual bool GetBool(const std::string& arg, bool def) = 0;
+};
+
+struct ArgReset {
+    ~ArgReset();
+};
+
+// Temporary replace the global getter for fetching user configurations.
+//
+// Returns a RAII object that sets system back to default state.
+std::auto_ptr<ArgReset> SetDummyArgGetter(std::auto_ptr<ArgGetter>);
+
+#endif

--- a/src/test/clientversion_tests.cpp
+++ b/src/test/clientversion_tests.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) 2015- The Bitcoin XT developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <boost/test/unit_test.hpp>
+
+#include "clientversion.h"
+#include "options.h"
+
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 105500 // Boost 1.55 or newer
+#include <boost/predef.h>
+#endif
+
+BOOST_AUTO_TEST_SUITE(clientversion_tests)
+
+struct DummyArgGetter : public ArgGetter {
+
+    DummyArgGetter() : stealthmode(false), hideplatform(false)
+    {
+    }
+
+    virtual bool GetBool(const std::string& arg, bool def) {
+        if (arg == "-stealth-mode")
+            return stealthmode;
+        if (arg == "-hide-platform")
+            return hideplatform;
+        return def;
+    }
+
+    bool stealthmode;
+    bool hideplatform;
+};
+
+bool OsInStr(const std::string& version) {
+    // Assume OS is in string if string contains comments
+    return version.find("(") != std::string::npos;
+}
+
+BOOST_AUTO_TEST_CASE(platform_in_xtsubversion)
+{
+    std::auto_ptr<DummyArgGetter> arg(new DummyArgGetter);
+    DummyArgGetter* argPtr = arg.get();
+    std::auto_ptr<ArgReset> argraii
+        = SetDummyArgGetter(std::auto_ptr<ArgGetter>(arg.release()));
+
+    argPtr->hideplatform = true;
+    argPtr->stealthmode = false;
+    BOOST_CHECK(!OsInStr(XTSubVersion()));
+
+    argPtr->hideplatform = false;
+    argPtr->stealthmode = true;
+    BOOST_CHECK(!OsInStr(XTSubVersion()));
+
+#if BOOST_VERSION >= 105500
+    argPtr->hideplatform = false;
+    argPtr->stealthmode = false;
+    BOOST_CHECK(OsInStr(XTSubVersion()));
+#endif
+}
+
+BOOST_AUTO_TEST_CASE(xtsubversion_stealthmode)
+{
+    std::auto_ptr<DummyArgGetter> arg(new DummyArgGetter);
+    DummyArgGetter* argPtr = arg.get();
+    std::auto_ptr<ArgReset> argraii
+        = SetDummyArgGetter(std::auto_ptr<ArgGetter>(arg.release()));
+
+    argPtr->stealthmode = true;
+    BOOST_CHECK(XTSubVersion().find("XT") == std::string::npos);
+
+    argPtr->stealthmode = false;
+    BOOST_CHECK(XTSubVersion().find("XT") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+


### PR DESCRIPTION
This PR is an alternative implementation of #69 

This one is compatible with #98. Also, compared to #69 it does not add a global subversion variable, has a unit test and --help text.