### PR TITLE
remove -trustsystemclock and add -maxtimeadjustment with default of 0

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -22,6 +22,7 @@
 #include "rpcserver.h"
 #include "script/standard.h"
 #include "scheduler.h"
+#include "timedata.h"
 #include "txdb.h"
 #include "ui_interface.h"
 #include "util.h"
@@ -300,7 +301,6 @@ std::string HelpMessage(HelpMessageMode mode)
 #if !defined(WIN32)
     strUsage += HelpMessageOpt("-sysperms", _("Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)"));
 #endif
-    strUsage += HelpMessageOpt("-trustsystemclock", _("Trust, and depend solely on, the local system clock. Do not use peer time offset adjustments. (default: 1)"));
     strUsage += HelpMessageOpt("-txindex", strprintf(_("Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)"), 0));
 
     strUsage += HelpMessageGroup(_("Connection options:"));
@@ -320,6 +320,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-maxconnections=<n>", strprintf(_("Maintain at most <n> connections to peers (default: %u)"), 125));
     strUsage += HelpMessageOpt("-maxreceivebuffer=<n>", strprintf(_("Maximum per-connection receive buffer, <n>*1000 bytes (default: %u)"), 5000));
     strUsage += HelpMessageOpt("-maxsendbuffer=<n>", strprintf(_("Maximum per-connection send buffer, <n>*1000 bytes (default: %u)"), 1000));
+    strUsage += HelpMessageOpt("-maxtimeadjustment", strprintf(_("Maximum allowed median peer time offset adjustment. Local perspective of time may be influenced by peers forward or backward by this amount. (default: %u seconds)"), DEFAULT_MAX_TIME_ADJUSTMENT));
     strUsage += HelpMessageOpt("-onion=<ip:port>", strprintf(_("Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)"), "-proxy"));
     strUsage += HelpMessageOpt("-onlynet=<net>", _("Only connect to nodes in network <net> (ipv4, ipv6 or onion)"));
     strUsage += HelpMessageOpt("-permitbaremultisig", strprintf(_("Relay non-P2SH multisig (default: %u)"), 1));

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -32,11 +32,7 @@ int64_t GetTimeOffset()
 
 int64_t GetAdjustedTime()
 {
-    if (GetBoolArg("-trustsystemclock", true)) {
-        return GetTime();
-    } else {
-        return GetTime() + GetTimeOffset();
-    }
+    return GetTime() + GetTimeOffset();
 }
 
 static int64_t abs64(int64_t n)
@@ -79,7 +75,7 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
         int64_t nMedian = vTimeOffsets.median();
         std::vector<int64_t> vSorted = vTimeOffsets.sorted();
         // Only let other nodes change our time by so much
-        if (abs64(nMedian) < 70 * 60)
+        if (abs64(nMedian) <= std::max<int64_t>(0, GetArg("-maxtimeadjustment", DEFAULT_MAX_TIME_ADJUSTMENT)))
         {
             nTimeOffset = nMedian;
         }

--- a/src/timedata.h
+++ b/src/timedata.h
@@ -10,6 +10,8 @@
 #include <stdint.h>
 #include <vector>
 
+static const int64_t DEFAULT_MAX_TIME_ADJUSTMENT = 0;
+
 class CNetAddr;
 
 /** 


### PR DESCRIPTION
remove -trustsystemclock and add -maxtimeadjustment with default of 0 instead of the 4200 used upstream.

for reference:
https://github.com/bitcoinxt/bitcoinxt/pull/35

https://github.com/bitcoin/bitcoin/pull/7573
