### PR TITLE
Support waiting for regular pong and thin block pong at the same time.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5292,26 +5292,16 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
             vRecv >> nonce;
 
             // Only process pong message if there is an outstanding ping (old ping without nonce should never pong)
-            if (pfrom->nPingNonceSent != 0) {
-                if (nonce == pfrom->nPingNonceSent) {
-                    // Matching pong received, this ping is no longer outstanding
-                    bPingFinished = true;
-                    int64_t pingUsecTime = pingUsecEnd - pfrom->nPingUsecStart;
-                    if (pingUsecTime > 0) {
-                        // Successful ping time measurement, replace previous
-                        pfrom->nPingUsecTime = pingUsecTime;
-                    } else {
-                        // This should never happen
-                        sProblem = "Timing mishap";
-                    }
+            if (pfrom->nPingNonceSent && nonce == pfrom->nPingNonceSent) {
+                // Matching pong received, this ping is no longer outstanding
+                bPingFinished = true;
+                int64_t pingUsecTime = pingUsecEnd - pfrom->nPingUsecStart;
+                if (pingUsecTime > 0) {
+                    // Successful ping time measurement, replace previous
+                    pfrom->nPingUsecTime = pingUsecTime;
                 } else {
-                    // Nonce mismatches are normal when pings are overlapping
-                    sProblem = "Nonce mismatch";
-                    if (nonce == 0) {
-                        // This is most likely a bug in another implementation somewhere; cancel this ping
-                        bPingFinished = true;
-                        sProblem = "Nonce zero";
-                    }
+                    // This should never happen
+                    sProblem = "Timing mishap";
                 }
             } else if (nonce && pfrom->thinBlockNonce == nonce) {
                 LOCK(cs_main);
@@ -5320,7 +5310,17 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
                 MarkBlockAsInFlight m;
                 ThinBlockConcluder concludeDownload(m);
                 concludeDownload(pfrom, nonce, thinblock);
-            } else {
+            }
+            else if (pfrom->nPingNonceSent) {
+                // Nonce mismatches are normal when pings are overlapping
+                sProblem = "Nonce mismatch";
+                if (nonce == 0) {
+                    // This is most likely a bug in another implementation somewhere; cancel this ping
+                    bPingFinished = true;
+                    sProblem = "Nonce zero";
+                }
+            }
+            else {
                 sProblem = "Unsolicited pong without ping";
             }
         } else {


### PR DESCRIPTION
Fixes a bug where a thin block pong is interpreted as a regular pong.
This caused the block download to time out.