### PR TITLE
Corrections to bad-chain alert triggering

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1461,7 +1461,8 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     int64_t nPowTargetSpacing = Params().GetConsensus().nPowTargetSpacing;
     CScheduler::Function f = boost::bind(&PartitionCheck, &IsInitialBlockDownload,
                                          boost::ref(cs_main), boost::cref(pindexBestHeader), nPowTargetSpacing);
-    scheduler.scheduleEvery(f, nPowTargetSpacing);
+    CBlockIndex *pdummy = NULL;
+    scheduler.scheduleEvery(f, PartitionCheck(&IsInitialBlockDownload, boost::ref(cs_main), boost::cref(pdummy), nPowTargetSpacing));
 
 #ifdef ENABLE_WALLET
     // Generate coins in the background

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2073,19 +2073,31 @@ void ThreadScriptCheck() {
 // Called periodically asynchronously; alerts if it smells like
 // we're being fed a bad chain (blocks being generated much
 // too slowly or too quickly).
+// Always returns the constant interval at which it should be scheduled.
 //
-void PartitionCheck(bool (*initialDownloadCheck)(), CCriticalSection& cs, const CBlockIndex *const &bestHeader,
+int PartitionCheck(bool (*initialDownloadCheck)(), CCriticalSection& cs, const CBlockIndex *const &bestHeader,
                     int64_t nPowTargetSpacing)
 {
-    if (bestHeader == NULL || initialDownloadCheck()) return;
+    // Aim for one false-positive about every fifty years of normal running:
+    // The sample interval SPAN_SECONDS is chosen as the smallest multiple of target spacing expected
+    // to trigger a too-few-blocks alert only once in fifty years (this will be when 0 blocks are seen):
+    // blocks  cdf(blocks, 0)  alertThreshold
+    //   11    1.67017e-5      4.18569e-6
+    //   12    6.14421e-6      4.56621e-6
+    //   13    2.26033e-6      4.94673e-6 <--- min such that (cdf < threshold)
+    //   14    8.31529e-7      5.32725e-6
+    //   15    3.05902e-7      5.70776e-6
+    //TODO find BLOCKS_EXPECTED dynamically, for correct timing of non-10-minute intervals
+    const int FIFTY_YEARS = 50*365*24*60*60;
+    const int BLOCKS_EXPECTED = 13;
+    const int SPAN_SECONDS = BLOCKS_EXPECTED * nPowTargetSpacing;
+    double alertThreshold = 1.0 / (FIFTY_YEARS / SPAN_SECONDS);
+
+    if (bestHeader == NULL || initialDownloadCheck()) return SPAN_SECONDS;
 
     static int64_t lastAlertTime = 0;
     int64_t now = GetAdjustedTime();
-    if (lastAlertTime > now-60*60*24) return; // Alert at most once per day
-
-    const int SPAN_HOURS=4;
-    const int SPAN_SECONDS=SPAN_HOURS*60*60;
-    int BLOCKS_EXPECTED = SPAN_SECONDS / nPowTargetSpacing;
+    if (lastAlertTime > now-60*60*24) return SPAN_SECONDS; // Alert at most once per day
 
     boost::math::poisson_distribution<double> poisson(BLOCKS_EXPECTED);
 
@@ -2098,30 +2110,28 @@ void PartitionCheck(bool (*initialDownloadCheck)(), CCriticalSection& cs, const 
     while (i->GetBlockTime() >= startTime) {
         ++nBlocks;
         i = i->pprev;
-        if (i == NULL) return; // Ran out of chain, we must not be fully sync'ed
+        if (i == NULL) return SPAN_SECONDS; // Ran out of chain, we must not be fully sync'ed
     }
 
-    // How likely is it to find that many by chance?
-    double p = boost::math::pdf(poisson, nBlocks);
+    // How likely is it to find at least that many by chance?
+    double pHigh = 1.0 - boost::math::cdf(poisson, std::max(0, nBlocks - 1));
+    // How likely is it to find at most that few by chance?
+    double pLow = boost::math::cdf(poisson, nBlocks);
 
-    LogPrint("partitioncheck", "%s : Found %d blocks in the last %d hours\n", __func__, nBlocks, SPAN_HOURS);
-    LogPrint("partitioncheck", "%s : likelihood: %g\n", __func__, p);
+    LogPrint("partitioncheck", "%s: Found %d blocks in the last %d seconds\n", __func__, nBlocks, SPAN_SECONDS);
+    LogPrint("partitioncheck", "%s: likelihood that many: %g, that few: %g\n", __func__, pHigh, pLow);
 
-    // Aim for one false-positive about every fifty years of normal running:
-    const int FIFTY_YEARS = 50*365*24*60*60;
-    double alertThreshold = 1.0 / (FIFTY_YEARS / SPAN_SECONDS);
-
-    if (p <= alertThreshold && nBlocks < BLOCKS_EXPECTED)
+    if (pLow <= alertThreshold)
     {
         // Many fewer blocks than expected: alert!
-        strWarning = strprintf(_("WARNING: check your network connection, %d blocks received in the last %d hours (%d expected)"),
-                               nBlocks, SPAN_HOURS, BLOCKS_EXPECTED);
+        strWarning = strprintf(_("WARNING: check your network connection, %d blocks received in the last %d seconds (%d expected)"),
+                               nBlocks, SPAN_SECONDS, BLOCKS_EXPECTED);
     }
-    else if (p <= alertThreshold && nBlocks > BLOCKS_EXPECTED)
+    else if (pHigh <= alertThreshold)
     {
         // Many more blocks than expected: alert!
-        strWarning = strprintf(_("WARNING: abnormally high number of blocks generated, %d blocks received in the last %d hours (%d expected)"),
-                               nBlocks, SPAN_HOURS, BLOCKS_EXPECTED);
+        strWarning = strprintf(_("WARNING: abnormally high number of blocks generated, %d blocks received in the last %d seconds (%d expected)"),
+                               nBlocks, SPAN_SECONDS, BLOCKS_EXPECTED);
     }
     if (!strWarning.empty())
     {
@@ -2129,6 +2139,7 @@ void PartitionCheck(bool (*initialDownloadCheck)(), CCriticalSection& cs, const 
         CAlert::Notify(strWarning, true);
         lastAlertTime = now;
     }
+    return SPAN_SECONDS;
 }
 
 static int64_t nTimeVerify = 0;

--- a/src/main.h
+++ b/src/main.h
@@ -205,7 +205,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle);
 /** Run an instance of the script checking thread */
 void ThreadScriptCheck();
 /** Try to detect Partition (network isolation) attacks against us */
-void PartitionCheck(bool (*initialDownloadCheck)(), CCriticalSection& cs, const CBlockIndex *const &bestHeader, int64_t nPowTargetSpacing);
+int PartitionCheck(bool (*initialDownloadCheck)(), CCriticalSection& cs, const CBlockIndex *const &bestHeader, int64_t nPowTargetSpacing);
 /** Check whether we are doing an initial block download (synchronizing from disk or network) */
 bool IsInitialBlockDownload();
 /** Format a string that describes several potential problems detected by the core */

--- a/src/test/alert_tests.cpp
+++ b/src/test/alert_tests.cpp
@@ -240,10 +240,10 @@ BOOST_AUTO_TEST_CASE(PartitionAlert)
     PartitionCheck(falseFunc, csDummy, &indexDummy[99], nPowTargetSpacing);
     BOOST_CHECK(strMiscWarning.empty());
 
-    // Test 4: get 2.5 times as many blocks as expected:
+    // Test 4: get 3 times as many blocks as expected:
     now += 60*60*24; // Pretend it is a day later
     SetMockTime(now);
-    int64_t quickSpacing = nPowTargetSpacing*2/5;
+    int64_t quickSpacing = nPowTargetSpacing/3;
     for (int i = 0; i < 100; i++) // Tweak chain timestamps:
         indexDummy[i].nTime = now - (100-i)*quickSpacing;
     PartitionCheck(falseFunc, csDummy, &indexDummy[99], nPowTargetSpacing);


### PR DESCRIPTION
Two corrections are made to the bad-chain alert triggering mechanism: oversampling is eliminated and the test is changed to make correct use of the poisson CDF.

Overall, the effect will be for the alert to trigger less often, since it was triggering too easily before.

There has been review and discussion at https://github.com/bitcoin/bitcoin/pull/7568.  The holdup there seems to be that this doesn't fix everything.  No disagreement that it's a big improvement.