### PR TITLE
Add pruning to options dialog

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -118,6 +118,82 @@
         </layout>
        </item>
        <item>
+        <widget class="QGroupBox" name="groupBox_3">
+         <property name="title">
+          <string>Disk usage</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <item>
+           <widget class="QCheckBox" name="pruneEnableChk">
+            <property name="text">
+             <string>Limit blockchain size (prune)</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+             <widget class="QLabel" name="label">
+              <property name="text">
+               <string>Use at most</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QDoubleSpinBox" name="pruneSize">
+              <property name="suffix">
+               <string> GB</string>
+              </property>
+              <property name="minimum">
+               <double>0.550000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>9999.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>200.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QLabel" name="diskRequiredLbl">
+            <property name="text">
+             <string>Note that %1GB additional disk space is required for chain state.</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>If you enable limiting and change this limit at any point, you will have to re-index and may have to re-download the full blockchain.</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_Main">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -53,4 +53,9 @@ static const int MAX_URI_LENGTH = 255;
 #define QAPP_APP_NAME_DEFAULT "Bitcoin-Qt"
 #define QAPP_APP_NAME_TESTNET "Bitcoin-Qt-testnet"
 
+/* Minimum free space (in GB) needed for data directory when pruned; Does not include prune target */
+static const uint64_t CHAIN_STATE_SIZE = 2;
+/* Minimum free space (in GB) needed for data directory */
+static const uint64_t BLOCK_CHAIN_SIZE = 80;
+
 #endif // BITCOIN_QT_GUICONSTANTS_H

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -6,6 +6,7 @@
 #include "ui_intro.h"
 
 #include "guiutil.h"
+#include "guiconstants.h"
 #include "scicon.h"
 
 #include "util.h"
@@ -19,10 +20,6 @@
 #include <cmath>
 
 static const uint64_t GB_BYTES = 1000000000LL;
-/* Minimum free space (in GB) needed for data directory */
-static const uint64_t BLOCK_CHAIN_SIZE = 80;
-/* Minimum free space (in GB) needed for data directory when pruned; Does not include prune target */
-static const uint64_t CHAIN_STATE_SIZE = 2;
 /* Total required space (in GB) depending on user choice (prune, not prune) */
 static uint64_t requiredSpace;
 

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -16,9 +16,15 @@
 #include <QSettings>
 #include <QMessageBox>
 
-/* Minimum free space (in bytes) needed for data directory */
+#include <cmath>
+
 static const uint64_t GB_BYTES = 1000000000LL;
-static const uint64_t BLOCK_CHAIN_SIZE = 20LL * GB_BYTES;
+/* Minimum free space (in GB) needed for data directory */
+static const uint64_t BLOCK_CHAIN_SIZE = 80;
+/* Minimum free space (in GB) needed for data directory when pruned; Does not include prune target */
+static const uint64_t CHAIN_STATE_SIZE = 2;
+/* Total required space (in GB) depending on user choice (prune, not prune) */
+static uint64_t requiredSpace;
 
 /* Check free space asynchronously to prevent hanging the UI thread.
 
@@ -113,7 +119,11 @@ Intro::Intro(QWidget *parent) :
     signalled(false)
 {
     ui->setupUi(this);
-    ui->sizeWarningLabel->setText(ui->sizeWarningLabel->text().arg(BLOCK_CHAIN_SIZE/GB_BYTES));
+    uint64_t pruneTarget = std::max<int64_t>(0, GetArg("-prune", 0));
+    requiredSpace = BLOCK_CHAIN_SIZE;
+    if (pruneTarget)
+        requiredSpace = CHAIN_STATE_SIZE + std::ceil(pruneTarget * 1024 * 1024.0 / GB_BYTES);
+    ui->sizeWarningLabel->setText(ui->sizeWarningLabel->text().arg(requiredSpace));
     startThread();
 }
 
@@ -217,9 +227,9 @@ void Intro::setStatus(int status, const QString &message, quint64 bytesAvailable
         ui->freeSpace->setText("");
     } else {
         QString freeString = tr("%n GB of free space available", "", bytesAvailable/GB_BYTES);
-        if(bytesAvailable < BLOCK_CHAIN_SIZE)
+        if(bytesAvailable < requiredSpace * GB_BYTES)
         {
-            freeString += " " + tr("(of %n GB needed)", "", BLOCK_CHAIN_SIZE/GB_BYTES);
+            freeString += " " + tr("(of %n GB needed)", "", requiredSpace);
             ui->freeSpace->setStyleSheet("QLabel { color: #800000 }");
         } else {
             ui->freeSpace->setStyleSheet("");

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -9,12 +9,13 @@
 
 #include "optionsdialog.h"
 #include "ui_optionsdialog.h"
+#include "guiconstants.h" // for CHAIN_STATE_SIZE
 
 #include "bitcoinunits.h"
 #include "guiutil.h"
 #include "optionsmodel.h"
 
-#include "main.h" // for MAX_SCRIPTCHECK_THREADS
+#include "main.h" // for MAX_SCRIPTCHECK_THREADS, MIN_DISK_SPACE_FOR_BLOCK_FILES
 #include "netbase.h"
 #include "txdb.h" // for -dbcache defaults
 
@@ -46,6 +47,9 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
     ui->databaseCache->setMaximum(nMaxDbCache);
     ui->threadsScriptVerif->setMinimum(-(int)boost::thread::hardware_concurrency());
     ui->threadsScriptVerif->setMaximum(MAX_SCRIPTCHECK_THREADS);
+    ui->diskRequiredLbl->setText(
+            ui->diskRequiredLbl->text().arg(CHAIN_STATE_SIZE));
+    ui->pruneSize->setMinimum(double(MIN_DISK_SPACE_FOR_BLOCK_FILES) / 1024 / 1024 / 1024);
 
     /* Network elements init */
 #ifndef USE_UPNP
@@ -58,6 +62,7 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
 
     connect(ui->connectSocks, SIGNAL(toggled(bool)), ui->proxyIp, SLOT(setEnabled(bool)));
     connect(ui->connectSocks, SIGNAL(toggled(bool)), ui->proxyPort, SLOT(setEnabled(bool)));
+    connect(ui->pruneEnableChk, SIGNAL(toggled(bool)), ui->pruneSize, SLOT(setEnabled(bool)));
 
     ui->proxyIp->installEventFilter(this);
 
@@ -162,6 +167,8 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->bitcoinAtStartup, OptionsModel::StartAtStartup);
     mapper->addMapping(ui->threadsScriptVerif, OptionsModel::ThreadsScriptVerif);
     mapper->addMapping(ui->databaseCache, OptionsModel::DatabaseCache);
+    mapper->addMapping(ui->pruneEnableChk, OptionsModel::Prune);
+    mapper->addMapping(ui->pruneSize, OptionsModel::PruneSize);
 
     /* Wallet */
     mapper->addMapping(ui->spendZeroConfChange, OptionsModel::SpendZeroConfChange);

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -48,6 +48,8 @@ public:
         ReceiveAve,             // int
         SendBurst,              // int
         SendAve,                // int
+        Prune,                  // bool
+        PruneSize,              // int
         OptionIDRowCount,
     };
 


### PR DESCRIPTION
I believe it to be a common misconception that running a full node requires > 60 GB of dedicated space. I think the pruning feature should be more available.

This PR adds pruning to options dialog as seen on this screenshot:
![screen shot 2016-02-08 at 10 52 57](https://cloud.githubusercontent.com/assets/92707/12882629/421196a8-ce53-11e5-985c-5abe6b55735e.png)
