### PR TITLE
Fix compile-platform-dependent mempool bug

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -263,7 +263,7 @@ void CTxMemPool::UpdateForRemoveFromMempool(const setEntries &entriesToRemove, b
             setEntries setDescendants;
             CalculateDescendants(removeIt, setDescendants);
             setDescendants.erase(removeIt); // don't update state for self
-            int64_t modifySize = -removeIt->GetTxSize();
+            int64_t modifySize = -((int64_t)removeIt->GetTxSize());
             CAmount modifyFee = -removeIt->GetFee();
             BOOST_FOREACH(txiter dit, setDescendants) {
                 mapTx.modify(dit, update_ancestor_state(modifySize, modifyFee, -1));


### PR DESCRIPTION
Negating a size_t and assigning to int64_t does not work with < 64-bit compile platform.