### PR TITLE
Display coinjoins properly in QT

### DIFF
--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -142,13 +142,6 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
             strHTML += "(" + tr("not accepted") + ")";
         strHTML += "<br>";
     }
-    else if (nNet > 0)
-    {
-        //
-        // Credit
-        //
-        strHTML += "<b>" + tr("Credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, nNet) + "<br>";
-    }
     else
     {
         isminetype fAllFromMe = ISMINE_SPENDABLE;

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -42,7 +42,81 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
     uint256 hash = wtx.GetHash();
     std::map<std::string, std::string> mapValue = wtx.mapValue;
 
-    if (nNet > 0 || wtx.IsCoinBase())
+
+    bool involvesWatchAddress = false;
+    isminetype fAllFromMe = ISMINE_SPENDABLE;
+    BOOST_FOREACH(const CTxIn& txin, wtx.vin)
+    {
+        isminetype mine = wallet->IsMine(txin);
+        if(mine == ISMINE_WATCH_ONLY) involvesWatchAddress = true;
+        if(fAllFromMe > mine) fAllFromMe = mine;
+    }
+
+    isminetype fAllToMe = ISMINE_SPENDABLE;
+    BOOST_FOREACH(const CTxOut& txout, wtx.vout)
+    {
+        isminetype mine = wallet->IsMine(txout);
+        if(mine == ISMINE_WATCH_ONLY) involvesWatchAddress = true;
+        if(fAllToMe > mine) fAllToMe = mine;
+    }
+
+    if (fAllFromMe && fAllToMe)
+    {
+        // Payment to self
+        CAmount nChange = wtx.GetChange();
+
+        parts.append(TransactionRecord(hash, nTime, TransactionRecord::SendToSelf, "",
+                        -(nDebit - nChange), nCredit - nChange));
+        parts.last().involvesWatchAddress = involvesWatchAddress;   // maybe pass to TransactionRecord as constructor argument
+    }
+    else if (fAllFromMe)
+    {
+        //
+        // Debit
+        //
+        CAmount nTxFee = nDebit - wtx.GetValueOut();
+
+        for (unsigned int nOut = 0; nOut < wtx.vout.size(); nOut++)
+        {
+            const CTxOut& txout = wtx.vout[nOut];
+            TransactionRecord sub(hash, nTime);
+            sub.idx = parts.size();
+            sub.involvesWatchAddress = involvesWatchAddress;
+
+            if(wallet->IsMine(txout))
+            {
+                // Ignore parts sent to self, as this is usually the change
+                // from a transaction sent back to our own address.
+                continue;
+            }
+
+            CTxDestination address;
+            if (ExtractDestination(txout.scriptPubKey, address))
+            {
+                // Sent to Bitcoin Address
+                sub.type = TransactionRecord::SendToAddress;
+                sub.address = CBitcoinAddress(address).ToString();
+            }
+            else
+            {
+                // Sent to IP, or other non-address transaction like OP_EVAL
+                sub.type = TransactionRecord::SendToOther;
+                sub.address = mapValue["to"];
+            }
+
+            CAmount nValue = txout.nValue;
+            /* Add fee to first output */
+            if (nTxFee > 0)
+            {
+                nValue += nTxFee;
+                nTxFee = 0;
+            }
+            sub.debit = -nValue;
+
+            parts.append(sub);
+        }
+    }
+    else if (fAllToMe)
     {
         //
         // Credit
@@ -81,87 +155,11 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
     }
     else
     {
-        bool involvesWatchAddress = false;
-        isminetype fAllFromMe = ISMINE_SPENDABLE;
-        BOOST_FOREACH(const CTxIn& txin, wtx.vin)
-        {
-            isminetype mine = wallet->IsMine(txin);
-            if(mine == ISMINE_WATCH_ONLY) involvesWatchAddress = true;
-            if(fAllFromMe > mine) fAllFromMe = mine;
-        }
-
-        isminetype fAllToMe = ISMINE_SPENDABLE;
-        BOOST_FOREACH(const CTxOut& txout, wtx.vout)
-        {
-            isminetype mine = wallet->IsMine(txout);
-            if(mine == ISMINE_WATCH_ONLY) involvesWatchAddress = true;
-            if(fAllToMe > mine) fAllToMe = mine;
-        }
-
-        if (fAllFromMe && fAllToMe)
-        {
-            // Payment to self
-            CAmount nChange = wtx.GetChange();
-
-            parts.append(TransactionRecord(hash, nTime, TransactionRecord::SendToSelf, "",
-                            -(nDebit - nChange), nCredit - nChange));
-            parts.last().involvesWatchAddress = involvesWatchAddress;   // maybe pass to TransactionRecord as constructor argument
-        }
-        else if (fAllFromMe)
-        {
-            //
-            // Debit
-            //
-            CAmount nTxFee = nDebit - wtx.GetValueOut();
-
-            for (unsigned int nOut = 0; nOut < wtx.vout.size(); nOut++)
-            {
-                const CTxOut& txout = wtx.vout[nOut];
-                TransactionRecord sub(hash, nTime);
-                sub.idx = parts.size();
-                sub.involvesWatchAddress = involvesWatchAddress;
-
-                if(wallet->IsMine(txout))
-                {
-                    // Ignore parts sent to self, as this is usually the change
-                    // from a transaction sent back to our own address.
-                    continue;
-                }
-
-                CTxDestination address;
-                if (ExtractDestination(txout.scriptPubKey, address))
-                {
-                    // Sent to Bitcoin Address
-                    sub.type = TransactionRecord::SendToAddress;
-                    sub.address = CBitcoinAddress(address).ToString();
-                }
-                else
-                {
-                    // Sent to IP, or other non-address transaction like OP_EVAL
-                    sub.type = TransactionRecord::SendToOther;
-                    sub.address = mapValue["to"];
-                }
-
-                CAmount nValue = txout.nValue;
-                /* Add fee to first output */
-                if (nTxFee > 0)
-                {
-                    nValue += nTxFee;
-                    nTxFee = 0;
-                }
-                sub.debit = -nValue;
-
-                parts.append(sub);
-            }
-        }
-        else
-        {
-            //
-            // Mixed debit transaction, can't break down payees
-            //
-            parts.append(TransactionRecord(hash, nTime, TransactionRecord::Other, "", nNet, 0));
-            parts.last().involvesWatchAddress = involvesWatchAddress;
-        }
+        //
+        // Mixed debit transaction, coinjoins, can't break down payees
+        //
+        parts.append(TransactionRecord(hash, nTime, TransactionRecord::Other, "", nNet, 0));
+        parts.last().involvesWatchAddress = involvesWatchAddress;
     }
 
     return parts;


### PR DESCRIPTION
Big diff from modifying the main conditional, but actually only a few lines changed. I just got rid of the first "if (nNet > 0 || wtx.IsCoinBase())" statement, fixed the indentation, and moved the "// Credit" section down into an "else if (fAllToMe)" block. Then added a comment where the coinjoins are caught. Thats all.

This fixes the transaction list so that it shows 1 row per transaction instead of 2 for coinjoins, and for the amount shows the transaction Net value. More importantly, this fixes the details view for coinjoin transactions so that Debits and Credits are shown accurately, allowing one to discern what Debits and Credits were theirs in this transaction.