### PR TITLE
#128 Updated gitian-debian build script and README.md to version 0.11E

### DIFF
--- a/contrib/gitian-debian/README.md
+++ b/contrib/gitian-debian/README.md
@@ -4,7 +4,7 @@
 
   ```
   cd bitcoinxt/contrib/gitian-debian
-  wget https://github.com/bitcoinxt/bitcoinxt/releases/download/v0.11A/bitcoin-0.11.0-linux64.tar.gz
+  wget https://github.com/bitcoinxt/bitcoinxt/releases/download/v0.11E/bitcoin-xt-0.11.0-E-linux64.tar.gz
   ```
 
 2. Execute debian installer build script:
@@ -17,7 +17,7 @@
 1. Install newly created debian package on test debian system:
 
   ```
-  sudo gdebi bitcoinxt-0.11A.deb
+  sudo gdebi bitcoinxt-0.11E.deb
   ```
 
 2. Verify bitcoinxt daemon installed and started:

--- a/contrib/gitian-debian/build.sh
+++ b/contrib/gitian-debian/build.sh
@@ -7,8 +7,8 @@
 #  - Wrap in a script that sends crash reports/core dumps to some issue tracker.
 #  - etc ...
 
-ver=0.11.0-B
-realver=0.11B
+ver=0.11.0-E
+realver=0.11E
 
 set +e
 


### PR DESCRIPTION
@dgenr8 I tested updated gitian-debian build instructions and upgrade installation on Debian 8 VM.  New 0.11E package installed and started daemon with no errors.