### PR TITLE
Re-enable known-inventory filter in merkleblock

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4429,9 +4429,11 @@ void static ProcessGetData(CNode* pfrom)
                             // they must either disconnect and retry or request the full block.
                             // Thus, the protocol spec specified allows for us to provide duplicate txn here,
                             // however we MUST always provide at least what the remote peer needs
+                            LOCK(pfrom->cs_inventory);
                             typedef std::pair<unsigned int, uint256> PairType;
                             BOOST_FOREACH(PairType& pair, merkleBlock.vMatchedTxn)
-                                pfrom->PushMessage("tx", block.vtx[pair.first]);
+                                if (!pfrom->filterInventoryKnown.contains(pair.second))
+                                    pfrom->PushMessage("tx", block.vtx[pair.first]);
                         }
                         // else
                             // no response


### PR DESCRIPTION
This is required to serve thin blocks.

We accept the same 1e-6 false-positive rate that is already accepted in the other places the known-inventory filter is used (eg RelayTransaction).

The filter was disabled in core version 0.12 by https://github.com/bitcoin/bitcoin/commit/ec73ef37eccfeda76de55c4ff93ea54d4e69e1ec.