### PR TITLE
SPV: Push unconfirmed ancestors to peer. SPV test.

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -16,6 +16,7 @@ fi
 #Run the tests
 
 testScripts=(
+    'spv.py'
     'wallet.py'
     'listtransactions.py'
     'mempool_resurrect_test.py'

--- a/qa/rpc-tests/spv.py
+++ b/qa/rpc-tests/spv.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python2
+#
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+
+import binascii
+
+from test_framework.mininode import *
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from numpy.ma.testutils import assert_equal
+
+'''
+spv.py
+
+Act as an SPV client to test SPV server functionality
+This is not yet a complete suite.  It was added to test inclusion of ancestors
+in connection filters.
+'''
+
+class BaseNode(NodeConnCB):
+    def __init__(self):
+        NodeConnCB.__init__(self)
+        self.connection = None
+        self.ping_counter = 1
+        self.last_pong = msg_pong(0)
+        self.sleep_time = 0.1
+
+    def add_connection(self, conn):
+        self.connection = conn
+
+    # Wrapper for the NodeConn's send_message function
+    def send_message(self, message):
+        self.connection.send_message(message)
+
+    def on_pong(self, conn, message):
+        self.last_pong = message
+
+    # Syncing helpers
+    def sync(self, test_function, timeout=30):
+        while timeout > 0:
+            with mininode_lock:
+                if test_function():
+                    return
+            time.sleep(self.sleep_time)
+            timeout -= self.sleep_time
+        raise AssertionError("Sync failed to complete")
+
+    def sync_with_ping(self):
+        self.send_message(msg_ping(nonce=self.ping_counter))
+        test_function = lambda: self.last_pong.nonce == self.ping_counter
+        self.sync(test_function)
+        self.ping_counter += 1
+        return
+
+
+class TestNode(BaseNode):
+    def __init__(self):
+        BaseNode.__init__(self)
+        self.txids = []
+        self.txidstream_isopen = False
+        self.txidstream_pos = 0
+
+    def on_inv(self, conn, message):
+        if self.txidstream_isopen:
+            for i in message.inv:
+                if i.type == 1:
+                    self.txids.append(('%x' % i.hash).zfill(64))
+
+    def open_txidstream(self):
+        self.txidstream_isopen = True
+
+    def read_txidstream(self):
+        if not self.txidstream_isopen:
+            raise AssertionError("TXID stream not opened for reading")
+        self.sync(lambda: len(self.txids) >= self.txidstream_pos + 1)
+        self.txidstream_pos += 1
+        return self.txids[self.txidstream_pos - 1]
+
+
+class SPVTest(BitcoinTestFramework):
+
+    def __init__(self):
+        self.num_nodes = 2
+
+    def setup_chain(self):
+        print "Initializing test directory "+self.options.tmpdir
+        initialize_chain_clean(self.options.tmpdir, self.num_nodes)
+
+    def setup_network(self):
+        self.nodes = []
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-relaypriority=0 -debug=mempool"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-relaypriority=0 -debug=mempool"]))
+        connect_nodes(self.nodes[0], 1)
+
+    def run_test(self):
+        # Setup the p2p connections
+        spv_node = TestNode()
+        connection = NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], spv_node, services=0)
+        spv_node.add_connection(connection)
+
+        # Add a bunch of extra connections to our nodes[0] peer, so spv_node is
+        # unlikely to get inv's due to trickling rather than filter matches
+        other_nodes = []
+        for i in range(0,25):
+            other_nodes.append(BaseNode())
+            other_connection = NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], other_nodes[i])
+            other_nodes[i].add_connection(other_connection)
+
+        NetworkThread().start() # Start up network handling in another thread
+        spv_node.wait_for_verack()
+
+        # Generate some coins
+        self.nodes[1].generate(110)
+        sync_blocks(self.nodes[0:2])
+
+        # Start collecting txid inv's
+        spv_node.open_txidstream()
+
+        # Generate an address and extract pubkeyhash
+        address0 = self.nodes[0].getnewaddress()
+        dummyoutputs = {}
+        dummyoutputs[address0] = 1
+        dummytxhex = self.nodes[0].createrawtransaction([], dummyoutputs)
+        dummytx = self.nodes[0].decoderawtransaction(dummytxhex)
+        dummyasm = dummytx["vout"][0]["scriptPubKey"]["asm"]
+        pkhstart = dummyasm.index("OP_HASH160") + len("OP_HASH160") + 1
+        pkhhex = dummyasm[pkhstart:pkhstart+20*2]
+        pubkeyhash0 = bytearray.fromhex(pkhhex)
+
+        # Load bloom filter to peer
+        spvFilter = CBloomFilter(nFlags=CBloomFilter.ANCESTOR_UPDATE_BIT)
+        spvFilter.insert(pubkeyhash0)
+        spv_node.send_message(msg_filterload(spvFilter))
+
+        # Test 1. Bloom filter positive match
+        tx1_id = self.nodes[1].sendtoaddress(address0, 1)
+        got_txid = spv_node.read_txidstream()
+        assert_equal(got_txid, tx1_id) #tx1 pays us
+
+        # Test 2. Ancestor relay and mempool response
+
+        # Send a control tx that neither pays us, nor is an ancestor of a tx that pays us
+        txextra_id = self.nodes[1].sendtoaddress(self.nodes[1].getnewaddress(), 15)
+
+        # Build an ancestor chain where the grandchild pays us
+        tx2grandparent_id = self.nodes[1].sendtoaddress(self.nodes[1].getnewaddress(), 25)
+
+        tx2parent_input = {}
+        tx2parent_input["txid"] = tx2grandparent_id
+        tx2parent_input["vout"] = 0
+        tx2parent_output = {}
+        tx2parent_output[self.nodes[1].getnewaddress()] = 12.5
+        tx2parent_output[self.nodes[1].getnewaddress()] = 12.48
+        tx2parent = self.nodes[1].createrawtransaction([tx2parent_input], tx2parent_output)
+        tx2parentsignresult = self.nodes[1].signrawtransaction(tx2parent)
+        assert_equal(tx2parentsignresult["complete"], True)
+        tx2parent_id = self.nodes[1].sendrawtransaction(tx2parentsignresult["hex"])
+
+        # Match tx2 by its consumption of a specific UTXO
+        spvFilter.insert(COutPoint(int(tx2parent_id,16),0))
+        spv_node.send_message(msg_filterload(spvFilter))
+
+        tx2_input = {}
+        tx2_input["txid"] = tx2parent_id
+        tx2_input["vout"] = 0
+        tx2_output = {}
+        tx2_output[self.nodes[0].getnewaddress()] = 2
+        tx2_output[self.nodes[1].getnewaddress()] = 10.48
+        tx2 = self.nodes[1].createrawtransaction([tx2_input], tx2_output)
+        tx2signresult = self.nodes[1].signrawtransaction(tx2)
+        assert_equal(tx2signresult["complete"], True)
+        tx2_id = self.nodes[1].sendrawtransaction(tx2signresult["hex"])
+
+        # Check that tx2 as well as all its ancestors are pushed to our SPV node
+        relayed = [spv_node.read_txidstream(), spv_node.read_txidstream(), spv_node.read_txidstream()]
+        expectedRelay = [tx2grandparent_id, tx2parent_id, tx2_id]
+        assert_equal(sorted(relayed), sorted(expectedRelay))
+
+        sync_mempools(self.nodes[0:2])
+        spv_node.send_message(msg_mempool())
+
+        # Check the complete filtered mempool returned by our peer
+        pool = [spv_node.read_txidstream(), spv_node.read_txidstream(), spv_node.read_txidstream(), spv_node.read_txidstream()]
+        expectedPool = [tx1_id, tx2grandparent_id, tx2parent_id, tx2_id]
+        assert_equal(sorted(pool), sorted(expectedPool))
+
+if __name__ == '__main__':
+    SPVTest().main()

