### PR TITLE
Direct headers announcement

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -37,6 +37,7 @@ testScripts=(
     'walletbackup.py'
     'p2p-versionbits-warning.py'
     'decodescript.py'
+    'sendheaders.py'
 );
 testScriptsExt=(
     'bigblocks.py'
@@ -62,7 +63,6 @@ testScriptsExt=(
     'maxblocksinflight.py'
     'invalidblockrequest.py'
     'rawtransactions.py'
-#    'forknotify.py'
     'p2p-acceptblock.py'
     'mempool_packages.py'
 );

--- a/qa/rpc-tests/sendheaders.py
+++ b/qa/rpc-tests/sendheaders.py
@@ -1,0 +1,519 @@
+#!/usr/bin/env python2
+#
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+
+from test_framework.mininode import *
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+import time
+from test_framework.blocktools import create_block, create_coinbase
+
+'''
+SendHeadersTest -- test behavior of headers messages to announce blocks.
+
+Setup: 
+
+- Two nodes, two p2p connections to node0. One p2p connection should only ever
+  receive inv's (omitted from testing description below, this is our control).
+  Second node is used for creating reorgs.
+
+Part 1: No headers announcements before "sendheaders"
+a. node mines a block [expect: inv]
+   send getdata for the block [expect: block]
+b. node mines another block [expect: inv]
+   send getheaders and getdata [expect: headers, then block]
+c. node mines another block [expect: inv]
+   peer mines a block, announces with header [expect: getdata]
+d. node mines another block [expect: inv]
+
+Part 2: After "sendheaders", headers announcements should generally work.
+a. peer sends sendheaders [expect: no response]
+   peer sends getheaders with current tip [expect: no response]
+b. node mines a block [expect: tip header]
+c. for N in 1, ..., 10:
+   * for announce-type in {inv, header}
+     - peer mines N blocks, announces with announce-type
+       [ expect: getheaders/getdata or getdata, deliver block(s) ]
+     - node mines a block [ expect: 1 header ]
+
+Part 3: Headers announcements stop after large reorg and resume after getheaders or inv from peer.
+- For response-type in {inv, getheaders}
+  * node mines a 7 block reorg [ expect: headers announcement of 8 blocks ]
+  * node mines an 8-block reorg [ expect: inv at tip ]
+  * peer responds with getblocks/getdata [expect: inv, blocks ]
+  * node mines another block [ expect: inv at tip, peer sends getdata, expect: block ]
+  * node mines another block at tip [ expect: inv ]
+  * peer responds with getheaders with an old hashstop more than 8 blocks back [expect: headers]
+  * peer requests block [ expect: block ]
+  * node mines another block at tip [ expect: inv, peer sends getdata, expect: block ]
+  * peer sends response-type [expect headers if getheaders, getheaders/getdata if mining new block]
+  * node mines 1 block [expect: 1 header, peer responds with getdata]
+
+Part 4: Test direct fetch behavior
+a. Announce 2 old block headers.
+   Expect: no getdata requests.
+b. Announce 3 new blocks via 1 headers message.
+   Expect: one getdata request for all 3 blocks.
+   (Send blocks.)
+c. Announce 1 header that forks off the last two blocks.
+   Expect: no response.
+d. Announce 1 more header that builds on that fork.
+   Expect: one getdata request for two blocks.
+e. Announce 16 more headers that build on that fork.
+   Expect: getdata request for 14 more blocks.
+f. Announce 1 more header that builds on that fork.
+   Expect: no response.
+'''
+
+class BaseNode(NodeConnCB):
+    def __init__(self):
+        NodeConnCB.__init__(self)
+        self.create_callback_map()
+        self.connection = None
+        self.last_inv = None
+        self.last_headers = None
+        self.last_block = None
+        self.ping_counter = 1
+        self.last_pong = msg_pong(0)
+        self.last_getdata = None
+        self.sleep_time = 0.05
+        self.block_announced = False
+
+    def clear_last_announcement(self):
+        with mininode_lock:
+            self.block_announced = False
+            self.last_inv = None
+            self.last_headers = None
+
+    def add_connection(self, conn):
+        self.connection = conn
+
+    # Request data for a list of block hashes
+    def get_data(self, block_hashes):
+        msg = msg_getdata()
+        for x in block_hashes:
+            msg.inv.append(CInv(2, x))
+        self.connection.send_message(msg)
+
+    def get_headers(self, locator, hashstop):
+        msg = msg_getheaders()
+        msg.locator.vHave = locator
+        msg.hashstop = hashstop
+        self.connection.send_message(msg)
+
+    def send_block_inv(self, blockhash):
+        msg = msg_inv()
+        msg.inv = [CInv(2, blockhash)]
+        self.connection.send_message(msg)
+
+    # Wrapper for the NodeConn's send_message function
+    def send_message(self, message):
+        self.connection.send_message(message)
+
+    def on_inv(self, conn, message):
+        self.last_inv = message
+        self.block_announced = True
+
+    def on_headers(self, conn, message):
+        self.last_headers = message
+        self.block_announced = True
+
+    def on_block(self, conn, message):
+        self.last_block = message.block
+        self.last_block.calc_sha256()
+
+    def on_getdata(self, conn, message):
+        self.last_getdata = message
+
+    def on_pong(self, conn, message):
+        self.last_pong = message
+
+    # Test whether the last announcement we received had the
+    # right header or the right inv
+    # inv and headers should be lists of block hashes
+    def check_last_announcement(self, headers=None, inv=None):
+        expect_headers = headers if headers != None else []
+        expect_inv = inv if inv != None else []
+        test_function = lambda: self.block_announced
+        self.sync(test_function)
+        with mininode_lock:
+            self.block_announced = False
+
+            success = True
+            compare_inv = []
+            if self.last_inv != None:
+                compare_inv = [x.hash for x in self.last_inv.inv]
+            if compare_inv != expect_inv:
+                success = False
+
+            hash_headers = []
+            if self.last_headers != None:
+                # treat headers as a list of block hashes
+                hash_headers = [ x.sha256 for x in self.last_headers.headers ]
+            if hash_headers != expect_headers:
+                success = False
+
+            self.last_inv = None
+            self.last_headers = None
+        return success
+
+    # Syncing helpers
+    def sync(self, test_function, timeout=60):
+        while timeout > 0:
+            with mininode_lock:
+                if test_function():
+                    return
+            time.sleep(self.sleep_time)
+            timeout -= self.sleep_time
+        raise AssertionError("Sync failed to complete")
+        
+    def sync_with_ping(self, timeout=60):
+        self.send_message(msg_ping(nonce=self.ping_counter))
+        test_function = lambda: self.last_pong.nonce == self.ping_counter
+        self.sync(test_function, timeout)
+        self.ping_counter += 1
+        return
+
+    def wait_for_block(self, blockhash, timeout=60):
+        test_function = lambda: self.last_block != None and self.last_block.sha256 == blockhash
+        self.sync(test_function, timeout)
+        return
+
+    def wait_for_getdata(self, hash_list, timeout=60):
+        if hash_list == []:
+            return
+
+        test_function = lambda: self.last_getdata != None and [x.hash for x in self.last_getdata.inv] == hash_list
+        self.sync(test_function, timeout)
+        return
+
+    def send_header_for_blocks(self, new_blocks):
+        headers_message = msg_headers()
+        headers_message.headers = [ CBlockHeader(b) for b in new_blocks ]
+        self.send_message(headers_message)
+
+    def send_getblocks(self, locator):
+        getblocks_message = msg_getblocks()
+        getblocks_message.locator.vHave = locator
+        self.send_message(getblocks_message)
+
+# InvNode: This peer should only ever receive inv's, because it doesn't ever send a
+# "sendheaders" message.
+class InvNode(BaseNode):
+    def __init__(self):
+        BaseNode.__init__(self)
+
+# TestNode: This peer is the one we use for most of the testing.
+class TestNode(BaseNode):
+    def __init__(self):
+        BaseNode.__init__(self)
+
+class SendHeadersTest(BitcoinTestFramework):
+    def setup_chain(self):
+        initialize_chain_clean(self.options.tmpdir, 2)
+
+    def setup_network(self):
+        self.nodes = []
+        self.nodes = start_nodes(2, self.options.tmpdir, [["-debug", "-logtimemicros=1"]]*2)
+        connect_nodes(self.nodes[0], 1)
+
+    # mine count blocks and return the new tip
+    def mine_blocks(self, count):
+        self.nodes[0].generate(count)
+        return int(self.nodes[0].getbestblockhash(), 16)
+
+    # mine a reorg that invalidates length blocks (replacing them with
+    # length+1 blocks).
+    # peers is the p2p nodes we're using; we clear their state after the
+    # to-be-reorged-out blocks are mined, so that we don't break later tests.
+    # return the list of block hashes newly mined
+    def mine_reorg(self, length, peers):
+        self.nodes[0].generate(length) # make sure all invalidated blocks are node0's
+        sync_blocks(self.nodes, wait=0.1)
+        [x.clear_last_announcement() for x in peers]
+
+        tip_height = self.nodes[1].getblockcount()
+        hash_to_invalidate = self.nodes[1].getblockhash(tip_height-(length-1))
+        self.nodes[1].invalidateblock(hash_to_invalidate)
+        all_hashes = self.nodes[1].generate(length+1) # Must be longer than the orig chain
+        sync_blocks(self.nodes, wait=0.1)
+        return [int(x, 16) for x in all_hashes]
+
+    def run_test(self):
+        # Setup the p2p connections and start up the network thread.
+        inv_node = InvNode()
+        test_node = TestNode()
+
+        connections = []
+        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], inv_node))
+        # Set nServices to 0 for test_node, so no block download will occur outside of
+        # direct fetching
+        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], test_node, services=0))
+        inv_node.add_connection(connections[0])
+        test_node.add_connection(connections[1])
+
+        NetworkThread().start() # Start up network handling in another thread
+
+        # Test logic begins here
+        inv_node.wait_for_verack()
+        test_node.wait_for_verack()
+
+        tip = int(self.nodes[0].getbestblockhash(), 16)
+
+        # PART 1
+        # 1. Mine a block; expect inv announcements each time
+        print "Part 1: headers don't start before sendheaders message..."
+        for i in xrange(4):
+            old_tip = tip
+            tip = self.mine_blocks(1)
+            assert_equal(inv_node.check_last_announcement(inv=[tip]), True)
+            assert_equal(test_node.check_last_announcement(inv=[tip]), True)
+            # Try a few different responses; none should affect next announcement
+            if i == 0:
+                # first request the block
+                test_node.get_data([tip])
+                test_node.wait_for_block(tip, timeout=5)
+            elif i == 1:
+                # next try requesting header and block
+                test_node.get_headers(locator=[old_tip], hashstop=tip)
+                test_node.get_data([tip])
+                test_node.wait_for_block(tip)
+                test_node.clear_last_announcement() # since we requested headers...
+            elif i == 2:
+                # this time announce own block via headers
+                height = self.nodes[0].getblockcount()
+                last_time = self.nodes[0].getblock(self.nodes[0].getbestblockhash())['time']
+                block_time = last_time + 1
+                new_block = create_block(tip, create_coinbase(height+1), block_time)
+                new_block.solve()
+                test_node.send_header_for_blocks([new_block])
+                test_node.wait_for_getdata([new_block.sha256], timeout=5)
+                test_node.send_message(msg_block(new_block))
+                test_node.sync_with_ping() # make sure this block is processed
+                inv_node.clear_last_announcement()
+                test_node.clear_last_announcement()
+
+        print "Part 1: success!"
+        print "Part 2: announce blocks with headers after sendheaders message..."
+        # PART 2
+        # 2. Send a sendheaders message and test that headers announcements
+        # commence and keep working.
+        test_node.send_message(msg_sendheaders())
+        prev_tip = int(self.nodes[0].getbestblockhash(), 16)
+        test_node.get_headers(locator=[prev_tip], hashstop=0L)
+        test_node.sync_with_ping()
+        test_node.clear_last_announcement() # Clear out empty headers response
+
+        # Now that we've synced headers, headers announcements should work
+        tip = self.mine_blocks(1)
+        assert_equal(inv_node.check_last_announcement(inv=[tip]), True)
+        assert_equal(test_node.check_last_announcement(headers=[tip]), True)
+
+        height = self.nodes[0].getblockcount()+1
+        block_time += 10  # Advance far enough ahead
+        for i in xrange(10):
+            # Mine i blocks, and alternate announcing either via
+            # inv (of tip) or via headers. After each, new blocks
+            # mined by the node should successfully be announced
+            # with block header, even though the blocks are never requested
+            for j in xrange(2):
+                blocks = []
+                for b in xrange(i+1):
+                    blocks.append(create_block(tip, create_coinbase(height), block_time))
+                    blocks[-1].solve()
+                    tip = blocks[-1].sha256
+                    block_time += 1
+                    height += 1
+                if j == 0:
+                    # Announce via inv
+                    test_node.send_block_inv(tip)
+                    test_node.wait_for_getdata([tip], timeout=5)
+                    # Test that duplicate inv's won't result in duplicate
+                    # getdata requests, or duplicate headers announcements
+                    inv_node.send_block_inv(tip)
+                    # Should have received a getheaders as well!
+                    test_node.send_header_for_blocks(blocks)
+                    test_node.wait_for_getdata([x.sha256 for x in blocks[0:-1]], timeout=5)
+                    [ inv_node.send_block_inv(x.sha256) for x in blocks[0:-1] ]
+                    inv_node.sync_with_ping()
+                else:
+                    # Announce via headers
+                    test_node.send_header_for_blocks(blocks)
+                    test_node.wait_for_getdata([x.sha256 for x in blocks], timeout=5)
+                    # Test that duplicate headers won't result in duplicate
+                    # getdata requests (the check is further down)
+                    inv_node.send_header_for_blocks(blocks)
+                    inv_node.sync_with_ping()
+                [ test_node.send_message(msg_block(x)) for x in blocks ]
+                test_node.sync_with_ping()
+                inv_node.sync_with_ping()
+                # This block should not be announced to the inv node (since it also
+                # broadcast it)
+                assert_equal(inv_node.last_inv, None)
+                assert_equal(inv_node.last_headers, None)
+                inv_node.clear_last_announcement()
+                test_node.clear_last_announcement()
+                tip = self.mine_blocks(1)
+                assert_equal(inv_node.check_last_announcement(inv=[tip]), True)
+                assert_equal(test_node.check_last_announcement(headers=[tip]), True)
+                height += 1
+                block_time += 1
+
+        print "Part 2: success!"
+
+        print "Part 3: headers announcements can stop after large reorg, and resume after headers/inv from peer..."
+
+        # PART 3.  Headers announcements can stop after large reorg, and resume after
+        # getheaders or inv from peer.
+        for j in xrange(2):
+            # First try mining a reorg that can propagate with header announcement
+            new_block_hashes = self.mine_reorg(length=7, peers=[test_node, inv_node])
+            tip = new_block_hashes[-1]
+            assert_equal(inv_node.check_last_announcement(inv=[tip]), True)
+            assert_equal(test_node.check_last_announcement(headers=new_block_hashes), True)
+
+            block_time += 8 
+
+            # Mine a too-large reorg, which should be announced with a single inv
+            new_block_hashes = self.mine_reorg(length=8, peers=[test_node, inv_node])
+            tip = new_block_hashes[-1]
+            assert_equal(inv_node.check_last_announcement(inv=[tip]), True)
+            assert_equal(test_node.check_last_announcement(inv=[tip]), True)
+
+            block_time += 9
+
+            fork_point = self.nodes[0].getblock("%02x" % new_block_hashes[0])["previousblockhash"]
+            fork_point = int(fork_point, 16)
+
+            # Use getblocks/getdata
+            test_node.send_getblocks(locator = [fork_point])
+            assert_equal(test_node.check_last_announcement(inv=new_block_hashes[0:-1]), True)
+            test_node.get_data(new_block_hashes)
+            test_node.wait_for_block(new_block_hashes[-1])
+
+            for i in xrange(3):
+                # Mine another block, still should get only an inv
+                tip = self.mine_blocks(1)
+                assert_equal(inv_node.check_last_announcement(inv=[tip]), True)
+                assert_equal(test_node.check_last_announcement(inv=[tip]), True)
+                if i == 0:
+                    # Just get the data -- shouldn't cause headers announcements to resume
+                    test_node.get_data([tip])
+                    test_node.wait_for_block(tip)
+                elif i == 1:
+                    # Send a getheaders message that shouldn't trigger headers announcements
+                    # to resume (best header sent will be too old)
+                    test_node.get_headers(locator=[fork_point], hashstop=new_block_hashes[1])
+                    test_node.get_data([tip])
+                    test_node.wait_for_block(tip)
+                    test_node.clear_last_announcement()
+                elif i == 2:
+                    test_node.get_data([tip])
+                    test_node.wait_for_block(tip)
+                    # This time, try sending either a getheaders to trigger resumption
+                    # of headers announcements, or mine a new block and inv it, also 
+                    # triggering resumption of headers announcements.
+                    if j == 0:
+                        test_node.get_headers(locator=[tip], hashstop=0L)
+                        test_node.sync_with_ping()
+                    else:
+                        test_node.send_block_inv(tip)
+                        test_node.sync_with_ping()
+            # New blocks should now be announced with header
+            tip = self.mine_blocks(1)
+            assert_equal(inv_node.check_last_announcement(inv=[tip]), True)
+            assert_equal(test_node.check_last_announcement(headers=[tip]), True)
+
+        print "Part 3: success!"
+
+        print "Part 4: Testing direct fetch behavior..."
+        tip = self.mine_blocks(1)
+        height = self.nodes[0].getblockcount() + 1
+        last_time = self.nodes[0].getblock(self.nodes[0].getbestblockhash())['time']
+        block_time = last_time + 1
+
+        # Create 2 blocks.  Send the blocks, then send the headers.
+        blocks = []
+        for b in xrange(2):
+            blocks.append(create_block(tip, create_coinbase(height), block_time))
+            blocks[-1].solve()
+            tip = blocks[-1].sha256
+            block_time += 1
+            height += 1
+            inv_node.send_message(msg_block(blocks[-1]))
+
+        inv_node.sync_with_ping() # Make sure blocks are processed
+        test_node.last_getdata = None
+        test_node.send_header_for_blocks(blocks);
+        test_node.sync_with_ping()
+        # should not have received any getdata messages
+        with mininode_lock:
+            assert_equal(test_node.last_getdata, None)
+
+        # This time, direct fetch should work
+        blocks = []
+        for b in xrange(3):
+            blocks.append(create_block(tip, create_coinbase(height), block_time))
+            blocks[-1].solve()
+            tip = blocks[-1].sha256
+            block_time += 1
+            height += 1
+
+        test_node.send_header_for_blocks(blocks)
+        test_node.sync_with_ping()
+        test_node.wait_for_getdata([x.sha256 for x in blocks], timeout=test_node.sleep_time)
+
+        [ test_node.send_message(msg_block(x)) for x in blocks ]
+
+        test_node.sync_with_ping()
+
+        # Now announce a header that forks the last two blocks
+        tip = blocks[0].sha256
+        height -= 1
+        blocks = []
+
+        # Create extra blocks for later
+        for b in xrange(20):
+            blocks.append(create_block(tip, create_coinbase(height), block_time))
+            blocks[-1].solve()
+            tip = blocks[-1].sha256
+            block_time += 1
+            height += 1
+
+        # Announcing one block on fork should not trigger direct fetch
+        # (less work than tip)
+        test_node.last_getdata = None
+        test_node.send_header_for_blocks(blocks[0:1])
+        test_node.sync_with_ping()
+        with mininode_lock:
+            assert_equal(test_node.last_getdata, None)
+
+        # Announcing one more block on fork should trigger direct fetch for
+        # both blocks (same work as tip)
+        test_node.send_header_for_blocks(blocks[1:2])
+        test_node.sync_with_ping()
+        test_node.wait_for_getdata([x.sha256 for x in blocks[0:2]], timeout=test_node.sleep_time)
+
+        # Announcing 16 more headers should trigger direct fetch for 14 more
+        # blocks
+        test_node.send_header_for_blocks(blocks[2:18])
+        test_node.sync_with_ping()
+        test_node.wait_for_getdata([x.sha256 for x in blocks[2:16]], timeout=test_node.sleep_time)
+
+        # Announcing 1 more header should not trigger any response
+        test_node.last_getdata = None
+        test_node.send_header_for_blocks(blocks[18:19])
+        test_node.sync_with_ping()
+        with mininode_lock:
+            assert_equal(test_node.last_getdata, None)
+
+        print "Part 4: success!"
+
+        # Finally, check that the inv node never received a getdata request,
+        # throughout the test
+        assert_equal(inv_node.last_getdata, None)
+
+if __name__ == '__main__':
+    SendHeadersTest().main()

