### PR TITLE
De-prioritize IPs with 2 or more connections.

### DIFF
--- a/src/ipgroups.cpp
+++ b/src/ipgroups.cpp
@@ -191,12 +191,14 @@ static void LoadTorIPsFromStaticData() {
     groups.push_back(ipGroup);
 }
 
-static void AddOrReplace(CIPGroup &group) {
+void AddOrReplace(CIPGroup &group) {
     LOCK(*cs_groups);
     // Try to replace existing group with same name.
     for (size_t i = 0; i < groups.size(); i++) {
         if (groups[i].header.name == group.header.name) {
+            int connCount = groups[i].header.connCount;
             groups[i] = group;
+            groups[i].header.connCount = connCount;
             return;
         }
     }

--- a/src/ipgroups.h
+++ b/src/ipgroups.h
@@ -6,15 +6,22 @@
 #define BITCOIN_CIPGROUPS_H
 
 #include "netbase.h"
+#include "sync.h"
+#include <boost/noncopyable.hpp>
 
 #define IP_PRIO_SRC_FLAG_NAME "-ip-priority-source"
 
 class CScheduler;
 
+static const int DEFAULT_IPGROUP_PRI = 0; //< same as an IP with 1 connection
+static const int IPGROUP_CONN_MODIFIER = 1; //< how much priority is modified per connection in group
+
 // A group of logically related IP addresses. Useful for banning or deprioritising
 // sources of abusive traffic/DoS attacks.
 struct CIPGroupData {
+
     std::string name;
+
     // A priority score indicates how important this group of IP addresses is to this node.
     // Importance determines which group wins when the node is out of resources. Any IP
     // that is not in a group gets a default priority of zero. Therefore, groups with a priority
@@ -22,7 +29,23 @@ struct CIPGroupData {
     // IPs, and groups with a higher priority will be serviced before ungrouped IPs.
     int priority;
 
-    CIPGroupData() : priority(0) {}
+    // If priority should be modified per connection in group
+    bool decrPriority;
+
+    // Group should be erased when connCount goes to 0
+    bool selfErases;
+    // Connections currently in group
+    int connCount;
+
+    CIPGroupData() : priority(DEFAULT_IPGROUP_PRI), decrPriority(false),
+        selfErases(false), connCount(0)
+    {
+    }
+
+    CIPGroupData(const std::string& name, int pri, bool decr = false, bool erases = false) :
+        name(name), priority(pri), decrPriority(decr), selfErases(erases), connCount(0)
+    {
+    }
 };
 
 struct CIPGroup {
@@ -30,10 +53,28 @@ struct CIPGroup {
     std::vector<CSubNet> subnets;
 };
 
-// Returns NULL if the IP does not belong to any group.
+// Assigned to each connected node to react to a new connection
+// in ipgroup and to react to a node disconnecting.
+class IPGroupSlot : boost::noncopyable {
+    public:
+        IPGroupSlot(const std::string& groupName);
+        ~IPGroupSlot();
+
+        CIPGroupData Group();
+
+    private:
+        std::string groupName;
+        boost::weak_ptr<CCriticalSection> groupCS;
+};
+
 CIPGroupData FindGroupForIP(CNetAddr ip);
 
 void InitIPGroupsFromCommandLine();
 void InitIPGroups(CScheduler *scheduler);
+
+// Creates a group slot for given IP.
+// If IP does not belong to a group then a new group will be created.
+std::auto_ptr<IPGroupSlot> AssignIPGroupSlot(const CNetAddr& ip);
+
 
 #endif //BITCOIN_CIPGROUPS_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4819,7 +4819,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
         if (fLogIPs)
             remoteAddr = ", peeraddr=" + pfrom->addr.ToString();
 
-        CIPGroupData ipgroup = FindGroupForIP(pfrom->addr);
+        CIPGroupData ipgroup = pfrom->ipgroupSlot->Group();
         string group = ipgroup.name != "" ? tfm::format(", ipgroup=%s", ipgroup.name) : "";
 
         LogPrintf("receive version message: %s: version %d, blocks=%d, us=%s, peerid=%d%s%s\n",

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -904,9 +904,6 @@ void ThreadSocketHandler()
                     // Calculate the priority of the new IP to see if we should drop it immediately (normal) or kick
                     // one of the other peers out to make room for it.
 
-                    // TODO: Lower the priority of an IP as it establishes more connections.
-                    // The goal is to force an attacker to spread out in order to get lots of priority.
-
                     // See if this IP has static prio data from a group.
                     CIPGroupData ipgroup = FindGroupForIP(addr);
 
@@ -2078,8 +2075,9 @@ CNode::CNode(SOCKET hSocketIn, CAddress addrIn, std::string addrNameIn, bool fIn
         id = nLastNodeId++;
     }
 
-    CIPGroupData ipgroup = FindGroupForIP(CNetAddr(addr.ToStringIP()));
-    std::string strIpGroup = ipgroup.name != "" ? tfm::format("(group %s)", ipgroup.name) : "";
+    ipgroupSlot = AssignIPGroupSlot(CNetAddr(addr.ToStringIP()));
+    CIPGroupData ipgroup = ipgroupSlot->Group();
+    std::string strIpGroup = tfm::format("(group %s)", ipgroup.name);
     if (fLogIPs)
         LogPrint("net", "Added connection to %s peer=%d %s\n", addrName, id, strIpGroup);
     else

--- a/src/net.h
+++ b/src/net.h
@@ -341,6 +341,9 @@ public:
     // Whether a ping is requested.
     bool fPingQueued;
 
+    // adds connection to ipgroup (for prioritising connection slots)
+    std::auto_ptr<IPGroupSlot> ipgroupSlot;
+
     CNode(SOCKET hSocketIn, CAddress addrIn, std::string addrNameIn = "", bool fInboundIn=false);
     virtual ~CNode();
 

--- a/src/test/ipgroups_tests.cpp
+++ b/src/test/ipgroups_tests.cpp
@@ -12,6 +12,7 @@
 #include <test/test_bitcoin.h>
 
 extern std::vector<CSubNet> ParseIPData(std::string input);
+extern void AddOrReplace(CIPGroup &group);
 
 BOOST_AUTO_TEST_SUITE(ipgroups_tests);
 
@@ -148,5 +149,19 @@ BOOST_AUTO_TEST_CASE(ipgroup_self_erases) {
     BOOST_CHECK_EQUAL(0, newip.connCount);
 }
 
-BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_CASE(add_or_replace_keeps_conncount) {
+    CIPGroup g;
+    g.header.name = "test";
+    AddOrReplace(g);
 
+    CNetAddr ip("127.1.1.1");
+    std::auto_ptr<IPGroupSlot> slot1 = AssignIPGroupSlot(ip);
+
+    CIPGroup g2;
+    g.header.name = "test";
+    AddOrReplace(g2);
+
+    BOOST_CHECK_EQUAL(1, FindGroupForIP(ip).connCount);
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/test/ipgroups_tests.cpp
+++ b/src/test/ipgroups_tests.cpp
@@ -88,5 +88,65 @@ BOOST_AUTO_TEST_CASE(cmd_line_sources)
     BOOST_CHECK_EQUAL(FindGroupForIP(CNetAddr("100.200.3.1")).priority, 0);
 }
 
+BOOST_AUTO_TEST_CASE(assign_creates_ipgroup) {
+    CNetAddr ip("10.0.0.2");
+    CIPGroupData newip = FindGroupForIP(ip);
+
+    // IP does belong to a group and has no connections, so no group
+    // assignment.
+    BOOST_CHECK(newip.name.empty());
+    BOOST_CHECK_EQUAL(0, newip.connCount);
+    BOOST_CHECK_EQUAL(DEFAULT_IPGROUP_PRI, newip.priority);
+
+    // A node with this IP connects and taks a slot.
+    std::auto_ptr<IPGroupSlot> slot = AssignIPGroupSlot(ip);
+
+    // IP should now have its own group.
+    newip = FindGroupForIP(ip);
+    BOOST_CHECK(!newip.name.empty());
+    BOOST_CHECK_EQUAL(1, newip.connCount);
+}
+
+BOOST_AUTO_TEST_CASE(multiple_connections_decr_pri) {
+    CNetAddr ip("10.0.0.2");
+
+    // IP with one connection should have normal pri.
+    std::auto_ptr<IPGroupSlot> slot1 = AssignIPGroupSlot(ip);
+    CIPGroupData newip = FindGroupForIP(ip);
+    BOOST_CHECK_EQUAL(DEFAULT_IPGROUP_PRI, newip.priority);
+
+    // IP with two connections should have lower.
+    std::auto_ptr<IPGroupSlot> slot2 = AssignIPGroupSlot(ip);
+    newip = FindGroupForIP(ip);
+    BOOST_CHECK_EQUAL(DEFAULT_IPGROUP_PRI - IPGROUP_CONN_MODIFIER, newip.priority);
+
+    // Should be in same group
+    BOOST_CHECK_EQUAL(slot1->Group().name, slot2->Group().name);
+    BOOST_CHECK_EQUAL(2, slot1->Group().connCount);
+
+    // Disconnecting one node should increase pri again
+    slot2.reset();
+    newip = FindGroupForIP(ip);
+    BOOST_CHECK_EQUAL(DEFAULT_IPGROUP_PRI, newip.priority);
+    BOOST_CHECK_EQUAL(1, slot1->Group().connCount);
+}
+
+BOOST_AUTO_TEST_CASE(ipgroup_self_erases) {
+
+    CNetAddr ip("10.0.0.2");
+
+    // When a new group is created for a single IP, that group
+    // should self erase when last node from that IP disconnects.
+    std::auto_ptr<IPGroupSlot> slot1 = AssignIPGroupSlot(ip);
+    CIPGroupData newip = FindGroupForIP(ip);
+    BOOST_CHECK(!newip.name.empty());
+    BOOST_CHECK_EQUAL(1, newip.connCount);
+
+    slot1.reset();
+    newip = FindGroupForIP(ip);
+    BOOST_CHECK(newip.name.empty());
+    BOOST_CHECK_EQUAL(0, newip.connCount);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include <boost/test/unit_test.hpp>
 #include "net.h"
+#include "ipgroups.h"
 
 BOOST_AUTO_TEST_SUITE(node_tests);
 
@@ -13,6 +14,23 @@ BOOST_AUTO_TEST_CASE(support_xthin_test) {
     BOOST_CHECK(!node.SupportsXThinBlocks());
     node.nServices |= NODE_THIN;
     BOOST_CHECK(node.SupportsXThinBlocks());
+}
+
+// Test that a correct IP group is created for node, then removed
+// when node is destructed.
+BOOST_AUTO_TEST_CASE(ipgroup_assigned) {
+    CNetAddr ip("10.0.0.1");
+    std::auto_ptr<CNode> node(new CNode(
+                INVALID_SOCKET, CAddress(CService(ip, 1234))));
+
+    CIPGroupData ipgroup = FindGroupForIP(ip);
+    BOOST_CHECK_EQUAL(1, ipgroup.connCount);
+    BOOST_CHECK_EQUAL(ip.ToStringIP(), ipgroup.name);
+
+    node.reset();
+    ipgroup = FindGroupForIP(ip);
+    BOOST_CHECK_EQUAL(0, ipgroup.connCount);
+
 }
 
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
The goal is to force an attacker to spread out with multiple IPs
to exaust connection slots, making the attack more expensive.

This is done by creating a single-ip-ipgroup for every node that does
not belong to any other ipgroups. For every new connection from the same
ip, that group gets lower priority. When a node disconnects, the
priority increases again.