--- a/qa/rpc-tests/test_framework/murmurhash.py
+++ b/qa/rpc-tests/test_framework/murmurhash.py
@@ -1,0 +1,64 @@
+# murmurhash.py
+#
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# This python code was copied from
+# https://raw.githubusercontent.com/jgarzik/python-bitcoinlib/417afe9e5868430e620301131f098645c081a90c/bitcoin/hash.py
+
+import struct
+
+def ROTL32(x, r):
+    assert x <= 0xFFFFFFFF
+    return ((x << r) & 0xFFFFFFFF) | (x >> (32 - r))
+
+def MurmurHash3(nHashSeed, vDataToHash):
+
+    assert nHashSeed <= 0xFFFFFFFF
+
+    h1 = nHashSeed
+    c1 = 0xcc9e2d51
+    c2 = 0x1b873593
+
+    # body
+    i = 0
+    while i < len(vDataToHash) - len(vDataToHash) % 4 \
+          and len(vDataToHash) - i >= 4:
+
+        k1 = struct.unpack("<L", vDataToHash[i:i+4])[0]
+
+        k1 = (k1 * c1) & 0xFFFFFFFF
+        k1 = ROTL32(k1, 15)
+        k1 = (k1 * c2) & 0xFFFFFFFF
+
+        h1 ^= k1
+        h1 = ROTL32(h1, 13)
+        h1 = (((h1*5) & 0xFFFFFFFF) + 0xe6546b64) & 0xFFFFFFFF
+
+        i += 4
+
+    # tail
+    k1 = 0
+    j = (len(vDataToHash) // 4) * 4
+    if len(vDataToHash) & 3 >= 3:
+        k1 ^= struct.unpack('<B', vDataToHash[j+2])[0] << 16
+    if len(vDataToHash) & 3 >= 2:
+        k1 ^= struct.unpack('<B', vDataToHash[j+1])[0] << 8
+    if len(vDataToHash) & 3 >= 1:
+        k1 ^= struct.unpack('<B', vDataToHash[j])[0]
+
+    k1 &= 0xFFFFFFFF
+    k1 = (k1 * c1) & 0xFFFFFFFF
+    k1 = ROTL32(k1, 15)
+    k1 = (k1 * c2) & 0xFFFFFFFF
+    h1 ^= k1
+
+    # finalization
+    h1 ^= len(vDataToHash) & 0xFFFFFFFF
+    h1 ^= (h1 & 0xFFFFFFFF) >> 16
+    h1 *= 0x85ebca6b
+    h1 ^= (h1 & 0xFFFFFFFF) >> 13
+    h1 *= 0xc2b2ae35
+    h1 ^= (h1 & 0xFFFFFFFF) >> 16
+
+    return h1 & 0xFFFFFFFF

--- a/src/bloom.h
+++ b/src/bloom.h
@@ -19,7 +19,6 @@ static const unsigned int MAX_HASH_FUNCS = 50;
 
 /**
  * First two bits of nFlags control how much IsRelevantAndUpdate actually updates
- * The remaining bits are reserved
  */
 enum bloomflags
 {
@@ -29,6 +28,12 @@ enum bloomflags
     BLOOM_UPDATE_P2PUBKEY_ONLY = 2,
     BLOOM_UPDATE_MASK = 3,
 };
+
+/* Third bit of nFlags indicates filter wants to be updated with mempool ancestors for its entries.
+ * This also requires that we set NODE_BLOOM locally, regardless of peer version
+ * The remaining bits are reserved
+ */
+static const unsigned char BLOOM_ANCESTOR_UPDATE_BIT = 4;
 
 /**
  * BloomFilter is a probabilistic filter which SPV clients provide
@@ -97,6 +102,9 @@ public:
 
     //! Also adds any outputs which match the filter to the filter (to match their spending txes)
     bool IsRelevantAndUpdate(const CTransaction& tx);
+
+    //! Wants ancestors of matching transactions to be inserted
+    bool WantsAncestors() {return nFlags & BLOOM_ANCESTOR_UPDATE_BIT;}
 
     //! Checks for empty and full filters to avoid wasting cpu
     void UpdateEmptyFull();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1364,8 +1364,11 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
                 doubleSpendFilter.clear();
             doubleSpendFilter.insert(relayForOutpoint);
 
-            if (!Opt().IsStealthMode())
-                RelayTransaction(tx);
+            if (!Opt().IsStealthMode()) {
+                std::vector<uint256> vAncestors;
+                vAncestors.push_back(hash); // Alert only for the tx itself
+                RelayTransaction(tx, vAncestors);
+            }
         }
         else
         {
@@ -5050,7 +5053,9 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
             if (!AlreadyHave(inv) && AcceptToMemoryPool(mempool, state, tx, true, &fMissingInputs))
             {
                 mempool.check(pcoinsTip);
-                RelayTransaction(tx);
+                std::vector<uint256> vAncestors;
+                mempool.queryAncestors(tx.GetHash(), vAncestors);
+                RelayTransaction(tx, vAncestors);
                 vWorkQueue.push_back(inv.hash);
 
                 LogPrint("mempool", "AcceptToMemoryPool: peer=%d %s: accepted %s (poolsz %u)\n",
@@ -5084,7 +5089,9 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
                         if (AcceptToMemoryPool(mempool, stateDummy, orphanTx, true, &fMissingInputs2))
                         {
                             LogPrint("mempool", "   accepted orphan tx %s\n", orphanHash.ToString());
-                            RelayTransaction(orphanTx);
+                            std::vector<uint256> vAncestors;
+                            mempool.queryAncestors(orphanTx.GetHash(), vAncestors);
+                            RelayTransaction(orphanTx, vAncestors);
                             vWorkQueue.push_back(orphanHash);
                             vEraseQueue.push_back(orphanHash);
                         }
@@ -5132,7 +5139,9 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
                     // FIXME: This includes invalid transactions, which means a
                     // whitelisted peer could get us banned! We may want to change
                     // that.
-                    RelayTransaction(tx);
+                    std::vector<uint256> vAncestors;
+                    mempool.queryAncestors(tx.GetHash(), vAncestors);
+                    RelayTransaction(tx, vAncestors);
                 }
             }
             int nDoS = 0;
@@ -5253,18 +5262,29 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
 
         std::vector<uint256> vtxid;
         mempool.queryHashes(vtxid);
-        vector<CInv> vInv;
+        std::set<CInv> vInv;
         BOOST_FOREACH(uint256& hash, vtxid) {
-            CInv inv(MSG_TX, hash);
             CTransaction tx;
             bool fInMemPool = mempool.lookup(hash, tx);
             if (!fInMemPool) continue; // another thread removed since queryHashes, maybe...
-            if ((pfrom->pfilter && pfrom->pfilter->IsRelevantAndUpdate(tx)) ||
-               (!pfrom->pfilter))
-                vInv.push_back(inv);
-            if (vInv.size() == MAX_INV_SZ) {
-                pfrom->PushMessage("inv", vInv);
-                vInv.clear();
+            if (pfrom->pfilter && !pfrom->pfilter->IsRelevantAndUpdate(tx))
+                continue;
+
+            // No filter, or filter matched
+            std::vector<uint256> vAncestors;
+            if (pfrom->pfilter && pfrom->pfilter->WantsAncestors())
+                mempool.queryAncestors(hash, vAncestors);
+            else
+            	vAncestors.push_back(hash);
+            BOOST_FOREACH(uint256& hashFound, vAncestors) {
+                if (hashFound != hash && pfrom->pfilter && pfrom->pfilter->WantsAncestors())
+                    pfrom->pfilter->insert(hashFound);
+                if (hashFound == hash || (pfrom->pfilter && pfrom->pfilter->WantsAncestors()))
+                    vInv.insert(CInv(MSG_TX, hashFound));
+                if (vInv.size() == MAX_INV_SZ) {
+                    pfrom->PushMessage("inv", vInv);
+                    vInv.clear();
+                }
             }
         }
         if (vInv.size() > 0)

--- a/src/net.h
+++ b/src/net.h
@@ -650,8 +650,8 @@ public:
 
 
 class CTransaction;
-void RelayTransaction(const CTransaction& tx);
-void RelayTransaction(const CTransaction& tx, const CDataStream& ss);
+void RelayTransaction(const CTransaction& tx, std::vector<uint256>& vAncestors);
+void RelayTransaction(const CTransaction& tx, const CDataStream& ss, std::vector<uint256>& vAncestors);
 
 bool FindTransactionInRelayMap(uint256 hash, CTransaction &out);
 

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -805,7 +805,9 @@ Value sendrawtransaction(const Array& params, bool fHelp)
     } else if (fHaveChain) {
         throw JSONRPCError(RPC_TRANSACTION_ALREADY_IN_CHAIN, "transaction already in block chain");
     }
-    RelayTransaction(tx);
+    std::vector<uint256> vAncestors;
+    mempool.queryAncestors(tx.GetHash(), vAncestors);
+    RelayTransaction(tx, vAncestors);
 
     return hashTx.GetHex();
 }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -212,6 +212,25 @@ bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, setEntr
     return true;
 }
 
+void CTxMemPool::queryAncestors(const uint256 txHash, std::vector<uint256>& vAncestors) {
+    CTxMemPool::setEntries setAncestors;
+	const uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
+	std::string dummy;
+
+    LOCK(cs);
+    vAncestors.push_back(txHash);
+    if (!(nLocalServices & NODE_BLOOM))
+        return;
+    indexed_transaction_set::const_iterator it = mapTx.find(txHash);
+    if (it == mapTx.end())
+        return;
+    CalculateMemPoolAncestors(*it, setAncestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy, false);
+    BOOST_FOREACH(txiter ancestorIt, setAncestors)
+        vAncestors.push_back(ancestorIt->GetTx().GetHash());
+    return;
+}
+
+
 void CTxMemPool::UpdateAncestorsOf(bool add, txiter it, setEntries &setAncestors)
 {
     setEntries parentIters = GetMemPoolParents(it);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -471,6 +471,12 @@ public:
      */
     bool CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, setEntries &setAncestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string &errString, bool fSearchForParents = true);
 
