### PR TITLE
Fix class/struct mismatches

### DIFF
--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -16,7 +16,8 @@ typedef int NodeId;
 class CBlockHeader;
 
 // We may, or may not have the full uint256 hash of transactions in block.
-struct ThinTx {
+class ThinTx {
+public:
     ThinTx(const uint256& h) :
         hash(h), cheapHash(h.GetCheapHash())  { }
 
@@ -44,7 +45,7 @@ struct ThinTx {
         return !(b == *this);
     }
 
-    private:
+private:
         uint256 hash;
         uint64_t cheapHash;
 };
@@ -62,7 +63,8 @@ struct StubData {
 };
 inline StubData::~StubData() { }
 
-struct TxFinder {
+class TxFinder {
+public:
     // returned tx is null if not found (and needs to be downloaded)
     virtual CTransaction operator()(const ThinTx& hash) const = 0;
     virtual ~TxFinder() = 0;

--- a/src/thinblockmanager.h
+++ b/src/thinblockmanager.h
@@ -20,7 +20,7 @@ struct StubData;
 class ThinBlockBuilder;
 class ThinBlockWorker;
 class CTransaction;
-struct ThinTx;
+class ThinTx;
 typedef int NodeId;
 
 // Call when a block is reassembled.

--- a/src/utilprocessmsg.h
+++ b/src/utilprocessmsg.h
@@ -9,8 +9,8 @@ class CBlockHeader;
 bool HaveBlockData(const uint256& hash);
 
 // Process received block header.
-struct BlockHeaderProcessor {
-
+class BlockHeaderProcessor {
+public:
     // returns false on error
     virtual bool operator()(const std::vector<CBlockHeader>& headers, bool peerSentMax) = 0;
 

--- a/src/xthin.h
+++ b/src/xthin.h
@@ -24,7 +24,7 @@ struct xthin_collision_error : public std::runtime_error {
 // based on a filter it sent us.
 //
 // Always includes coinbase.
-struct XThinBlock {
+class XThinBlock {
 
     public:
         XThinBlock();
@@ -106,7 +106,8 @@ struct XThinStub : public StubData {
 };
 
 // XThin has its own message for re-requesting transactions missing.
-struct XThinReRequest {
+class XThinReRequest {
+public:
     uint256 block;
     std::set<uint64_t> txRequesting;
 


### PR DESCRIPTION
Several types were declared as structs (presumably to save a `public:` line), but were forward-declared throughout the code as classes.

I changed them back to `class` since it seemed like the path of least resistance (otherwise all the forward declarations would have to be changed).