--- a/qa/rpc-tests/sendheaders.py
+++ b/qa/rpc-tests/sendheaders.py
@@ -389,7 +389,7 @@ class SendHeadersTest(BitcoinTestFramework):
 
             # Use getblocks/getdata
             test_node.send_getblocks(locator = [fork_point])
-            assert_equal(test_node.check_last_announcement(inv=new_block_hashes[0:-1]), True)
+            assert_equal(test_node.check_last_announcement(inv=new_block_hashes), True)
             test_node.get_data(new_block_hashes)
             test_node.wait_for_block(new_block_hashes[-1])
 

--- a/qa/rpc-tests/sendheaders.py
+++ b/qa/rpc-tests/sendheaders.py
@@ -221,18 +221,20 @@ class SendHeadersTest(BitcoinTestFramework):
 
     # mine count blocks and return the new tip
     def mine_blocks(self, count):
+        # Clear out last block announcement from each p2p listener
+        [ x.clear_last_announcement() for x in self.p2p_connections ]
         self.nodes[0].generate(count)
         return int(self.nodes[0].getbestblockhash(), 16)
 
     # mine a reorg that invalidates length blocks (replacing them with
     # length+1 blocks).
-    # peers is the p2p nodes we're using; we clear their state after the
+    # Note: we clear the state of our p2p connections after the
     # to-be-reorged-out blocks are mined, so that we don't break later tests.
     # return the list of block hashes newly mined
-    def mine_reorg(self, length, peers):
+    def mine_reorg(self, length):
         self.nodes[0].generate(length) # make sure all invalidated blocks are node0's
         sync_blocks(self.nodes, wait=0.1)
-        [x.clear_last_announcement() for x in peers]
+        [x.clear_last_announcement() for x in self.p2p_connections]
 
         tip_height = self.nodes[1].getblockcount()
         hash_to_invalidate = self.nodes[1].getblockhash(tip_height-(length-1))
@@ -245,6 +247,8 @@ class SendHeadersTest(BitcoinTestFramework):
         # Setup the p2p connections and start up the network thread.
         inv_node = InvNode()
         test_node = TestNode()
+
+        self.p2p_connections = [inv_node, test_node]
 
         connections = []
         connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], inv_node))
@@ -304,7 +308,6 @@ class SendHeadersTest(BitcoinTestFramework):
         prev_tip = int(self.nodes[0].getbestblockhash(), 16)
         test_node.get_headers(locator=[prev_tip], hashstop=0L)
         test_node.sync_with_ping()
-        test_node.clear_last_announcement() # Clear out empty headers response
 
         # Now that we've synced headers, headers announcements should work
         tip = self.mine_blocks(1)
@@ -353,8 +356,6 @@ class SendHeadersTest(BitcoinTestFramework):
                 # broadcast it)
                 assert_equal(inv_node.last_inv, None)
                 assert_equal(inv_node.last_headers, None)
-                inv_node.clear_last_announcement()
-                test_node.clear_last_announcement()
                 tip = self.mine_blocks(1)
                 assert_equal(inv_node.check_last_announcement(inv=[tip]), True)
                 assert_equal(test_node.check_last_announcement(headers=[tip]), True)
@@ -369,7 +370,7 @@ class SendHeadersTest(BitcoinTestFramework):
         # getheaders or inv from peer.
         for j in xrange(2):
             # First try mining a reorg that can propagate with header announcement
-            new_block_hashes = self.mine_reorg(length=7, peers=[test_node, inv_node])
+            new_block_hashes = self.mine_reorg(length=7)
             tip = new_block_hashes[-1]
             assert_equal(inv_node.check_last_announcement(inv=[tip]), True)
             assert_equal(test_node.check_last_announcement(headers=new_block_hashes), True)
@@ -377,7 +378,7 @@ class SendHeadersTest(BitcoinTestFramework):
             block_time += 8 
 
             # Mine a too-large reorg, which should be announced with a single inv
-            new_block_hashes = self.mine_reorg(length=8, peers=[test_node, inv_node])
+            new_block_hashes = self.mine_reorg(length=8)
             tip = new_block_hashes[-1]
             assert_equal(inv_node.check_last_announcement(inv=[tip]), True)
             assert_equal(test_node.check_last_announcement(inv=[tip]), True)
@@ -408,7 +409,6 @@ class SendHeadersTest(BitcoinTestFramework):
                     test_node.get_headers(locator=[fork_point], hashstop=new_block_hashes[1])
                     test_node.get_data([tip])
                     test_node.wait_for_block(tip)
-                    test_node.clear_last_announcement()
                 elif i == 2:
                     test_node.get_data([tip])
                     test_node.wait_for_block(tip)

--- a/qa/rpc-tests/sendheaders.py
+++ b/qa/rpc-tests/sendheaders.py
@@ -65,6 +65,21 @@ e. Announce 16 more headers that build on that fork.
    Expect: getdata request for 14 more blocks.
 f. Announce 1 more header that builds on that fork.
    Expect: no response.
