### PR TITLE
Don't use CNode::cs_filter to protect xthinFilter

### DIFF
--- a/src/blocksender.cpp
+++ b/src/blocksender.cpp
@@ -92,7 +92,7 @@ void BlockSender::sendBlock(CNode& node,
 
     CBloomFilter filter;
     {
-        LOCK(node.cs_filter);
+        LOCK(node.cs_xfilter);
         assert(bool(node.xthinFilter.get())); // a filter is always allocated.
         filter = *node.xthinFilter;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5630,7 +5630,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
             Misbehaving(pfrom->GetId(), 100);
         else
         {
-            LOCK(pfrom->cs_filter);
+            LOCK(pfrom->cs_xfilter);
             pfrom->xthinFilter.reset(new CBloomFilter(dontWant));
             pfrom->xthinFilter->UpdateEmptyFull();
 

--- a/src/net.h
+++ b/src/net.h
@@ -290,7 +290,7 @@ public:
     //    until it has initialized its bloom filter.
     bool fRelayTxes;
     CSemaphoreGrant grantOutbound;
-    CCriticalSection cs_filter;
+    CCriticalSection cs_filter, cs_xfilter;
     CBloomFilter* pfilter;
     std::auto_ptr<CBloomFilter> xthinFilter;
     int nRefCount;


### PR DESCRIPTION
I encountered a deadlock in testing due to reuse of CNode::cs_filter to protect xthinFilter.  This pull introduces a dedicated lock cs_xfilter for this purpose.