### PR TITLE
Modify mainnet params for 2/4/8, block version=5

### DIFF
--- a/qa/rpc-tests/bigblocks.py
+++ b/qa/rpc-tests/bigblocks.py
@@ -15,7 +15,7 @@ CACHE_DIR = "cache_bigblock"
 
 # regression test / testnet fork params:
 FORK_TIME = 1438387200
-FORK_BLOCK_VERSION = 0x20000007
+FORK_BLOCK_VERSION = 5
 FORK_GRACE_PERIOD = 60*60*24
 
 class BigBlockTest(BitcoinTestFramework):

--- a/qa/rpc-tests/forknotify.py
+++ b/qa/rpc-tests/forknotify.py
@@ -35,9 +35,9 @@ class ForkNotifyTest(BitcoinTestFramework):
                                 ["-blockversion=211"]))
         connect_nodes(self.nodes[1], 0)
 
-        # Node2 mines block.version=0x20000007 blocks
+        # Node2 mines block.version=5 blocks
         self.nodes.append(start_node(2, self.options.tmpdir,
-                            ["-blockversion=%d"%(0x20000007,)]))
+                            ["-blockversion=%d"%(5,)]))
         connect_nodes(self.nodes[2], 0)
 
         self.is_network_split = False

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -60,8 +60,8 @@ public:
         // Then, if miner consensus: 8MB max, doubling every two years
         consensus.nMaxSizePreFork = 1000*1000; // 1MB max pre-fork
         consensus.nSizeDoubleEpoch = 60*60*24*365*2; // two years
-        consensus.nMaxSizeBase = 8*1000*1000; // 8MB
-        consensus.nMaxSizeDoublings = 10;
+        consensus.nMaxSizeBase = 2*1000*1000; // 2MB
+        consensus.nMaxSizeDoublings = 2;
         consensus.nActivateSizeForkMajority = 750; // 75% of hashpower to activate fork
         consensus.nSizeForkGracePeriod = 60*60*24*14; // two week grace period after activation
 

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -11,7 +11,7 @@
 #include "uint256.h"
 
 /** Blocks with version fields that have these bits set activate the bigger-block fork */
-const unsigned int SIZE_FORK_VERSION = 0x20000007;
+const unsigned int SIZE_FORK_VERSION = 5;
 
 /** Nodes collect new transactions into a block, hash them into a hash tree,
  * and scan through nonce values to make the block's hash satisfy proof-of-work

--- a/src/test/block_size_tests.cpp
+++ b/src/test/block_size_tests.cpp
@@ -18,7 +18,7 @@
 // These must match parameters in chainparams.cpp
 static const uint64_t EARLIEST_FORK_TIME = 1452470400; // 11 Jan 2016
 static const uint32_t MAXSIZE_PREFORK = 1000*1000;
-static const uint32_t MAXSIZE_POSTFORK = 8*1000*1000;
+static const uint32_t MAXSIZE_POSTFORK = 2*1000*1000;
 static const uint64_t SIZE_DOUBLE_EPOCH = 60*60*24*365*2; // two years
 
 BOOST_FIXTURE_TEST_SUITE(block_size_tests, TestingSetup)


### PR DESCRIPTION
Makes 2 changes to the BIP101 implementation:
 - Initial post-fork block size limit is 2MB
 - The limit doubles twice, at 2-year intervals

Earliest activation is not changed.  Grace period is not changed.

Block version is set to 5.

There is no BIP that corresponds exactly to this PR.  It is BIP101 with the above changes.

No testnet parameters are changed (testnet still supports 8MB and 10 doublings).