+
+Part 5: Test handling of headers that don't connect.
+a. Repeat 10 times:
+   1. Announce a header that doesn't connect.
+      Expect: getheaders message
+   2. Send headers chain.
+      Expect: getdata for the missing blocks, tip update.
+b. Then send 9 more headers that don't connect.
+   Expect: getheaders message each time.
+c. Announce a header that does connect.
+   Expect: no response.
+d. Announce 49 headers that don't connect.
+   Expect: getheaders message each time.
+e. Announce one more that doesn't connect.
+   Expect: disconnect.
 '''
 
 class BaseNode(NodeConnCB):
@@ -80,6 +95,8 @@ class BaseNode(NodeConnCB):
         self.last_getdata = None
         self.sleep_time = 0.05
         self.block_announced = False
+        self.last_getheaders = None
+        self.disconnected = False
 
     def clear_last_announcement(self):
         with mininode_lock:
@@ -129,6 +146,12 @@ class BaseNode(NodeConnCB):
 
     def on_pong(self, conn, message):
         self.last_pong = message
+
+    def on_getheaders(self, conn, message):
+        self.last_getheaders = message
+
+    def on_close(self, conn):
+        self.disconnected = True
 
     # Test whether the last announcement we received had the
     # right header or the right inv
@@ -181,11 +204,21 @@ class BaseNode(NodeConnCB):
         self.sync(test_function, timeout)
         return
 
+    def wait_for_getheaders(self, timeout=60):
+        test_function = lambda: self.last_getheaders != None
+        self.sync(test_function, timeout)
+        return
+
     def wait_for_getdata(self, hash_list, timeout=60):
         if hash_list == []:
             return
 
         test_function = lambda: self.last_getdata != None and [x.hash for x in self.last_getdata.inv] == hash_list
+        self.sync(test_function, timeout)
+        return
+
+    def wait_for_disconnect(self, timeout=60):
+        test_function = lambda: self.disconnected
         self.sync(test_function, timeout)
         return
 
@@ -512,6 +545,78 @@ class SendHeadersTest(BitcoinTestFramework):
             assert_equal(test_node.last_getdata, None)
 
         print "Part 4: success!"
+
+        # Now deliver all those blocks we announced.
+        [ test_node.send_message(msg_block(x)) for x in blocks ]
+
+        print("Part 5: Testing handling of unconnecting headers")
+        # First we test that receipt of an unconnecting header doesn't prevent
+        # chain sync.
+        for i in range(10):
+            test_node.last_getdata = None
+            blocks = []
+            # Create two more blocks.
+            for j in range(2):
+                blocks.append(create_block(tip, create_coinbase(height), block_time))
+                blocks[-1].solve()
+                tip = blocks[-1].sha256
+                block_time += 1
+                height += 1
+            # Send the header of the second block -> this won't connect.
+            with mininode_lock:
+                test_node.last_getheaders = None
+            test_node.send_header_for_blocks([blocks[1]])
+            test_node.wait_for_getheaders(timeout=1)
+            test_node.send_header_for_blocks(blocks)
+            test_node.wait_for_getdata([x.sha256 for x in blocks])
+            [ test_node.send_message(msg_block(x)) for x in blocks ]
+            test_node.sync_with_ping()
+            assert_equal(int(self.nodes[0].getbestblockhash(), 16), blocks[1].sha256)
+
+        blocks = []
+        # Now we test that if we repeatedly don't send connecting headers, we
+        # don't go into an infinite loop trying to get them to connect.
+        MAX_UNCONNECTING_HEADERS = 10
+        for j in range(MAX_UNCONNECTING_HEADERS+1):
+            blocks.append(create_block(tip, create_coinbase(height), block_time))
+            blocks[-1].solve()
+            tip = blocks[-1].sha256
+            block_time += 1
+            height += 1
+
+        for i in range(1, MAX_UNCONNECTING_HEADERS):
+            # Send a header that doesn't connect, check that we get a getheaders.
+            with mininode_lock:
+                test_node.last_getheaders = None
+            test_node.send_header_for_blocks([blocks[i]])
+            test_node.wait_for_getheaders(timeout=1)
+
+        # Next header will connect, should re-set our count:
+        test_node.send_header_for_blocks([blocks[0]])
+
+        # Remove the first two entries (blocks[1] would connect):
+        blocks = blocks[2:]
+
+        # Now try to see how many unconnecting headers we can send
+        # before we get disconnected.  Should be 5*MAX_UNCONNECTING_HEADERS
+        for i in range(5*MAX_UNCONNECTING_HEADERS - 1):
+            # Send a header that doesn't connect, check that we get a getheaders.
+            with mininode_lock:
+                test_node.last_getheaders = None
+            test_node.send_header_for_blocks([blocks[i%len(blocks)]])
+            test_node.wait_for_getheaders(timeout=1)
+
+        # Eventually this stops working.
+        with mininode_lock:
+            self.last_getheaders = None
+        test_node.send_header_for_blocks([blocks[-1]])
+
+        # Should get disconnected
+        test_node.wait_for_disconnect()
+        with mininode_lock:
+            self.last_getheaders = True
+
+        print("Part 5: success!")
 
         # Finally, check that the inv node never received a getdata request,
         # throughout the test

--- a/qa/rpc-tests/sendheaders.py
+++ b/qa/rpc-tests/sendheaders.py
@@ -395,10 +395,12 @@ class SendHeadersTest(BitcoinTestFramework):
             test_node.wait_for_block(new_block_hashes[-1])
 
             for i in xrange(3):
-                # Mine another block, still should get only an inv
+                # Mine another block, <strike>still should get only an inv</strike>
+                # XT change: We received header for previous block as a part of the block
+                # download, so we can continue with header announcements.
                 tip = self.mine_blocks(1)
                 assert_equal(inv_node.check_last_announcement(inv=[tip]), True)
-                assert_equal(test_node.check_last_announcement(inv=[tip]), True)
+                assert_equal(test_node.check_last_announcement(headers=[tip]), True)
                 if i == 0:
                     # Just get the data -- shouldn't cause headers announcements to resume
                     test_node.get_data([tip])

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -991,6 +991,20 @@ class msg_mempool(object):
     def __repr__(self):
         return "msg_mempool()"
 
+class msg_sendheaders(object):
+    command = "sendheaders"
+
+    def __init__(self):
+        pass
+
+    def deserialize(self, f):
+        pass
+
+    def serialize(self):
+        return ""
+
+    def __repr__(self):
+        return "msg_sendheaders()"
 
 # getheaders message has
 # number of entries
@@ -1104,6 +1118,28 @@ class NodeConnCB(object):
                 if self.verack_received:
                     return
             time.sleep(0.05)
+
+    # Derived classes should call this function once to set the message map
+    # which associates the derived classes' functions to incoming messages
+    def create_callback_map(self):
+        self.cbmap = {
+            "version": self.on_version,
+            "verack": self.on_verack,
+            "addr": self.on_addr,
+            "alert": self.on_alert,
+            "inv": self.on_inv,
+            "getdata": self.on_getdata,
+            "getblocks": self.on_getblocks,
+            "tx": self.on_tx,
+            "block": self.on_block,
+            "getaddr": self.on_getaddr,
+            "ping": self.on_ping,
+            "pong": self.on_pong,
+            "headers": self.on_headers,
+            "getheaders": self.on_getheaders,
+            "reject": self.on_reject,
+            "mempool": self.on_mempool
+        }
 
     def deliver(self, conn, message):
         with mininode_lock:

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -76,6 +76,7 @@ BITCOIN_CORE_H = \
   amount.h \
   arith_uint256.h \
   base58.h \
+  blockannounce.h \
   blocksender.h \
   bloom.h \
   bloomthin.h \
@@ -194,6 +195,7 @@ libbitcoin_server_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(MINIUPNPC_CP
 libbitcoin_server_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_server_a_SOURCES = \
   addrman.cpp \
+  blockannounce.cpp \
   blocksender.cpp \
   bloom.cpp \
   bloomthin.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -77,6 +77,7 @@ BITCOIN_CORE_H = \
   arith_uint256.h \
   base58.h \
   blockannounce.h \
+  blockheaderprocessor.h \
   blocksender.h \
   bloom.h \
   bloomthin.h \
@@ -196,6 +197,7 @@ libbitcoin_server_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_server_a_SOURCES = \
   addrman.cpp \
   blockannounce.cpp \
+  blockheaderprocessor.cpp \
   blocksender.cpp \
   bloom.cpp \
   bloomthin.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -115,6 +115,7 @@ BITCOIN_CORE_H = \
   miner.h \
   net.h \
   netbase.h \
+  nodestate.h \
   noui.h \
   options.h \
   policy/fees.h \
@@ -294,6 +295,7 @@ libbitcoin_common_a_SOURCES = \
   key.cpp \
   keystore.cpp \
   netbase.cpp \
+  nodestate.cpp \
   primitives/block.cpp \
   primitives/transaction.cpp \
   protocol.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -41,6 +41,7 @@ BITCOIN_TESTS =\
   test/base64_tests.cpp \
   test/bip32_tests.cpp \
   test/block_size_tests.cpp \
+  test/blockannounce_tests.cpp \
   test/blocksender_tests.cpp \
   test/bloom_tests.cpp \
   test/checkblock_tests.cpp \
@@ -80,6 +81,7 @@ BITCOIN_TESTS =\
   test/skiplist_tests.cpp \
   test/test_bitcoin.cpp \
   test/test_bitcoin.h \
+  test/testutil.h \
   test/thinblockbuilder_tests.cpp \
   test/thinblockconcluder_tests.cpp \
   test/thinblockmanager_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -42,6 +42,7 @@ BITCOIN_TESTS =\
   test/bip32_tests.cpp \
   test/block_size_tests.cpp \
   test/blockannounce_tests.cpp \
+  test/blockheaderprocessor_tests.cpp \
   test/blocksender_tests.cpp \
   test/bloom_tests.cpp \
   test/checkblock_tests.cpp \

--- a/src/blockannounce.cpp
+++ b/src/blockannounce.cpp
@@ -11,31 +11,39 @@
 #include "thinblockmanager.h"
 #include "thinblock.h"
 
-bool BlockAnnounceProcessor::isInitialBlockDownload() const {
+bool BlockAnnounceReceiver::isInitialBlockDownload() const {
     return ::IsInitialBlockDownload();
 }
 
-bool BlockAnnounceProcessor::fetchAsThin() const {
+bool BlockAnnounceReceiver::fetchAsThin() const {
     return !isInitialBlockDownload() && Opt().UsingThinBlocks()
         && (from.SupportsBloomThinBlocks() || from.SupportsXThinBlocks());
 }
 
-bool BlockAnnounceProcessor::wantBlock() const {
-    return !mapBlockIndex.count(block);
+bool BlockAnnounceReceiver::blockHeaderIsKnown() const {
+    return mapBlockIndex.count(block);
 }
 
-void BlockAnnounceProcessor::updateBlockAvailability() {
+bool BlockAnnounceReceiver::hasBlockData() const {
+    return mapBlockIndex.count(block)
+        && mapBlockIndex.find(block)->second->nStatus & BLOCK_HAVE_DATA;
+}
+
+void BlockAnnounceReceiver::updateBlockAvailability() {
     ::UpdateBlockAvailability(from.id, block);
 }
 
-bool BlockAnnounceProcessor::almostSynced() {
+bool BlockAnnounceReceiver::almostSynced() {
     return chainActive.Tip()->GetBlockTime() > GetAdjustedTime() - Params().GetConsensus().nPowTargetSpacing * 20;
 }
 
         
-BlockAnnounceProcessor::DownloadStrategy BlockAnnounceProcessor::pickDownloadStrategy() {
+BlockAnnounceReceiver::DownloadStrategy BlockAnnounceReceiver::pickDownloadStrategy() {
 
     if (!almostSynced())
+        return DONT_DOWNL;
+
+    if (hasBlockData())
         return DONT_DOWNL;
 
     if (!fetchAsThin()) {
@@ -75,25 +83,40 @@ BlockAnnounceProcessor::DownloadStrategy BlockAnnounceProcessor::pickDownloadStr
                 from.id, block.ToString());
         return DOWNL_THIN_LATER;
     }
-
     return DOWNL_THIN_NOW;
+}
+
+void requestHeaders(CNode& from, const uint256& block) {
+
+    from.PushMessage("getheaders", chainActive.GetLocator(pindexBestHeader), block);
+    LogPrint("net", "getheaders (%d) %s to peer=%d\n",
+            pindexBestHeader->nHeight, block.ToString(), from.id);
 }
 
 // React to a block announcement.
 //
 // Returns true if we requested the block now from the peer that requested it.
-bool BlockAnnounceProcessor::onBlockAnnounced(std::vector<CInv>& toFetch) {
+bool BlockAnnounceReceiver::onBlockAnnounced(std::vector<CInv>& toFetch,
+        bool announcedAsHeader) {
     AssertLockHeld(cs_main);
 
     updateBlockAvailability();
-
-    if (!wantBlock())
-        return false;
 
     NodeStatePtr nodestate(from.id);
     DownloadStrategy s = pickDownloadStrategy();
     
     if (s == DOWNL_THIN_NOW) {
+
+        if (!announcedAsHeader && nodestate->prefersHeaders) {
+            // Node we're requesting from prefers headers announcement,
+            // but sent us an inv announcement.
+            //
+            // It is likely that we don't have previous blocks,
+            // this block may be part of an reorg. So we request headers to
+            // be sure that we have all headers leading up to this block.
+            requestHeaders(from, block);
+        }
+
         int numDownloading = thinmg.numWorkers(block);
         LogPrint("thin", "requesting %s from peer %d (%d of %d parallel)\n",
             block.ToString(), from.id, (numDownloading + 1), Opt().ThinBlocksMaxParallel());
@@ -113,9 +136,7 @@ bool BlockAnnounceProcessor::onBlockAnnounced(std::vector<CInv>& toFetch) {
     // not a direct successor.
 
     if (!blocksInFlight.isInFlight(block) || !nodestate->initialHeadersReceived) {
-        from.PushMessage("getheaders", chainActive.GetLocator(pindexBestHeader), block);
-        LogPrint("net", "getheaders (%d) %s to peer=%d\n",
-                pindexBestHeader->nHeight, block.ToString(), from.id);
+        requestHeaders(from, block);
     }
     
     if (s == DONT_DOWNL)
@@ -130,4 +151,196 @@ bool BlockAnnounceProcessor::onBlockAnnounced(std::vector<CInv>& toFetch) {
             block.ToString(), from.id);
     toFetch.push_back(CInv(MSG_BLOCK, block));
     return true;
+}
+
+bool blocksConnect(const std::vector<uint256>& blocksToAnnounce) {
+
+    CBlockIndex* best = nullptr;
+
+    for (auto h : blocksToAnnounce) {
+        auto block = mapBlockIndex.find(h)->second;
+        if (!best) {
+            best = block;
+            continue;
+        }
+
+        if (block->pprev != best) {
+            // This means that the list of blocks to announce don't
+            // connect to each other.
+            // This shouldn't really be possible to hit during
+            // regular operation (because reorgs should take us to
+            // a chain that has some block not on the prior chain,
+            // which should be caught by the prior check), but one
+            // way this could happen is by using invalidateblock /
+            // reconsiderblock repeatedly on the tip, causing it to
+            // be added multiple times to vBlockHashesToAnnounce.
+            // Robustly deal with this rare situation by reverting
+            // to an inv.
+            LogPrint("ann", "header announce: blocks don't connect: expected %s, is %s\n",
+                    best->GetBlockHash().ToString(),
+                    block->pprev->GetBlockHash().ToString());
+            return false;
+        }
+        best = block;
+    }
+    return true;
+}
+
+bool BlockAnnounceSender::canAnnounceWithHeaders() const {
+
+    // Set too many blocks to announce. In this corner case
+    // we revert to announcing blocks as inv even though
+    // peer prefers header announcements.
+    if (to.blocksToAnnounce.size() > MAX_BLOCKS_TO_ANNOUNCE)
+        return false;
+
+    if (!NodeStatePtr(to.id)->prefersHeaders)
+        return false;
+
+    // If we come across any
+    // headers that aren't on chainActive, give up.
+    for (auto h : to.blocksToAnnounce) {
+            auto mi = mapBlockIndex.find(h);
+            assert(mi != mapBlockIndex.end());
+            auto block = mi->second;
+            if (chainActive[block->nHeight] != block)
+            {
+                LogPrint("ann", "bailing out from header to peer=%d ann, reorged away from %s\n",
+                        to.id, block->GetBlockHash().ToString());
+                // Bail out if we reorged away from this block
+                return false;
+            }
+    }
+
+    return blocksConnect(to.blocksToAnnounce);
+}
+
+bool BlockAnnounceSender::announceWithHeaders() {
+
+    std::vector<CBlock> headers;
+    bool foundStartingHeader = false;
+
+    CBlockIndex* best = nullptr;
+    for (auto hash : to.blocksToAnnounce) {
+        CBlockIndex* block = mapBlockIndex.find(hash)->second;
+
+        if (foundStartingHeader) {
+            headers.push_back(block->GetBlockHeader());
+            best = block;
+            continue;
+        }
+
+        if (peerHasHeader(block)) {
+            LogPrint("ann", "header ann: peer=%d has header %s\n",
+                    to.id, block->GetBlockHash().ToString());
+            continue; // keep looking for the first new block
+        }
+
+        if (block->pprev == nullptr || peerHasHeader(block->pprev)) {
+            // Peer doesn't have this header but they do have the prior one.
+            // Start sending headers.
+            foundStartingHeader = true;
+            headers.push_back(block->GetBlockHeader());
+            best = block;
+            continue;
+        }
+
+        // Peer doesn't have this header or the prior one -- nothing will
+        // connect, so bail out.
+        LogPrint("ann", "header ann to peer=%d, nothing connects\n",
+                to.id);
+        return false;
+    }
+
+    if (headers.empty())
+        return true;
+
+    LogPrint("net", "%s: %u headers, range (%s, %s), to peer=%d\n", __func__,
+            headers.size(),
+            headers.front().GetHash().ToString(),
+            headers.back().GetHash().ToString(), to.id);
+
+    to.PushMessage("headers", headers);
+    NodeStatePtr(to.id)->bestHeaderSent = best;
+
+    return true;
+}
+
+void BlockAnnounceSender::announce() {
+    LOCK(to.cs_inventory);
+
+    if (to.blocksToAnnounce.empty())
+        return;
+
+    LogPrint("ann", "Announce for peer=%d, %d blocks, prefersheaders: %d\n",
+            to.id, to.blocksToAnnounce.size(), NodeStatePtr(to.id)->prefersHeaders);
+
+    try {
+        if (!(canAnnounceWithHeaders() && announceWithHeaders()))
+            announceWithInv();
+    }
+    catch (const std::exception& e) {
+        LogPrintf("Error when announcing headers to peer %d: %s\n",
+            to.id, e.what());
+    }
+    to.blocksToAnnounce.clear();
+}
+
+void BlockAnnounceSender::announceWithInv() {
+
+    assert(!to.blocksToAnnounce.empty());
+
+    // If falling back to using an inv, just try to inv the tip.
+    // The last entry in vBlockHashesToAnnounce was our tip at some point
+    // in the past.
+
+    const uint256 &hashToAnnounce = to.blocksToAnnounce.back();
+    BlockMap::iterator mi = mapBlockIndex.find(hashToAnnounce);
+    assert(mi != mapBlockIndex.end());
+    CBlockIndex *pindex = mi->second;
+
+    // If the peer announced this block to us, don't inv it back.
+    // (Since block announcements may not be via inv's, we can't solely rely on
+    // setInventoryKnown to track this.)
+    if (!peerHasHeader(pindex)) {
+        to.PushInventory(CInv(MSG_BLOCK, hashToAnnounce));
+        LogPrint("net", "%s: sending inv peer=%d hash=%s\n", __func__,
+                to.id, hashToAnnounce.ToString());
+    }
+}
+
+// Requires cs_main
+bool BlockAnnounceSender::peerHasHeader(const CBlockIndex *block) const {
+    NodeStatePtr state(to.id);
+    if (state->pindexBestKnownBlock
+        && block == state->pindexBestKnownBlock->GetAncestor(block->nHeight))
+        return true;
+
+    if (state->bestHeaderSent
+        && block == state->bestHeaderSent->GetAncestor(block->nHeight))
+        return true;
+
+    return false;
+}
+
+// Find the hashes of all blocks that weren't previously in the best chain.
+std::vector<uint256> findHeadersToAnnounce(const CBlockIndex* oldTip, const CBlockIndex* newTip) {
+
+    std::vector<uint256> hashes;
+    const CBlockIndex* toAnnounce = newTip;
+
+    while (toAnnounce != oldTip) {
+        hashes.push_back(toAnnounce->GetBlockHash());
+        toAnnounce = toAnnounce->pprev;
+
+        if (hashes.size() == MAX_BLOCKS_TO_ANNOUNCE) {
+            // Limit announcements in case of a huge reorganization.
+            // Rely on the peer's synchronization mechanism in that case.
+            break;
+        }
+    }
+
+    // Reverse so that they are in the right order (older block to newest)
+    std::reverse(std::begin(hashes), std::end(hashes));
+    return hashes;
 }

--- a/src/blockannounce.cpp
+++ b/src/blockannounce.cpp
@@ -1,0 +1,133 @@
+// Copyright (c) 2016 The Bitcoin XT developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include "blockannounce.h"
+#include "main.h" // for mapBlockIndex, UpdateBlockAvailability, IsInitialBlockDownload
+#include "options.h"
+#include "timedata.h"
+#include "inflightindex.h"
+#include "nodestate.h"
+#include "util.h"
+#include "thinblockmanager.h"
+#include "thinblock.h"
+
+bool BlockAnnounceProcessor::isInitialBlockDownload() const {
+    return ::IsInitialBlockDownload();
+}
+
+bool BlockAnnounceProcessor::fetchAsThin() const {
+    return !isInitialBlockDownload() && Opt().UsingThinBlocks()
+        && (from.SupportsBloomThinBlocks() || from.SupportsXThinBlocks());
+}
+
+bool BlockAnnounceProcessor::wantBlock() const {
+    return !mapBlockIndex.count(block);
+}
+
+void BlockAnnounceProcessor::updateBlockAvailability() {
+    ::UpdateBlockAvailability(from.id, block);
+}
+
+bool BlockAnnounceProcessor::almostSynced() {
+    return chainActive.Tip()->GetBlockTime() > GetAdjustedTime() - Params().GetConsensus().nPowTargetSpacing * 20;
+}
+
+        
+BlockAnnounceProcessor::DownloadStrategy BlockAnnounceProcessor::pickDownloadStrategy() {
+
+    if (!almostSynced())
+        return DONT_DOWNL;
+
+    if (!fetchAsThin()) {
+    
+        if (blocksInFlight.isInFlight(block))
+            return DONT_DOWNL;
+
+        NodeStatePtr nodestate(from.id);
+        if (nodestate->nBlocksInFlight >= MAX_BLOCKS_IN_TRANSIT_PER_PEER)
+            return DONT_DOWNL;
+
+        if (Opt().AvoidFullBlocks()) {
+            LogPrint("thin", "avoiding full blocks, not requesting %s from %d\n",
+                block.ToString(), from.id);
+
+            return DONT_DOWNL;
+        }
+        
+        return DOWNL_FULL_NOW;
+    }
+
+    // At this point we know we want a thin block.
+
+    NodeStatePtr state(from.id);
+
+    if (!state->initialHeadersReceived)
+        return DOWNL_THIN_LATER;
+
+    if (thinmg.numWorkers(block) >= Opt().ThinBlocksMaxParallel()) {
+        LogPrint("thin", "max parallel thin req reached, not req %s from peer %d\n",
+                block.ToString(), from.id);
+        return DONT_DOWNL;
+    }
+
+    if (!state->thinblock->isAvailable()) {
+        LogPrint("thin", "peer %d is busy, won't req %s\n",
+                from.id, block.ToString());
+        return DOWNL_THIN_LATER;
+    }
+
+    return DOWNL_THIN_NOW;
+}
+
+// React to a block announcement.
+//
+// Returns true if we requested the block now from the peer that requested it.
+bool BlockAnnounceProcessor::onBlockAnnounced(std::vector<CInv>& toFetch) {
+    AssertLockHeld(cs_main);
+
+    updateBlockAvailability();
+
+    if (!wantBlock())
+        return false;
+
+    NodeStatePtr nodestate(from.id);
+    DownloadStrategy s = pickDownloadStrategy();
+    
+    if (s == DOWNL_THIN_NOW) {
+        int numDownloading = thinmg.numWorkers(block);
+        LogPrint("thin", "requesting %s from peer %d (%d of %d parallel)\n",
+            block.ToString(), from.id, (numDownloading + 1), Opt().ThinBlocksMaxParallel());
+
+        nodestate->thinblock->requestBlock(block, toFetch, from);
+        nodestate->thinblock->setToWork(block);
+        return true;
+    }
+
+    // First request the headers preceding the announced block. In the normal fully-synced
+    // case where a new block is announced that succeeds the current tip (no reorganization),
+    // there are no such headers.
+    // Secondly, and only when we are close to being synced, we request the announced block directly,
+    // to avoid an extra round-trip. Note that we must *first* ask for the headers, so by the
+    // time the block arrives, the header chain leading up to it is already validated. Not
+    // doing this will result in the received block being rejected as an orphan in case it is
+    // not a direct successor.
+
+    if (!blocksInFlight.isInFlight(block) || !nodestate->initialHeadersReceived) {
+        from.PushMessage("getheaders", chainActive.GetLocator(pindexBestHeader), block);
+        LogPrint("net", "getheaders (%d) %s to peer=%d\n",
+                pindexBestHeader->nHeight, block.ToString(), from.id);
+    }
+    
+    if (s == DONT_DOWNL)
+        return false;
+
+    if (s == DOWNL_THIN_LATER)
+        return false;
+    
+    assert(s == DOWNL_FULL_NOW);
+
+    LogPrint("thin", "full block download of %s from %d\n",
+            block.ToString(), from.id);
+    toFetch.push_back(CInv(MSG_BLOCK, block));
+    return true;
+}

--- a/src/blockannounce.h
+++ b/src/blockannounce.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2016- The Bitcoin XT developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_BLOCKANNOUNCE_H
+#define BITCOIN_BLOCKANNOUNCE_H
+
+#include "uint256.h"
+#include <vector>
+
+class CInv;
+class CNode;
+class ThinBlockManager;
+class InFlightIndex;
+        
+class BlockAnnounceProcessor {
+
+    public:
+        BlockAnnounceProcessor(uint256 block,
+                CNode& from, ThinBlockManager& thinmg, InFlightIndex& inFlightIndex) : 
+            block(block), from(from), thinmg(thinmg), blocksInFlight(inFlightIndex)
+        {
+        }
+
+        bool onBlockAnnounced(std::vector<CInv>& toFetch);
+        
+        enum DownloadStrategy {
+            DOWNL_THIN_NOW,
+            DOWNL_FULL_NOW,
+            DOWNL_THIN_LATER,
+            DONT_DOWNL,
+            INVALID
+        };
+
+
+    protected:
+        virtual bool almostSynced();
+        virtual void updateBlockAvailability();
+        virtual DownloadStrategy pickDownloadStrategy();
+        virtual bool wantBlock() const;
+        virtual bool isInitialBlockDownload() const;
+       
+
+    private:
+        uint256 block;
+        CNode& from;
+        ThinBlockManager& thinmg;
+        InFlightIndex& blocksInFlight;
+
+        bool fetchAsThin() const;
+};
+
+#endif

--- a/src/blockheaderprocessor.cpp
+++ b/src/blockheaderprocessor.cpp
@@ -1,0 +1,126 @@
+#include "blockheaderprocessor.h"
+#include "blockannounce.h"
+#include "chain.h"
+#include "consensus/validation.h"
+#include "main.h" // Misbehaving, UpdateBlockAvailability
+#include "net.h"
+#include "primitives/block.h"
+#include "util.h"
+#include "inflightindex.h"
+#include "thinblockconcluder.h" // BlockInFlightMarker
+#include <boost/range/adaptor/reversed.hpp>
+
+using namespace std;
+
+DefaultHeaderProcessor::DefaultHeaderProcessor(CNode* pfrom,
+        InFlightIndex& i,
+        ThinBlockManager& mg,
+        BlockInFlightMarker& inFlight,
+        std::function<void()> checkBlockIndex) :
+    pfrom(pfrom), blocksInFlight(i), thinmg(mg),
+    markAsInFlight(inFlight), checkBlockIndex(checkBlockIndex) { }
+
+// maybeAnnouncement: Header *might* have been received as a block announcement.
+bool DefaultHeaderProcessor::operator()(const std::vector<CBlockHeader>& headers,
+        bool peerSentMax,
+        bool maybeAnnouncement)
+{
+    CBlockIndex *pindexLast = nullptr;
+    for (const CBlockHeader& header : headers) {
+        CValidationState state;
+        if (pindexLast != nullptr && header.hashPrevBlock != pindexLast->GetBlockHash()) {
+            Misbehaving(pfrom->GetId(), 20);
+            return error("non-continuous headers sequence");
+        }
+        if (!AcceptBlockHeader(header, state, &pindexLast)) {
+            int nDoS;
+            if (state.IsInvalid(nDoS)) {
+                if (nDoS > 0)
+                    Misbehaving(pfrom->GetId(), nDoS);
+                return error("invalid header received");
+            }
+        }
+    }
+
+    if (pindexLast)
+        UpdateBlockAvailability(pfrom->GetId(), pindexLast->GetBlockHash());
+
+    if (peerSentMax && pindexLast) {
+        // Headers message had its maximum size; the peer may have more headers.
+        // TODO: optimize: if pindexLast is an ancestor of chainActive.Tip or pindexBestHeader, continue
+        // from there instead.
+        LogPrint("net", "more getheaders (%d) to end to peer=%d (startheight:%d)\n", pindexLast->nHeight, pfrom->id, pfrom->nStartingHeight);
+        pfrom->PushMessage("getheaders", chainActive.GetLocator(pindexLast), uint256());
+    }
+
+    if (pindexLast && maybeAnnouncement) {
+        std::vector<CBlockIndex*> toFetch = findMissingBlocks(pindexLast);
+
+        // We may or may not start downloading the blocks
+        // from this peer now.
+        suggestDownload(toFetch, pindexLast);
+    }
+
+    checkBlockIndex();
+    return true;
+}
+
+std::vector<CBlockIndex*> DefaultHeaderProcessor::findMissingBlocks(CBlockIndex* last) {
+    assert(last);
+
+    vector<CBlockIndex*> toFetch;
+    CBlockIndex* walk = last;
+
+    // Calculate all the blocks we'd need to switch to last, up to a limit.
+    do {
+        if (toFetch.size() == MAX_BLOCKS_IN_TRANSIT_PER_PEER)
+            break;
+
+        if (chainActive.Contains(walk))
+            break;
+
+        if (walk->nStatus & BLOCK_HAVE_DATA)
+            continue;
+
+        if (blocksInFlight.isInFlight(walk->GetBlockHash()))
+            continue;
+
+        // We don't have this block, and it's not yet in flight.
+        toFetch.push_back(walk);
+
+    } while ((walk = walk->pprev));
+
+    return toFetch;
+}
+
+bool DefaultHeaderProcessor::hasEqualOrMoreWork(CBlockIndex* last) {
+    return last->IsValid(BLOCK_VALID_TREE)
+        && chainActive.Tip()->nChainWork <= last->nChainWork;
+}
+
+void DefaultHeaderProcessor::suggestDownload(const std::vector<CBlockIndex*>& toFetch, CBlockIndex* last) {
+    std::vector<CInv> toGet;
+
+    if (!hasEqualOrMoreWork(last))
+        return;
+
+    for (auto b : boost::adaptors::reverse(toFetch)) {
+
+        BlockAnnounceReceiver ann(b->GetBlockHash(),
+                *pfrom, thinmg, blocksInFlight);
+
+        // Stop if we don't want to download this block now.
+        // Won't want next.
+        if (!ann.onBlockAnnounced(toGet, true))
+            break;
+
+        // This block has been requested from peer.
+        markAsInFlight(pfrom->id, b->GetBlockHash(), Params().GetConsensus(), nullptr);
+    }
+
+    if (!toGet.empty()) {
+        LogPrint("net", "Downloading blocks toward %s (%d) via headers direct fetch\n",
+                last->GetBlockHash().ToString(), last->nHeight);
+        pfrom->PushMessage("getdata", toGet);
+    }
+}

--- a/src/blockheaderprocessor.h
+++ b/src/blockheaderprocessor.h
@@ -1,0 +1,49 @@
+#ifndef BITCOIN_BLOCKHEDERPROCESSOR_H
+
+#include <vector>
+#include <functional>
+
+class CNode;
+class CBlockHeader;
+class CBlockIndex;
+class InFlightIndex;
+class ThinBlockManager;
+class BlockInFlightMarker;
+
+class BlockHeaderProcessor {
+    public:
+        virtual bool operator()(const std::vector<CBlockHeader>& headers,
+                bool peerSentMax,
+                bool maybeAnnouncement) = 0;
+        virtual ~BlockHeaderProcessor() = 0;
+};
+inline BlockHeaderProcessor::~BlockHeaderProcessor() { }
+
+class DefaultHeaderProcessor : public BlockHeaderProcessor {
+    public:
+
+        DefaultHeaderProcessor(CNode* pfrom,
+                InFlightIndex&, ThinBlockManager&, BlockInFlightMarker&,
+                std::function<void()> checkBlockIndex);
+
+        virtual bool operator()(const std::vector<CBlockHeader>& headers,
+                bool peerSentMax,
+                bool maybeAnnouncement) override;
+
+    private:
+
+        std::vector<CBlockIndex*> findMissingBlocks(CBlockIndex* last);
+
+        bool hasEqualOrMoreWork(CBlockIndex* last);
+        void suggestDownload(
+                const std::vector<CBlockIndex*>& toFetch, CBlockIndex* last);
+
+
+        CNode* pfrom;
+        InFlightIndex& blocksInFlight;
+        ThinBlockManager& thinmg;
+        BlockInFlightMarker& markAsInFlight;
+        std::function<void()> checkBlockIndex;
+};
+
+#endif

--- a/src/blockheaderprocessor.h
+++ b/src/blockheaderprocessor.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 #include <functional>
+#include <tuple>
 
 class CNode;
 class CBlockHeader;
@@ -24,11 +25,16 @@ class DefaultHeaderProcessor : public BlockHeaderProcessor {
 
         DefaultHeaderProcessor(CNode* pfrom,
                 InFlightIndex&, ThinBlockManager&, BlockInFlightMarker&,
-                std::function<void()> checkBlockIndex);
+                std::function<void()> checkBlockIndex,
+                std::function<void()> sendGetHeaders = [](){ });
 
-        virtual bool operator()(const std::vector<CBlockHeader>& headers,
+        bool operator()(const std::vector<CBlockHeader>& headers,
                 bool peerSentMax,
                 bool maybeAnnouncement) override;
+
+    protected:
+        virtual std::tuple<bool, CBlockIndex*> acceptHeaders(
+                const std::vector<CBlockHeader>& headers);
 
     private:
 
@@ -38,12 +44,12 @@ class DefaultHeaderProcessor : public BlockHeaderProcessor {
         void suggestDownload(
                 const std::vector<CBlockIndex*>& toFetch, CBlockIndex* last);
 
-
         CNode* pfrom;
         InFlightIndex& blocksInFlight;
         ThinBlockManager& thinmg;
         BlockInFlightMarker& markAsInFlight;
         std::function<void()> checkBlockIndex;
+        std::function<void()> sendGetHeaders;
 };
 
 #endif

--- a/src/blocksender.h
+++ b/src/blocksender.h
@@ -24,7 +24,7 @@ class BlockSender {
             CBlockIndex *pindexBestHeader);
 
         void send(const CChain& activeChain, CNode& node,
-            const CBlockIndex& blockIndex, const CInv& inv);
+            CBlockIndex& blockIndex, const CInv& inv);
 
         void sendBlock(CNode& node,
             const CBlockIndex& blockIndex, int invType);
@@ -33,7 +33,6 @@ class BlockSender {
         // from a thin block.
         void sendReReqReponse(CNode& node, const CBlockIndex& blockIndex,
             const XThinReRequest& req);
-
 
     protected: // used in unit tests
         void triggerNextRequest(const CChain& activeChain, const CInv& inv, CNode& node);

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -51,6 +51,9 @@ CBlockLocator CChain::GetLocator(const CBlockIndex *pindex) const {
 }
 
 const CBlockIndex *CChain::FindFork(const CBlockIndex *pindex) const {
+    if (!pindex)
+        return nullptr;
+
     if (pindex->nHeight > Height())
         pindex = pindex->GetAncestor(Height());
     while (pindex && !Contains(pindex))

--- a/src/inflightindex.h
+++ b/src/inflightindex.h
@@ -25,10 +25,11 @@ typedef std::list<QueuedBlock>::iterator QueuedBlockPtr;
 
 // Keeps track of blocks in flight.
 struct InFlightIndex {
+    virtual ~InFlightIndex() { }
     void erase(const QueuedBlockPtr& ptr);
     void erase(NodeId nodeid, const uint256& block);
     void insert(const QueuedBlockPtr& queued);
-    bool isInFlight(const uint256& block) const;
+    virtual bool isInFlight(const uint256& block) const;
     std::set<NodeId> nodesWithQueued(const uint256& block) const;
     std::vector<QueuedBlockPtr> queuedPtrsFor(const uint256& block) const;
     QueuedBlockPtr queuedItem(NodeId, const uint256& block) const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,11 +13,11 @@
 #include "checkpoints.h"
 #include "checkqueue.h"
 #include "consensus/validation.h"
-#include "dummythin.h"
 #include "inflightindex.h"
 #include "init.h"
 #include "merkleblock.h"
 #include "net.h"
+#include "nodestate.h"
 #include "options.h"
 #include "pow.h"
 #include "process_merkleblock.h"
@@ -275,130 +275,6 @@ ThinBlockManager thinblockmg(
 
 namespace {
 
-struct CBlockReject {
-    unsigned char chRejectCode;
-    string strRejectReason;
-    uint256 hashBlock;
-};
-
-/**
- * Maintain validation-specific state about nodes, protected by cs_main, instead
- * by CNode's own locks. This simplifies asynchronous operation, where
- * processing of incoming data is done after the ProcessMessage call returns,
- * and we're no longer holding the node's locks.
- */
-struct CNodeState {
-    //! The peer's address
-    CService address;
-    //! Whether we have a fully established connection.
-    bool fCurrentlyConnected;
-    //! Accumulated misbehaviour score for this peer.
-    int nMisbehavior;
-    //! Whether this peer should be disconnected and banned (unless whitelisted).
-    bool fShouldBan;
-    //! String name of this peer (debugging/logging purposes).
-    std::string name;
-    //! List of asynchronously-determined block rejections to notify this peer about.
-    std::vector<CBlockReject> rejects;
-    //! The best known block we know this peer has announced.
-    CBlockIndex *pindexBestKnownBlock;
-    //! The hash of the last unknown block this peer has announced.
-    uint256 hashLastUnknownBlock;
-    //! The last full block we both have.
-    CBlockIndex *pindexLastCommonBlock;
-    //! Whether we've started headers synchronization with this peer.
-    bool fSyncStarted;
-    //! Since when we're stalling block download progress (in microseconds), or 0.
-    int64_t nStallingSince;
-    list<QueuedBlock> vBlocksInFlight;
-    int nBlocksInFlight;
-    int nBlocksInFlightValidHeaders;
-    //! Whether we consider this a preferred download peer.
-    bool fPreferredDownload;
-
-    // we need to receive headers leading to a block, before we can
-    // request a block.
-    bool initialHeadersReceived;
-
-    //! the thin block the node is currently providing to us
-    boost::shared_ptr<ThinBlockWorker> thinblock;
-    std::set<uint256> recentThinBlockTx;
-
-    CNodeState(NodeId id) {
-        fCurrentlyConnected = false;
-        nMisbehavior = 0;
-        fShouldBan = false;
-        pindexBestKnownBlock = NULL;
-        hashLastUnknownBlock.SetNull();
-        pindexLastCommonBlock = NULL;
-        fSyncStarted = false;
-        nStallingSince = 0;
-        nBlocksInFlight = 0;
-        nBlocksInFlightValidHeaders = 0;
-        fPreferredDownload = false;
-        initialHeadersReceived = false;
-        thinblock.reset(new DummyThinWorker(thinblockmg, id));
-    }
-};
-
-// Class that maintains per-node state, and
-// acts as a RAII smart-pointer that make sure
-// the state stays consistent.
-class NodeStatePtr {
-private:
-    static CCriticalSection cs_mapNodeState;
-    static map<NodeId, CNodeState> mapNodeState;
-    CNodeState* s;
-    NodeId id;
-public:
-    static void insert(NodeId nodeid, const CNode *pnode) {
-        LOCK(cs_mapNodeState);
-        CNodeState &state = mapNodeState.insert(std::make_pair(nodeid, CNodeState(nodeid))).first->second;
-        state.name = pnode->addrName;
-        state.address = pnode->addr;
-    }
-
-    NodeStatePtr(NodeId nodeid) {
-        LOCK(cs_mapNodeState);
-        map<NodeId, CNodeState>::iterator it = mapNodeState.find(nodeid);
-        if (it == mapNodeState.end())
-            s = NULL;
-        else {
-            s = &it->second;
-            id = nodeid;
-            cs_mapNodeState.lock();
-        }
-    }
-    ~NodeStatePtr() {
-        if (s)
-            cs_mapNodeState.unlock();
-    }
-    bool IsNull() const { return s == NULL; }
-
-    CNodeState* operator ->() { return s; }
-    const CNodeState* operator ->() const { return s; }
-
-    void erase() {
-        if (s) {
-            mapNodeState.erase(id);
-            s = NULL;
-            cs_mapNodeState.unlock();
-        }
-    }
-
-    static void clear() {
-        LOCK(cs_mapNodeState);
-        mapNodeState.clear();
-    }
-
-private:
-    // disallow copy/assignment
-    NodeStatePtr(const NodeStatePtr&) {}
-    NodeStatePtr& operator=(const NodeStatePtr& p) { return *this; }
-};
-CCriticalSection NodeStatePtr::cs_mapNodeState;
-map<NodeId, CNodeState> NodeStatePtr::mapNodeState;
-
 int GetHeight()
 {
     LOCK(cs_main);
@@ -422,7 +298,7 @@ int64_t GetBlockTimeout(int64_t nTime, int nValidatedQueuedBefore, const Consens
 }
 
 void InitializeNode(NodeId nodeid, const CNode *pnode) {
-    NodeStatePtr::insert(nodeid, pnode);
+    NodeStatePtr::insert(nodeid, pnode, thinblockmg);
 }
 
 void FinalizeNode(NodeId nodeid) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,7 @@
 #include "undo.h"
 #include "util.h"
 #include "utilmoneystr.h"
+#include "utilprocessmsg.h"
 #include "validationinterface.h"
 #include "xthin.h"
 #include "versionbits.h"
@@ -5291,9 +5292,13 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
 
         NodeStatePtr(pfrom->id)->initialHeadersReceived = true;
 
+        auto sendGetHeaders = [pfrom](){
+            pfrom->PushMessage("getheaders",
+                    chainActive.GetLocator(pindexBestHeader), uint256());
+        };
         MarkBlockAsInFlight inFlight;
         DefaultHeaderProcessor p(pfrom, blocksInFlight, thinblockmg, inFlight,
-                CheckBlockIndex);
+                CheckBlockIndex, sendGetHeaders);
         if (!p(headers, nCount == MAX_HEADERS_RESULTS, true))
             return false;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5927,7 +5927,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
             vInvWait.reserve(pto->vInventoryToSend.size());
             BOOST_FOREACH(const CInv& inv, pto->vInventoryToSend)
             {
-                if (pto->filterInventoryKnown.contains(inv.hash))
+                if (inv.type == MSG_TX && pto->filterInventoryKnown.contains(inv.hash))
                     continue;
 
                 // trickle out tx inv to protect privacy
@@ -5948,15 +5948,13 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
                     }
                 }
 
-                if (!pto->filterInventoryKnown.contains(inv.hash))
+                pto->filterInventoryKnown.insert(inv.hash);
+
+                vInv.push_back(inv);
+                if (vInv.size() >= 1000)
                 {
-                    pto->filterInventoryKnown.insert(inv.hash);
-                    vInv.push_back(inv);
-                    if (vInv.size() >= 1000)
-                    {
-                        pto->PushMessage("inv", vInv);
-                        vInv.clear();
-                    }
+                    pto->PushMessage("inv", vInv);
+                    vInv.clear();
                 }
             }
             pto->vInventoryToSend = vInvWait;

--- a/src/main.h
+++ b/src/main.h
@@ -239,6 +239,8 @@ void UnlinkPrunedFiles(std::set<int>& setFilesToPrune);
 
 /** Create a new block index entry for a given block hash */
 CBlockIndex * InsertBlockIndex(uint256 hash);
+/** Update tracking information about which blocks a peer is assumed to have. */
+void UpdateBlockAvailability(NodeId nodeid, const uint256 &hash);
 /** Get statistics from node state */
 bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats);
 /** Increase a node's misbehavior score. */

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2190,8 +2190,6 @@ bool CNode::SupportsBloomThinBlocks() const {
     if (!SupportsBloom())
         return false;
 
-    const int SENDHEADERS_VERSION = 70012;
-
     // Bitcoin Core removed filterInventoryKnown filtering in 0.12,
     // causing those nodes to send us all transactions in a block.
     //

--- a/src/net.h
+++ b/src/net.h
@@ -437,8 +437,9 @@ public:
     {
         {
             LOCK(cs_inventory);
-            if (!filterInventoryKnown.contains(inv.hash))
-                vInventoryToSend.push_back(inv);
+            if (inv.type == MSG_TX && filterInventoryKnown.contains(inv.hash))
+                return;
+            vInventoryToSend.push_back(inv);
         }
     }
 

--- a/src/net.h
+++ b/src/net.h
@@ -331,6 +331,10 @@ public:
     CCriticalSection cs_inventory;
     std::multimap<int64_t, CInv> mapAskFor;
 
+    // Used for headers announcements - unfiltered blocks to relay
+    // Also protected by cs_inventory
+    std::vector<uint256> blocksToAnnounce;
+
     // Ping time measurement:
     // The pong reply we're expecting, or 0 if no pong expected.
     uint64_t nPingNonceSent;
@@ -441,6 +445,12 @@ public:
                 return;
             vInventoryToSend.push_back(inv);
         }
+    }
+
+    void PushBlockHash(const uint256 &hash)
+    {
+        LOCK(cs_inventory);
+        blocksToAnnounce.push_back(hash);
     }
 
     void AskFor(const CInv& inv);

--- a/src/nodestate.cpp
+++ b/src/nodestate.cpp
@@ -1,0 +1,30 @@
+#include "nodestate.h"
+#include "dummythin.h"
+#include "net.h" // for CNode
+
+CNodeState::CNodeState(NodeId id, ThinBlockManager& thinblockmg) {
+    fCurrentlyConnected = false;
+    nMisbehavior = 0;
+    fShouldBan = false;
+    pindexBestKnownBlock = NULL;
+    hashLastUnknownBlock.SetNull();
+    pindexLastCommonBlock = NULL;
+    fSyncStarted = false;
+    nStallingSince = 0;
+    nBlocksInFlight = 0;
+    nBlocksInFlightValidHeaders = 0;
+    fPreferredDownload = false;
+    initialHeadersReceived = false;
+    thinblock.reset(new DummyThinWorker(thinblockmg, id));
+}
+
+CCriticalSection NodeStatePtr::cs_mapNodeState;
+std::map<NodeId, CNodeState> NodeStatePtr::mapNodeState;
+
+void NodeStatePtr::insert(NodeId nodeid, const CNode *pnode, ThinBlockManager& thinblockmg) {
+    LOCK(cs_mapNodeState);
+    CNodeState &state = mapNodeState.insert(std::make_pair(
+                nodeid, CNodeState(nodeid, thinblockmg))).first->second;
+    state.name = pnode->addrName;
+    state.address = pnode->addr;
+}

--- a/src/nodestate.cpp
+++ b/src/nodestate.cpp
@@ -9,11 +9,13 @@ CNodeState::CNodeState(NodeId id, ThinBlockManager& thinblockmg) {
     pindexBestKnownBlock = NULL;
     hashLastUnknownBlock.SetNull();
     pindexLastCommonBlock = NULL;
+    bestHeaderSent = nullptr;
     fSyncStarted = false;
     nStallingSince = 0;
     nBlocksInFlight = 0;
     nBlocksInFlightValidHeaders = 0;
     fPreferredDownload = false;
+    prefersHeaders = false;
     initialHeadersReceived = false;
     thinblock.reset(new DummyThinWorker(thinblockmg, id));
 }

--- a/src/nodestate.cpp
+++ b/src/nodestate.cpp
@@ -10,6 +10,7 @@ CNodeState::CNodeState(NodeId id, ThinBlockManager& thinblockmg) {
     hashLastUnknownBlock.SetNull();
     pindexLastCommonBlock = NULL;
     bestHeaderSent = nullptr;
+    unconnectingHeaders = 0;
     fSyncStarted = false;
     nStallingSince = 0;
     nBlocksInFlight = 0;

--- a/src/nodestate.h
+++ b/src/nodestate.h
@@ -57,6 +57,8 @@ struct CNodeState {
     CBlockIndex *pindexLastCommonBlock;
     //! The best header we have sent our peer.
     CBlockIndex *bestHeaderSent;
+    //! Length of current-streak of unconnecting headers announcements
+    int unconnectingHeaders;
     //! Whether we've started headers synchronization with this peer.
     bool fSyncStarted;
     //! Since when we're stalling block download progress (in microseconds), or 0.

--- a/src/nodestate.h
+++ b/src/nodestate.h
@@ -55,6 +55,8 @@ struct CNodeState {
     uint256 hashLastUnknownBlock;
     //! The last full block we both have.
     CBlockIndex *pindexLastCommonBlock;
+    //! The best header we have sent our peer.
+    CBlockIndex *bestHeaderSent;
     //! Whether we've started headers synchronization with this peer.
     bool fSyncStarted;
     //! Since when we're stalling block download progress (in microseconds), or 0.
@@ -64,6 +66,9 @@ struct CNodeState {
     int nBlocksInFlightValidHeaders;
     //! Whether we consider this a preferred download peer.
     bool fPreferredDownload;
+
+    //! Whether this peer wants invs or headers (when possible) for block announcements.
+    bool prefersHeaders;
 
     // we need to receive headers leading to a block, before we can
     // request a block.

--- a/src/nodestate.h
+++ b/src/nodestate.h
@@ -1,0 +1,130 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin Core developers
+// Copyright (c) 2016 The Bitcoin XT developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_NODESTATE_H
+#define BITCOIN_NODESTATE_H
+
+#include "netbase.h" // CService
+#include "uint256.h"
+#include "inflightindex.h" // QueuedBlock
+#include "sync.h" // CCriticalSection
+
+#include <boost/shared_ptr.hpp>
+
+#include <string>
+#include <set>
+#include <map>
+#include <list>
+
+class CBlockIndex;
+class CNode;
+class ThinBlockWorker;
+class ThinBlockManager;
+typedef int NodeId;
+
+struct CBlockReject {
+    unsigned char chRejectCode;
+    std::string strRejectReason;
+    uint256 hashBlock;
+};
+
+/**
+ * Maintain validation-specific state about nodes, protected by cs_main, instead
+ * by CNode's own locks. This simplifies asynchronous operation, where
+ * processing of incoming data is done after the ProcessMessage call returns,
+ * and we're no longer holding the node's locks.
+ */
+struct CNodeState {
+    //! The peer's address
+    CService address;
+    //! Whether we have a fully established connection.
+    bool fCurrentlyConnected;
+    //! Accumulated misbehaviour score for this peer.
+    int nMisbehavior;
+    //! Whether this peer should be disconnected and banned (unless whitelisted).
+    bool fShouldBan;
+    //! String name of this peer (debugging/logging purposes).
+    std::string name;
+    //! List of asynchronously-determined block rejections to notify this peer about.
+    std::vector<CBlockReject> rejects;
+    //! The best known block we know this peer has announced.
+    CBlockIndex *pindexBestKnownBlock;
+    //! The hash of the last unknown block this peer has announced.
+    uint256 hashLastUnknownBlock;
+    //! The last full block we both have.
+    CBlockIndex *pindexLastCommonBlock;
+    //! Whether we've started headers synchronization with this peer.
+    bool fSyncStarted;
+    //! Since when we're stalling block download progress (in microseconds), or 0.
+    int64_t nStallingSince;
+    std::list<QueuedBlock> vBlocksInFlight;
+    int nBlocksInFlight;
+    int nBlocksInFlightValidHeaders;
+    //! Whether we consider this a preferred download peer.
+    bool fPreferredDownload;
+
+    // we need to receive headers leading to a block, before we can
+    // request a block.
+    bool initialHeadersReceived;
+
+    //! the thin block the node is currently providing to us
+    boost::shared_ptr<ThinBlockWorker> thinblock;
+    std::set<uint256> recentThinBlockTx;
+
+    CNodeState(NodeId id, ThinBlockManager&);
+};
+
+// Class that maintains per-node state, and
+// acts as a RAII smart-pointer that make sure
+// the state stays consistent.
+class NodeStatePtr {
+private:
+    static CCriticalSection cs_mapNodeState;
+    static std::map<NodeId, CNodeState> mapNodeState;
+    CNodeState* s;
+    NodeId id;
+public:
+    static void insert(NodeId nodeid, const CNode *pnode, ThinBlockManager&);
+
+    NodeStatePtr(NodeId nodeid) {
+        LOCK(cs_mapNodeState);
+        std::map<NodeId, CNodeState>::iterator it = mapNodeState.find(nodeid);
+        if (it == mapNodeState.end())
+            s = NULL;
+        else {
+            s = &it->second;
+            id = nodeid;
+            cs_mapNodeState.lock();
+        }
+    }
+    ~NodeStatePtr() {
+        if (s)
+            cs_mapNodeState.unlock();
+    }
+    bool IsNull() const { return s == NULL; }
+
+    CNodeState* operator ->() { return s; }
+    const CNodeState* operator ->() const { return s; }
+
+    void erase() {
+        if (s) {
+            mapNodeState.erase(id);
+            s = NULL;
+            cs_mapNodeState.unlock();
+        }
+    }
+
+    static void clear() {
+        LOCK(cs_mapNodeState);
+        mapNodeState.clear();
+    }
+
+private:
+    // disallow copy/assignment
+    NodeStatePtr(const NodeStatePtr&) {}
+    NodeStatePtr& operator=(const NodeStatePtr& p) { return *this; }
+};
+
+#endif

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -69,6 +69,28 @@ int64_t Opt::CheckpointDays() {
     return std::max(int64_t(1), Args->GetArg("-checkpoint-days", def));
 }
 
+bool Opt::UsingThinBlocks() {
+    if (IsStealthMode())
+        return false;
+    return Args->GetBool("-use-thin-blocks", true);
+}
+
+/// Don't request blocks from nodes hat don't support thin blocks.
+bool Opt::AvoidFullBlocks() {
+    return Args->GetArg("-use-thin-blocks", 1) == 2
+        || Args->GetArg("-use-thin-blocks", 1) == 3;
+}
+
+// Makes only outbound connection to xthin-supporting nodes.
+// Implicitly enables "avoid full blocks".
+bool Opt::XThinBlocksOnly() {
+    return Args->GetArg("-use-thin-blocks", 1) == 3;
+}
+
+int Opt::ThinBlocksMaxParallel() {
+    return Args->GetArg("-thin-blocks-max-parallel", 3);
+}
+
 std::unique_ptr<ArgReset> SetDummyArgGetter(std::unique_ptr<ArgGetter> getter) {
     Args.reset(getter.release());
     return std::unique_ptr<ArgReset>(new ArgReset);

--- a/src/options.h
+++ b/src/options.h
@@ -14,6 +14,12 @@ struct Opt {
     std::vector<std::string> UAComment(bool validate = false);
     int ScriptCheckThreads();
     int64_t CheckpointDays();
+
+    // Thin block options
+    bool UsingThinBlocks();
+    bool AvoidFullBlocks();
+    bool XThinBlocksOnly();
+    int ThinBlocksMaxParallel();
 };
 
 /** Maximum number of script-checking threads allowed */

--- a/src/process_merkleblock.cpp
+++ b/src/process_merkleblock.cpp
@@ -54,7 +54,7 @@ void ProcessMerkleBlock(CNode& pfrom, CDataStream& vRecv,
     }
 
     std::vector<CBlockHeader> headers(1, merkleBlock.header);
-    if (!processHeader(headers, false)) {
+    if (!processHeader(headers, false, false)) {
         LogPrint("thin", "Header failed for merkleblock peer=%d\n", pfrom.id);
         worker.setAvailable();
         return;

--- a/src/process_merkleblock.cpp
+++ b/src/process_merkleblock.cpp
@@ -1,4 +1,5 @@
 #include "process_merkleblock.h"
+#include "blockheaderprocessor.h"
 #include "bloomthin.h"
 #include "consensus/validation.h"
 #include "main.h" // Misbehaving, mapBlockIndex

--- a/src/process_xthinblock.cpp
+++ b/src/process_xthinblock.cpp
@@ -1,4 +1,5 @@
 #include "process_xthinblock.h"
+#include "blockheaderprocessor.h"
 #include "consensus/validation.h"
 #include "main.h" // Misbehaving, mapBlockIndex
 #include "thinblock.h"

--- a/src/process_xthinblock.cpp
+++ b/src/process_xthinblock.cpp
@@ -23,7 +23,7 @@ void XThinBlockProcessor::operator()(
 
     try {
         block.selfValidate();
-        if (!processHeader(std::vector<CBlockHeader>(1, block.header), false))
+        if (!processHeader(std::vector<CBlockHeader>(1, block.header), false, false))
             throw std::invalid_argument("invalid header");
     }
     catch (const std::invalid_argument& e) {

--- a/src/test/blockannounce_tests.cpp
+++ b/src/test/blockannounce_tests.cpp
@@ -1,0 +1,355 @@
+// Copyright (c) 2016- The Bitcoin XT developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <boost/test/unit_test.hpp>
+#include "test/testutil.h"
+#include "blockannounce.h"
+#include "inflightindex.h"
+#include "test/thinblockutil.h"
+#include "options.h"
+#include "xthin.h"
+#include "dummythin.h"
+
+struct DummyBlockAnnounceProcessor : public BlockAnnounceProcessor {
+
+    DummyBlockAnnounceProcessor(uint256 block,
+            CNode& from, ThinBlockManager& thinmg, InFlightIndex& inFlightIndex) : 
+        BlockAnnounceProcessor(block, from, thinmg, inFlightIndex),
+        updateCalled(0), 
+        isAlmostSynced(true),
+        overrideStrategy(BlockAnnounceProcessor::INVALID)
+    {
+    }
+    
+    void updateBlockAvailability() override {
+        ++updateCalled;
+    }
+        
+    bool almostSynced() override {
+        return isAlmostSynced;
+    }
+
+    DownloadStrategy pickDownloadStrategy() override {
+        return overrideStrategy != INVALID
+            ? overrideStrategy
+            : BlockAnnounceProcessor::pickDownloadStrategy();
+    }
+        
+    bool wantBlock() const override {
+        return BlockAnnounceProcessor::wantBlock();
+    }
+        
+    bool isInitialBlockDownload() const override {
+        return false;
+    }
+
+    int updateCalled;
+    bool isAlmostSynced;
+    DownloadStrategy overrideStrategy;
+};
+
+struct DummyInFlightIndex : public InFlightIndex {
+    DummyInFlightIndex() : InFlightIndex(), blockInFlight(false) { }
+    virtual bool isInFlight(const uint256& block) const override {
+        return blockInFlight;
+    }
+    bool blockInFlight;
+
+};
+
+struct BlockAnnounceFixture {
+    BlockAnnounceFixture() : 
+        block(uint256S("0xF00BAA")),
+        thinmg(GetDummyThinBlockMg()),
+        node(42, thinmg.get()),
+        ann(block, node, *thinmg, inFlightIndex),
+        nodestate(node.id)
+    {
+        SelectParams(CBaseChainParams::MAIN);
+        nodestate->initialHeadersReceived = true;
+    }
+
+    uint256 block;
+    std::unique_ptr<ThinBlockManager> thinmg;
+    DummyNode node;
+    DummyInFlightIndex inFlightIndex;
+    DummyBlockAnnounceProcessor ann;
+    NodeStatePtr nodestate;
+};
+
+BOOST_FIXTURE_TEST_SUITE(blockannounce_tests, BlockAnnounceFixture);
+
+BOOST_AUTO_TEST_CASE(want_block) {
+    
+    // We have not seen the block before. We want it.
+    BOOST_CHECK(ann.wantBlock());
+
+    // We have block, we don't want it.
+    DummyBlockIndexEntry entry(block);
+    BOOST_CHECK(!ann.wantBlock());
+}
+
+BOOST_AUTO_TEST_CASE(announce_updates_availability) {
+
+    std::vector<CInv> toFetch;
+    
+    ann.onBlockAnnounced(toFetch);
+    BOOST_CHECK_EQUAL(1, ann.updateCalled);
+
+    // Availability should also be called when we don't want block.
+    DummyBlockIndexEntry entry(block); //< we have block (we don't want it)
+    ann.onBlockAnnounced(toFetch);
+    BOOST_CHECK_EQUAL(2, ann.updateCalled);
+}
+
+BOOST_AUTO_TEST_CASE(fetch_when_wanted) {
+
+    {   // We want block.
+        std::vector<CInv> toFetch;
+        BOOST_CHECK(ann.onBlockAnnounced(toFetch));
+        BOOST_CHECK(!toFetch.empty());
+    }
+
+    {   // We have block (we don't want it)
+        std::vector<CInv> toFetch;
+        DummyBlockIndexEntry entry(block); 
+        BOOST_CHECK(!ann.onBlockAnnounced(toFetch));
+        BOOST_CHECK_EQUAL(0, toFetch.size());
+    }
+}
+
+const int NOT_SET = std::numeric_limits<int>::min();
+
+struct DummyArgGetter : public ArgGetter {
+
+    DummyArgGetter() : ArgGetter(),
+        usethin(NOT_SET), maxparallel(NOT_SET)
+    {
+    }
+
+    virtual int64_t GetArg(const std::string& arg, int64_t def) {
+        if (arg == "-use-thin-blocks")
+            return usethin == NOT_SET ? def : usethin;
+        if (arg == "-thin-blocks-max-parallel")
+            return maxparallel == NOT_SET ? def : maxparallel;
+        return def;
+    }
+    virtual std::vector<std::string> GetMultiArgs(const std::string& arg) {
+        assert(false);
+    }
+    virtual bool GetBool(const std::string& arg, bool def) {
+        if (arg == "-use-thin-blocks")
+            return usethin == NOT_SET ? def : bool(usethin);
+        return def;
+    }
+    int usethin;
+    int maxparallel;
+};
+
+BOOST_AUTO_TEST_CASE(dowl_strategy_full_now) {
+    
+    // Peer does not support thin blocks and we are almost synced.
+    node.nServices = 0;
+
+    BOOST_CHECK_EQUAL(
+            BlockAnnounceProcessor::DOWNL_FULL_NOW, 
+            ann.pickDownloadStrategy());
+
+    // Node supports thin, but thin is disabled.
+    std::unique_ptr<DummyArgGetter> arg(new DummyArgGetter);
+    DummyArgGetter* argPtr = arg.get();
+    std::unique_ptr<ArgReset> argraii
+        = SetDummyArgGetter(std::unique_ptr<ArgGetter>(arg.release()));
+
+    node.nServices = NODE_THIN;
+    argPtr->usethin = 0;
+    BOOST_CHECK_EQUAL(
+            BlockAnnounceProcessor::DOWNL_FULL_NOW, 
+            ann.pickDownloadStrategy());
+}
+
+BOOST_AUTO_TEST_CASE(downl_strategy_thin_later) {
+
+    // Node supports thin blocks, but we have not
+    // received any headers from node yet. We may not have
+    // caught up on its longest chain. Download thin later.
+    node.nServices = NODE_THIN;
+    nodestate->initialHeadersReceived = false;
+    BOOST_CHECK_EQUAL(
+            BlockAnnounceProcessor::DOWNL_THIN_LATER,
+            ann.pickDownloadStrategy());
+}
+
+
+BOOST_AUTO_TEST_CASE(dowl_strategy_thin_later_2) {
+
+    // Thin supports sending thin blocks but is busy. Request later.
+    node.nServices = NODE_THIN;
+
+    // By default DummyNode uses DummyThinWorker. 
+    // DummyThinWorker always returns false for isAvailable().
+    BOOST_ASSERT(!nodestate->thinblock->isAvailable());
+
+
+    BOOST_CHECK_EQUAL(
+            BlockAnnounceProcessor::DOWNL_THIN_LATER,
+            ann.pickDownloadStrategy());
+}
+
+BOOST_AUTO_TEST_CASE(dowl_strategy_dont_downl_1) {
+
+    // If we have requested block from max number of nodes
+    // then don't download.
+    
+    // Set max parallel to 1
+    auto arg(new DummyArgGetter);
+    std::unique_ptr<ArgReset> argraii
+        = SetDummyArgGetter(std::unique_ptr<ArgGetter>(arg));
+    arg->maxparallel = 1;
+    BOOST_CHECK_EQUAL(1, Opt().ThinBlocksMaxParallel());
+
+    // Put one node to work
+    DummyNode node2(11, thinmg.get());
+    NodeStatePtr state2(node2.id);
+    state2->initialHeadersReceived = true;
+    state2->thinblock.reset(new XThinWorker(*thinmg, node2.id));
+    state2->thinblock->setToWork(block);
+    BOOST_CHECK_EQUAL(1, thinmg->numWorkers(block));
+
+    // Second one should not attempt to download on announcement.
+    nodestate->thinblock.reset(new XThinWorker(*thinmg, node.id));
+    node.nServices = NODE_THIN;
+    
+    BOOST_CHECK_EQUAL(BlockAnnounceProcessor::DONT_DOWNL,
+            ann.pickDownloadStrategy());
+}
+
+BOOST_AUTO_TEST_CASE(dowl_strategy_dont_downl_2) {
+    // Don't download announced block unless we are close to
+    // catching up to the longest chain.
+    
+    ann.isAlmostSynced = false;
+    BOOST_CHECK_EQUAL(BlockAnnounceProcessor::DONT_DOWNL, ann.pickDownloadStrategy());
+}
+
+BOOST_AUTO_TEST_CASE(dowl_strategy_dont_dowl_3) {
+    // Don't download a block that is already in flight.
+    
+    node.nServices &= ~NODE_THIN;
+
+    inFlightIndex.blockInFlight = true;
+    BOOST_CHECK_EQUAL(BlockAnnounceProcessor::DONT_DOWNL,
+            ann.pickDownloadStrategy());
+}
+
+BOOST_AUTO_TEST_CASE(dowl_strategy_dont_dowl_4) {
+    
+    // Don't download a block from a peer that has
+    // many blocks queued up.
+    
+    nodestate->nBlocksInFlight = MAX_BLOCKS_IN_TRANSIT_PER_PEER;
+    BOOST_CHECK_EQUAL(BlockAnnounceProcessor::DONT_DOWNL,
+            ann.pickDownloadStrategy());
+}
+
+BOOST_AUTO_TEST_CASE(dowl_strategy_dont_dowl_5) {
+    
+    // Don't download a full block from a peer if we
+    // are configured to avoid full block downloads.
+    
+    node.nServices &= ~NODE_THIN;
+    
+    auto arg = new DummyArgGetter;
+    auto argraii = SetDummyArgGetter(std::unique_ptr<ArgGetter>(arg));
+    arg->usethin = 3; // xthin only, avoid full blocks
+
+    BOOST_CHECK_EQUAL(BlockAnnounceProcessor::DONT_DOWNL,
+            ann.pickDownloadStrategy());
+}
+
+/// Helper class to check if request block is called.
+struct RequestBlockWorker : public DummyThinWorker {
+    RequestBlockWorker(ThinBlockManager& mg, NodeId id)
+        : DummyThinWorker(mg, id), reqs(0) { }
+    
+    void requestBlock(const uint256& block,
+        std::vector<CInv>& getDataReq, CNode& node) override { 
+        ++reqs;
+    }
+    int reqs;
+};
+
+
+BOOST_AUTO_TEST_CASE(onannounced_downl_thin) {
+    // Test that onBlockAnnounced requests a thin block
+    // with DOWL_THIN_NOW strategy.
+
+    ann.overrideStrategy = BlockAnnounceProcessor::DOWNL_THIN_NOW;
+
+    auto worker = new RequestBlockWorker(*thinmg, node.id);
+    nodestate->thinblock.reset(worker); //<- takes ownership of ptr
+    
+    std::vector<CInv> r;
+    BOOST_CHECK(ann.onBlockAnnounced(r));
+    BOOST_CHECK_EQUAL(1, worker->reqs);
+
+    // thin blocks come with a header, we should not
+    // have requested headers.
+    BOOST_CHECK_EQUAL(0, node.messages.size());
+}
+
+BOOST_AUTO_TEST_CASE(onannounced_downl_full) {
+    // Test that onBlockAnnounced requests a full block
+    // with DOWL_FULL_NOW strategy.
+    
+    ann.overrideStrategy = BlockAnnounceProcessor::DOWNL_FULL_NOW;
+    
+    std::vector<CInv> toFetch;
+    BOOST_CHECK(ann.onBlockAnnounced(toFetch));
+    BOOST_CHECK_EQUAL(1, toFetch.size());
+    BOOST_CHECK_EQUAL(block.ToString(), toFetch.at(0).hash.ToString());
+
+    // Should also have requested headers.
+    BOOST_CHECK_EQUAL("getheaders", node.messages.at(0));
+}
+
+BOOST_AUTO_TEST_CASE(onannounced_dont_downl) {
+    // Test that onBlockAnnounced does not request anything 
+    // with DONT_DOWNL strategy.
+
+    ann.overrideStrategy = BlockAnnounceProcessor::DONT_DOWNL;
+
+    auto worker = new RequestBlockWorker(*thinmg, node.id);
+    nodestate->thinblock.reset(worker); //<- takes ownership of ptr
+    
+    std::vector<CInv> toFetch;
+    BOOST_CHECK(!ann.onBlockAnnounced(toFetch));
+    BOOST_CHECK_EQUAL(0, worker->reqs);
+    BOOST_CHECK_EQUAL(0, toFetch.size());
+
+    // If we don't download, we should still ask for the header.
+    BOOST_ASSERT(node.messages.size() > 0);
+    BOOST_CHECK_EQUAL("getheaders", node.messages.at(0));
+}
+
+BOOST_AUTO_TEST_CASE(onannounced_dowl_thin_later) {
+    // Test that onBlockAnnounced does not request anything 
+    // with DOWL_THIN_LATER strategy.
+
+    ann.overrideStrategy = BlockAnnounceProcessor::DOWNL_THIN_LATER;
+
+    auto worker = new RequestBlockWorker(*thinmg, node.id);
+    nodestate->thinblock.reset(worker); //<- takes ownership of ptr
+    
+    std::vector<CInv> toFetch;
+    BOOST_CHECK(!ann.onBlockAnnounced(toFetch));
+    BOOST_CHECK_EQUAL(0, worker->reqs);
+    BOOST_CHECK_EQUAL(0, toFetch.size());
+
+    // If we don't download, we should still ask for the header.
+    BOOST_ASSERT(node.messages.size() > 0);
+    BOOST_CHECK_EQUAL("getheaders", node.messages.at(0));
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/test/blockheaderprocessor_tests.cpp
+++ b/src/test/blockheaderprocessor_tests.cpp
@@ -1,0 +1,75 @@
+// Copyright (c) 2016- The Bitcoin XT developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <boost/test/unit_test.hpp>
+#include "blockheaderprocessor.h"
+#include "test/thinblockutil.h" // DummyNode
+#include "test/testutil.h"
+
+BOOST_AUTO_TEST_SUITE(blockheaderprocessor_tests);
+
+class DefaultHeaderProcessorDummy : public DefaultHeaderProcessor {
+    public:
+
+        DefaultHeaderProcessorDummy(CNode* pfrom,
+                InFlightIndex& i, ThinBlockManager& tm, BlockInFlightMarker& m,
+                std::function<void()> checkBlockIndex,
+                std::function<void()> sendGetHeaders) :
+            DefaultHeaderProcessor(pfrom, i, tm, m, checkBlockIndex, sendGetHeaders)
+        {
+        }
+
+        std::tuple<bool, CBlockIndex*> acceptHeaders(
+                const std::vector<CBlockHeader>& headers) override
+        {
+            return std::make_tuple(true, nullptr);
+        }
+};
+
+BOOST_AUTO_TEST_CASE(test_connect_chain_req) {
+
+    // Header does not connect, should
+    // send a getheaders to connect and stop processing headers.
+
+    bool checkBlockCalled = false;
+    auto checkBlockFunc = [&checkBlockCalled]() {
+        checkBlockCalled = true;
+    };
+
+    bool sendGetHeadersCalled = false;
+    auto sendGetHeadersFunc = [&sendGetHeadersCalled]() {
+        sendGetHeadersCalled = true;
+    };
+
+    DummyNode from;
+    auto thinmg = GetDummyThinBlockMg();
+    InFlightIndex inFlight;
+    DummyMarkAsInFlight markAsInFlight;
+
+    DefaultHeaderProcessorDummy processHeader(&from, inFlight, *thinmg,
+        markAsInFlight, checkBlockFunc, sendGetHeadersFunc);
+
+    // Try to process a header that does not connect
+    DummyBlockIndexEntry e1(uint256S("0xaaa"));
+    DummyBlockIndexEntry e2(uint256S("0xbbb"));
+
+    CBlockHeader header;
+    header.hashPrevBlock = uint256S("0xccc"); //< prev block not in mapBlockIndex
+    processHeader({ header }, false, true);
+
+    BOOST_CHECK(sendGetHeadersCalled);
+    BOOST_CHECK(!checkBlockCalled);
+    BOOST_CHECK_EQUAL(1, NodeStatePtr(from.id)->unconnectingHeaders);
+
+    // Add entry so that header connects. Try again.
+    sendGetHeadersCalled = false;
+    checkBlockCalled = false;
+
+    DummyBlockIndexEntry e3(header.hashPrevBlock);
+    processHeader({ header }, false, true);
+    BOOST_CHECK(!sendGetHeadersCalled);
+    BOOST_CHECK(checkBlockCalled);
+    BOOST_CHECK_EQUAL(0, NodeStatePtr(from.id)->unconnectingHeaders);
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/test/processmessage_tests.cpp
+++ b/src/test/processmessage_tests.cpp
@@ -1,4 +1,5 @@
 #include "test/thinblockutil.h"
+#include "blockheaderprocessor.h"
 #include "bloom.h"
 #include "bloomthin.h"
 #include "chain.h"
@@ -10,7 +11,6 @@
 #include "process_xthinblock.h"
 #include "testutil.h"
 #include "util.h" // for fPrintToDebugLog
-#include "utilprocessmsg.h"
 #include "xthin.h"
 #include <boost/test/unit_test_suite.hpp>
 #include <boost/test/test_tools.hpp>

--- a/src/test/processmessage_tests.cpp
+++ b/src/test/processmessage_tests.cpp
@@ -4,28 +4,16 @@
 #include "chain.h"
 #include "chainparams.h"
 #include "inflightindex.h"
-#include "main.h"
 #include "merkleblock.h"
 #include "net.h"
 #include "process_merkleblock.h"
 #include "process_xthinblock.h"
+#include "testutil.h"
 #include "util.h" // for fPrintToDebugLog
 #include "utilprocessmsg.h"
 #include "xthin.h"
 #include <boost/test/unit_test_suite.hpp>
 #include <boost/test/test_tools.hpp>
-
-struct DummyBlockIndexEntry {
-DummyBlockIndexEntry(const uint256& hash) : hash(hash) {
-    index.nStatus = BLOCK_HAVE_DATA;
-    mapBlockIndex.insert(std::make_pair(hash, &index));
-    }
-    ~DummyBlockIndexEntry() {
-        mapBlockIndex.erase(hash);
-    }
-    CBlockIndex index;
-    uint256 hash;
-};
 
 template <class WORKER_TYPE>
 struct DummyWorker : public WORKER_TYPE {

--- a/src/test/processmessage_tests.cpp
+++ b/src/test/processmessage_tests.cpp
@@ -36,7 +36,7 @@ struct DummyHeaderProcessor : public BlockHeaderProcessor {
 
     DummyHeaderProcessor() : headerOK(true), called(false) { }
 
-    bool operator()(const std::vector<CBlockHeader>&, bool) {
+    bool operator()(const std::vector<CBlockHeader>&, bool, bool) override {
         called = true;
         return headerOK;
     }

--- a/src/test/testutil.h
+++ b/src/test/testutil.h
@@ -1,0 +1,18 @@
+#ifndef BITCOIN_TESTUTIL_H
+#define BITCOIN_TESTUTIL_H
+
+#include "main.h"
+
+struct DummyBlockIndexEntry {
+DummyBlockIndexEntry(const uint256& hash) : hash(hash) {
+    index.nStatus = BLOCK_HAVE_DATA;
+    mapBlockIndex.insert(std::make_pair(hash, &index));
+    }
+    ~DummyBlockIndexEntry() {
+        mapBlockIndex.erase(hash);
+    }
+    CBlockIndex index;
+    uint256 hash;
+};
+
+#endif

--- a/src/test/testutil.h
+++ b/src/test/testutil.h
@@ -6,6 +6,7 @@
 struct DummyBlockIndexEntry {
 DummyBlockIndexEntry(const uint256& hash) : hash(hash) {
     index.nStatus = BLOCK_HAVE_DATA;
+    index.phashBlock = &this->hash;
     mapBlockIndex.insert(std::make_pair(hash, &index));
     }
     ~DummyBlockIndexEntry() {

--- a/src/test/thinblockconcluder_tests.cpp
+++ b/src/test/thinblockconcluder_tests.cpp
@@ -11,18 +11,6 @@
 #include "xthin.h"
 #include <memory>
 
-struct DummyMarkAsInFlight : public BlockInFlightMarker {
-
-    virtual void operator()(
-        NodeId nodeid, const uint256& hash,
-        const Consensus::Params& consensusParams,
-        CBlockIndex *pindex)
-    {
-        block = hash;
-    }
-    uint256 block;
-};
-
 struct DummyBloomConcluder : public BloomBlockConcluder {
 
     DummyBloomConcluder() :

--- a/src/test/thinblockmanager_tests.cpp
+++ b/src/test/thinblockmanager_tests.cpp
@@ -9,12 +9,6 @@
 #include "chainparams.h"
 #include <memory>
 
-std::unique_ptr<ThinBlockManager> GetMg() {
-    return std::unique_ptr<ThinBlockManager>(new ThinBlockManager(
-        std::unique_ptr<ThinBlockFinishedCallb>(new DummyFinishedCallb),
-        std::unique_ptr<InFlightEraser>(new DummyInFlightEraser)));
-}
-
 // Workaround for segfaulting
 struct Workaround {
     Workaround() {
@@ -25,7 +19,7 @@ struct Workaround {
 BOOST_FIXTURE_TEST_SUITE(thinblockmanager_tests, Workaround);
 
 BOOST_AUTO_TEST_CASE(add_and_del_worker) {
-    std::unique_ptr<ThinBlockManager> mg = GetMg();
+    std::unique_ptr<ThinBlockManager> mg = GetDummyThinBlockMg();
 
     std::unique_ptr<ThinBlockWorker> worker(new XThinWorker(*mg, 42));
 

--- a/src/test/thinblockutil.cpp
+++ b/src/test/thinblockutil.cpp
@@ -24,4 +24,8 @@ CBlock TestBlock2() {
     return block;
 }
 
-
+std::unique_ptr<ThinBlockManager> GetDummyThinBlockMg() {
+    return std::unique_ptr<ThinBlockManager>(new ThinBlockManager(
+        std::unique_ptr<ThinBlockFinishedCallb>(new DummyFinishedCallb),
+        std::unique_ptr<InFlightEraser>(new DummyInFlightEraser)));
+}

--- a/src/test/thinblockutil.h
+++ b/src/test/thinblockutil.h
@@ -2,14 +2,18 @@
 #define BITCOIN_THINBLOCKUTIL_H
 
 #include "net.h"
-#include "thinblockmanager.h"
 #include "thinblock.h"
+#include "nodestate.h"
+#include "thinblockmanager.h"
+#include "protocol.h"
+#include <memory>
 
 class CBlock;
 
 // Utils for thin block related unit tests
 CBlock TestBlock1();
 CBlock TestBlock2();
+std::unique_ptr<ThinBlockManager> GetDummyThinBlockMg();
 
 struct NullFinder : public TxFinder {
     virtual CTransaction operator()(const ThinTx& hash) const {
@@ -18,9 +22,16 @@ struct NullFinder : public TxFinder {
 };
 
 struct DummyNode : public CNode {
-    DummyNode() : CNode(INVALID_SOCKET, CAddress()) {
-        id = 42;
+    DummyNode(NodeId myid = 42, ThinBlockManager* mgr = nullptr) : CNode(INVALID_SOCKET, CAddress()) {
+        static auto staticmgr = GetDummyThinBlockMg();
+        if (!mgr)
+            mgr = staticmgr.get();
+
+        id = myid;
+        NodeStatePtr::insert(id, this, *mgr);
+        nVersion = PROTOCOL_VERSION;
     }
+    virtual ~DummyNode() { NodeStatePtr(id).erase(); }
     virtual void BeginMessage(const char* pszCommand) EXCLUSIVE_LOCK_FUNCTION(cs_vSend) {
         messages.push_back(pszCommand);
         CNode::BeginMessage(pszCommand);
@@ -36,6 +47,5 @@ struct DummyFinishedCallb : public ThinBlockFinishedCallb {
 struct DummyInFlightEraser : public InFlightEraser {
     virtual void operator()(NodeId, const uint256& hash) { }
 };
-
 
 #endif

--- a/src/test/thinblockutil.h
+++ b/src/test/thinblockutil.h
@@ -6,6 +6,7 @@
 #include "nodestate.h"
 #include "thinblockmanager.h"
 #include "protocol.h"
+#include "utilprocessmsg.h"
 #include <memory>
 
 class CBlock;
@@ -47,5 +48,18 @@ struct DummyFinishedCallb : public ThinBlockFinishedCallb {
 struct DummyInFlightEraser : public InFlightEraser {
     virtual void operator()(NodeId, const uint256& hash) { }
 };
+
+struct DummyMarkAsInFlight : public BlockInFlightMarker {
+
+    virtual void operator()(
+        NodeId nodeid, const uint256& hash,
+        const Consensus::Params& consensusParams,
+        CBlockIndex *pindex)
+    {
+        block = hash;
+    }
+    uint256 block;
+};
+
 
 #endif

--- a/src/thinblockconcluder.cpp
+++ b/src/thinblockconcluder.cpp
@@ -6,6 +6,7 @@
 #include "chainparams.h"
 #include "main.h" // For Misbehaving
 #include "xthin.h"
+#include "utilprocessmsg.h"
 #include <vector>
 
 

--- a/src/thinblockconcluder.h
+++ b/src/thinblockconcluder.h
@@ -43,15 +43,6 @@ struct BloomBlockConcluder {
         BlockInFlightMarker& markInFlight;
 };
 
-struct BlockInFlightMarker {
-    virtual ~BlockInFlightMarker() = 0;
-    virtual void operator()(
-        NodeId nodeid, const uint256& hash,
-        const Consensus::Params& consensusParams,
-        CBlockIndex *pindex) = 0;
-};
-inline BlockInFlightMarker::~BlockInFlightMarker() { }
-
 // Finishes a block using response from a transaction re-request.
 struct XThinBlockConcluder {
     void operator()(const XThinReReqResponse& resp,

--- a/src/utilprocessmsg.h
+++ b/src/utilprocessmsg.h
@@ -12,7 +12,8 @@ bool HaveBlockData(const uint256& hash);
 class BlockHeaderProcessor {
 public:
     // returns false on error
-    virtual bool operator()(const std::vector<CBlockHeader>& headers, bool peerSentMax) = 0;
+    virtual bool operator()(const std::vector<CBlockHeader>& headers,
+            bool peerSentMax, bool maybeAnnouncement) = 0;
 
     virtual ~BlockHeaderProcessor() = 0;
 };

--- a/src/utilprocessmsg.h
+++ b/src/utilprocessmsg.h
@@ -5,7 +5,20 @@
 class uint256;
 class CNode;
 class CBlockHeader;
+class CBlockIndex;
+namespace Consensus { struct Params; }
+
+typedef int NodeId;
 
 bool HaveBlockData(const uint256& hash);
+
+struct BlockInFlightMarker {
+    virtual ~BlockInFlightMarker() = 0;
+    virtual void operator()(
+        NodeId nodeid, const uint256& hash,
+        const Consensus::Params& consensusParams,
+        CBlockIndex* pindex) = 0;
+};
+inline BlockInFlightMarker::~BlockInFlightMarker() { }
 
 #endif

--- a/src/utilprocessmsg.h
+++ b/src/utilprocessmsg.h
@@ -8,15 +8,4 @@ class CBlockHeader;
 
 bool HaveBlockData(const uint256& hash);
 
-// Process received block header.
-class BlockHeaderProcessor {
-public:
-    // returns false on error
-    virtual bool operator()(const std::vector<CBlockHeader>& headers,
-            bool peerSentMax, bool maybeAnnouncement) = 0;
-
-    virtual ~BlockHeaderProcessor() = 0;
-};
-inline BlockHeaderProcessor::~BlockHeaderProcessor() { }
-
 #endif

--- a/src/version.h
+++ b/src/version.h
@@ -9,7 +9,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70011;
+static const int PROTOCOL_VERSION = 70012;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -36,5 +36,8 @@ static const int MEMPOOL_GD_VERSION = 60002;
 
 //! "filter*" commands are disabled without NODE_BLOOM in Bitcoin Core after and including this version
 static const int NO_BLOOM_VERSION = 70011;
+
+//! "sendheaders" command and announcing blocks with headers starts with this version
+static const int SENDHEADERS_VERSION = 70012;
 
 #endif // BITCOIN_VERSION_H


### PR DESCRIPTION
Further work on #137. Incorporates #148 because I wanted to use C++11.

This work is based on @sdaftuar work in Bitcoin Core PR #6494 (9fa8c48).
This work is based on @dgenr8 cherry picks in Bitcoin XT #137
    
This implements BIP130. This implementation is a refactor/rewrite on previous work done in Bitcoin Core.
    
This work supports headersfirst together with thin blocks. It is refactored to support unittests, and unittests have been written for most of the logic.