+    /** Utility method to find ancestor hashes.
+     *  txHash = tx hash for which to find ancestors
+     *  vAncestors = returned ancestor tx hashes, including txHash.
+     */
+    void queryAncestors(const uint256 txHash, std::vector<uint256>& vAncestors);
+
     /** Remove transactions from the mempool until its dynamic size is <= sizelimit. */
     void TrimToSize(size_t sizelimit);
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1176,7 +1176,9 @@ bool CWalletTx::RelayWalletTransaction()
     {
         if (GetDepthInMainChain() == 0) {
             LogPrintf("Relaying wtx %s\n", GetHash().ToString());
-            RelayTransaction((CTransaction)*this);
+            std::vector<uint256> vAncestors;
+            mempool.queryAncestors(GetHash(), vAncestors);
+            RelayTransaction((CTransaction)*this, vAncestors);
             return true;
         }
     }


### PR DESCRIPTION
Lets an SPV peer better track the confirmation process of wallet transactions by knowing details about unconfirmed ancestors.

Connection bloom filter nFlags bit ``BLOOM_ANCESTOR_UPDATE_BIT = 4`` is newly defined to mean that the SPV peer wants its filter be automatically updated with the txids of unconfirmed ancestors of transactions that are already contained in the filter.

Filter update with unconfirmed ancestors occurs in the two places that filtered results for unconfirmed transactions are provided: transaction relay, and the "mempool" p2p response.  The results also include the ancestors added.

SPV "merkleblock" response is indirectly enhanced, because the filter will contain id's for transactions that were at some point seen as unconfirmed ancestors of a wallet transaction.  Double-spend relay alerts are provided when an ancestor is respent, but those relays necessarily exclude malleability clones (which could be produced by a 3rd party).

The included test ``spv.py`` relies on new bloom filter support added to ``mininode.py``.  Additional tests of SPV server functionality can be added in the future.
