### PR TITLE
Compact blocks (BIP152)

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -38,6 +38,7 @@ testScripts=(
     'p2p-versionbits-warning.py'
     'decodescript.py'
     'sendheaders.py'
+    'p2p-compactblocks.py'
 );
 testScriptsExt=(
     'bigblocks.py'

--- a/qa/rpc-tests/p2p-compactblocks.py
+++ b/qa/rpc-tests/p2p-compactblocks.py
@@ -237,6 +237,8 @@ class CompactBlocksTest(BitcoinTestFramework):
         for i in range(num_transactions):
             self.nodes[0].sendtoaddress(address, 0.1)
 
+        self.test_node.sync_with_ping()
+
         # Now mine a block, and look at the resulting compact block.
         self.test_node.clear_block_announcement()
         block_hash = int(self.nodes[0].generate(1)[0], 16)

--- a/qa/rpc-tests/p2p-compactblocks.py
+++ b/qa/rpc-tests/p2p-compactblocks.py
@@ -1,0 +1,608 @@
+#!/usr/bin/env python3
+# Copyright (c) 2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.mininode import *
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from test_framework.blocktools import create_block, create_coinbase
+from test_framework.siphash import siphash256
+from test_framework.script import CScript, OP_TRUE
+
+'''
+CompactBlocksTest -- test compact blocks (BIP 152)
+'''
+
+
+# TestNode: A peer we use to send messages to bitcoind, and store responses.
+class TestNode(SingleNodeConnCB):
+    def __init__(self):
+        SingleNodeConnCB.__init__(self)
+        self.last_sendcmpct = None
+        self.last_headers = None
+        self.last_inv = None
+        self.last_cmpctblock = None
+        self.block_announced = False
+        self.last_getdata = None
+        self.last_getblocktxn = None
+        self.last_block = None
+        self.last_blocktxn = None
+
+    def on_sendcmpct(self, conn, message):
+        self.last_sendcmpct = message
+
+    def on_block(self, conn, message):
+        self.last_block = message
+
+    def on_cmpctblock(self, conn, message):
+        self.last_cmpctblock = message
+        self.block_announced = True
+
+    def on_headers(self, conn, message):
+        self.last_headers = message
+        self.block_announced = True
+
+    def on_inv(self, conn, message):
+        self.last_inv = message
+        self.block_announced = True
+
+    def on_getdata(self, conn, message):
+        self.last_getdata = message
+
+    def on_getblocktxn(self, conn, message):
+        self.last_getblocktxn = message
+
+    def on_blocktxn(self, conn, message):
+        self.last_blocktxn = message
+
+    # Requires caller to hold mininode_lock
+    def received_block_announcement(self):
+        return self.block_announced
+
+    def clear_block_announcement(self):
+        with mininode_lock:
+            self.block_announced = False
+            self.last_inv = None
+            self.last_headers = None
+            self.last_cmpctblock = None
+
+    def get_headers(self, locator, hashstop):
+        msg = msg_getheaders()
+        msg.locator.vHave = locator
+        msg.hashstop = hashstop
+        self.connection.send_message(msg)
+
+    def send_header_for_blocks(self, new_blocks):
+        headers_message = msg_headers()
+        headers_message.headers = [CBlockHeader(b) for b in new_blocks]
+        self.send_message(headers_message)
+
+
+class CompactBlocksTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.utxos = []
+
+    def setup_network(self):
+        self.nodes = []
+
+        # Turn off segwit in this test, as compact blocks don't currently work
+        # with segwit.  (After BIP 152 is updated to support segwit, we can
+        # test behavior with and without segwit enabled by adding a second node
+        # to the test.)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [["-debug", "-logtimemicros=1", "-bip9params=segwit:0:0"]])
+
+    def build_block_on_tip(self):
+        height = self.nodes[0].getblockcount()
+        tip = self.nodes[0].getbestblockhash()
+        mtp = self.nodes[0].getblockheader(tip)['mediantime']
+        block = create_block(int(tip, 16), create_coinbase(height + 1), mtp + 1)
+        block.solve()
+        return block
+
+    # Create 10 more anyone-can-spend utxo's for testing.
+    def make_utxos(self):
+        block = self.build_block_on_tip()
+        self.test_node.send_and_ping(msg_block(block))
+        assert(int(self.nodes[0].getbestblockhash(), 16) == block.sha256)
+        self.nodes[0].generate(100)
+
+        total_value = block.vtx[0].vout[0].nValue
+        out_value = total_value // 10
+        tx = CTransaction()
+        tx.vin.append(CTxIn(COutPoint(block.vtx[0].sha256, 0), b''))
+        for i in range(10):
+            tx.vout.append(CTxOut(out_value, CScript([OP_TRUE])))
+        tx.rehash()
+
+        block2 = self.build_block_on_tip()
+        block2.vtx.append(tx)
+        block2.hashMerkleRoot = block2.calc_merkle_root()
+        block2.solve()
+        self.test_node.send_and_ping(msg_block(block2))
+        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block2.sha256)
+        self.utxos.extend([[tx.sha256, i, out_value] for i in range(10)])
+        return
+
+    # Test "sendcmpct":
+    # - No compact block announcements or getdata(MSG_CMPCT_BLOCK) unless
+    #   sendcmpct is sent.
+    # - If sendcmpct is sent with version > 0, the message is ignored.
+    # - If sendcmpct is sent with boolean 0, then block announcements are not
+    #   made with compact blocks.
+    # - If sendcmpct is then sent with boolean 1, then new block announcements
+    #   are made with compact blocks.
+    def test_sendcmpct(self):
+        print("Testing SENDCMPCT p2p message... ")
+
+        # Make sure we get a version 0 SENDCMPCT message from our peer
+        def received_sendcmpct():
+            return (self.test_node.last_sendcmpct is not None)
+        got_message = wait_until(received_sendcmpct, timeout=30)
+        assert(got_message)
+        assert_equal(self.test_node.last_sendcmpct.version, 1)
+
+        tip = int(self.nodes[0].getbestblockhash(), 16)
+
+        def check_announcement_of_new_block(node, peer, predicate):
+            self.test_node.clear_block_announcement()
+            node.generate(1)
+            got_message = wait_until(peer.received_block_announcement, timeout=30)
+            assert(got_message)
+            with mininode_lock:
+                assert(predicate)
+
+        # We shouldn't get any block announcements via cmpctblock yet.
+        check_announcement_of_new_block(self.nodes[0], self.test_node, lambda: self.test_node.last_cmpctblock is None)
+
+        # Try one more time, this time after requesting headers.
+        self.test_node.clear_block_announcement()
+        self.test_node.get_headers(locator=[tip], hashstop=0)
+        wait_until(self.test_node.received_block_announcement, timeout=30)
+        self.test_node.clear_block_announcement()
+
+        check_announcement_of_new_block(self.nodes[0], self.test_node, lambda: self.test_node.last_cmpctblock is None and self.test_node.last_inv is not None)
+
+        # Now try a SENDCMPCT message with too-high version
+        sendcmpct = msg_sendcmpct()
+        sendcmpct.version = 2
+        self.test_node.send_message(sendcmpct)
+
+        check_announcement_of_new_block(self.nodes[0], self.test_node, lambda: self.test_node.last_cmpctblock is None)
+
+        # Now try a SENDCMPCT message with valid version, but announce=False
+        self.test_node.send_message(msg_sendcmpct())
+        check_announcement_of_new_block(self.nodes[0], self.test_node, lambda: self.test_node.last_cmpctblock is None)
+
+        # Finally, try a SENDCMPCT message with announce=True
+        sendcmpct.version = 1
+        sendcmpct.announce = True
+        self.test_node.send_message(sendcmpct)
+        check_announcement_of_new_block(self.nodes[0], self.test_node, lambda: self.test_node.last_cmpctblock is not None)
+
+        # Try one more time
+        check_announcement_of_new_block(self.nodes[0], self.test_node, lambda: self.test_node.last_cmpctblock is not None)
+
+        # Try one more time, after turning on sendheaders
+        self.test_node.send_message(msg_sendheaders())
+        check_announcement_of_new_block(self.nodes[0], self.test_node, lambda: self.test_node.last_cmpctblock is not None)
+
+        # Now turn off announcements
+        sendcmpct.announce = False
+        check_announcement_of_new_block(self.nodes[0], self.test_node, lambda: self.test_node.last_cmpctblock is None and self.test_node.last_headers is not None)
+
+    # This test actually causes bitcoind to (reasonably!) disconnect us, so do this last.
+    def test_invalid_cmpctblock_message(self):
+        print("Testing invalid index in cmpctblock message...")
+        self.nodes[0].generate(101)
+        block = self.build_block_on_tip()
+
+        cmpct_block = P2PHeaderAndShortIDs()
+        cmpct_block.header = CBlockHeader(block)
+        cmpct_block.prefilled_txn_length = 1
+        # This index will be too high
+        prefilled_txn = PrefilledTransaction(1, block.vtx[0])
+        cmpct_block.prefilled_txn = [prefilled_txn]
+        self.test_node.send_and_ping(msg_cmpctblock(cmpct_block))
+        assert(int(self.nodes[0].getbestblockhash(), 16) == block.hashPrevBlock)
+
+    # Compare the generated shortids to what we expect based on BIP 152, given
+    # bitcoind's choice of nonce.
+    def test_compactblock_construction(self):
+        print("Testing compactblock headers and shortIDs are correct...")
+
+        # Generate a bunch of transactions.
+        self.nodes[0].generate(101)
+        num_transactions = 25
+        address = self.nodes[0].getnewaddress()
+        for i in range(num_transactions):
+            self.nodes[0].sendtoaddress(address, 0.1)
+
+        # Now mine a block, and look at the resulting compact block.
+        self.test_node.clear_block_announcement()
+        block_hash = int(self.nodes[0].generate(1)[0], 16)
+
+        # Store the raw block in our internal format.
+        block = FromHex(CBlock(), self.nodes[0].getblock("%02x" % block_hash, False))
+        [tx.calc_sha256() for tx in block.vtx]
+        block.rehash()
+
+        # Don't care which type of announcement came back for this test; just
+        # request the compact block if we didn't get one yet.
+        wait_until(self.test_node.received_block_announcement, timeout=30)
+
+        with mininode_lock:
+            if self.test_node.last_cmpctblock is None:
+                self.test_node.clear_block_announcement()
+                inv = CInv(4, block_hash)  # 4 == "CompactBlock"
+                self.test_node.send_message(msg_getdata([inv]))
+
+        wait_until(self.test_node.received_block_announcement, timeout=30)
+
+        # Now we should have the compactblock
+        header_and_shortids = None
+        with mininode_lock:
+            assert(self.test_node.last_cmpctblock is not None)
+            # Convert the on-the-wire representation to absolute indexes
+            header_and_shortids = HeaderAndShortIDs(self.test_node.last_cmpctblock.header_and_shortids)
+
+        # Check that we got the right block!
+        header_and_shortids.header.calc_sha256()
+        assert_equal(header_and_shortids.header.sha256, block_hash)
+
+        # Make sure the prefilled_txn appears to have included the coinbase
+        assert(len(header_and_shortids.prefilled_txn) >= 1)
+        assert_equal(header_and_shortids.prefilled_txn[0].index, 0)
+
+        # Check that all prefilled_txn entries match what's in the block.
+        for entry in header_and_shortids.prefilled_txn:
+            entry.tx.calc_sha256()
+            assert_equal(entry.tx.sha256, block.vtx[entry.index].sha256)
+
+        # Check that the cmpctblock message announced all the transactions.
+        assert_equal(len(header_and_shortids.prefilled_txn) + len(header_and_shortids.shortids), len(block.vtx))
+
+        # And now check that all the shortids are as expected as well.
+        # Determine the siphash keys to use.
+        [k0, k1] = header_and_shortids.get_siphash_keys()
+
+        index = 0
+        while index < len(block.vtx):
+            if (len(header_and_shortids.prefilled_txn) > 0 and
+                    header_and_shortids.prefilled_txn[0].index == index):
+                # Already checked prefilled transactions above
+                header_and_shortids.prefilled_txn.pop(0)
+            else:
+                shortid = calculate_shortid(k0, k1, block.vtx[index].sha256)
+                assert_equal(shortid, header_and_shortids.shortids[0])
+                header_and_shortids.shortids.pop(0)
+            index += 1
+
+    # Test that bitcoind requests compact blocks when we announce new blocks
+    # via header or inv, and that responding to getblocktxn causes the block
+    # to be successfully reconstructed.
+    def test_compactblock_requests(self):
+        print("Testing compactblock requests... ")
+
+        # Try announcing a block with an inv or header, expect a compactblock
+        # request
+        for announce in ["inv", "header"]:
+            block = self.build_block_on_tip()
+            with mininode_lock:
+                self.test_node.last_getdata = None
+
+            if announce == "inv":
+                self.test_node.send_message(msg_inv([CInv(2, block.sha256)]))
+            else:
+                self.test_node.send_header_for_blocks([block])
+            success = wait_until(lambda: self.test_node.last_getdata is not None, timeout=30)
+            assert(success)
+            assert_equal(len(self.test_node.last_getdata.inv), 1)
+            assert_equal(self.test_node.last_getdata.inv[0].type, 4)
+            assert_equal(self.test_node.last_getdata.inv[0].hash, block.sha256)
+
+            # Send back a compactblock message that omits the coinbase
+            comp_block = HeaderAndShortIDs()
+            comp_block.header = CBlockHeader(block)
+            comp_block.nonce = 0
+            comp_block.shortids = [1]  # this is useless, and wrong
+            self.test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
+            assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.hashPrevBlock)
+            # Expect a getblocktxn message.
+            with mininode_lock:
+                assert(self.test_node.last_getblocktxn is not None)
+                absolute_indexes = self.test_node.last_getblocktxn.block_txn_request.to_absolute()
+            assert_equal(absolute_indexes, [0])  # should be a coinbase request
+
+            # Send the coinbase, and verify that the tip advances.
+            msg = msg_blocktxn()
+            msg.block_transactions.blockhash = block.sha256
+            msg.block_transactions.transactions = [block.vtx[0]]
+            self.test_node.send_and_ping(msg)
+            assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.sha256)
+
+    # Create a chain of transactions from given utxo, and add to a new block.
+    def build_block_with_transactions(self, utxo, num_transactions):
+        block = self.build_block_on_tip()
+
+        for i in range(num_transactions):
+            tx = CTransaction()
+            tx.vin.append(CTxIn(COutPoint(utxo[0], utxo[1]), b''))
+            tx.vout.append(CTxOut(utxo[2] - 1000, CScript([OP_TRUE])))
+            tx.rehash()
+            utxo = [tx.sha256, 0, tx.vout[0].nValue]
+            block.vtx.append(tx)
+
+        block.hashMerkleRoot = block.calc_merkle_root()
+        block.solve()
+        return block
+
+    # Test that we only receive getblocktxn requests for transactions that the
+    # node needs, and that responding to them causes the block to be
+    # reconstructed.
+    def test_getblocktxn_requests(self):
+        print("Testing getblocktxn requests...")
+
+        # First try announcing compactblocks that won't reconstruct, and verify
+        # that we receive getblocktxn messages back.
+        utxo = self.utxos.pop(0)
+
+        block = self.build_block_with_transactions(utxo, 5)
+        self.utxos.append([block.vtx[-1].sha256, 0, block.vtx[-1].vout[0].nValue])
+
+        comp_block = HeaderAndShortIDs()
+        comp_block.initialize_from_block(block)
+
+        self.test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
+        with mininode_lock:
+            assert(self.test_node.last_getblocktxn is not None)
+            absolute_indexes = self.test_node.last_getblocktxn.block_txn_request.to_absolute()
+        assert_equal(absolute_indexes, [1, 2, 3, 4, 5])
+        msg = msg_blocktxn()
+        msg.block_transactions = BlockTransactions(block.sha256, block.vtx[1:])
+        self.test_node.send_and_ping(msg)
+        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.sha256)
+
+        utxo = self.utxos.pop(0)
+        block = self.build_block_with_transactions(utxo, 5)
+        self.utxos.append([block.vtx[-1].sha256, 0, block.vtx[-1].vout[0].nValue])
+
+        # Now try interspersing the prefilled transactions
+        comp_block.initialize_from_block(block, prefill_list=[0, 1, 5])
+        self.test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
+        with mininode_lock:
+            assert(self.test_node.last_getblocktxn is not None)
+            absolute_indexes = self.test_node.last_getblocktxn.block_txn_request.to_absolute()
+        assert_equal(absolute_indexes, [2, 3, 4])
+        msg.block_transactions = BlockTransactions(block.sha256, block.vtx[2:5])
+        self.test_node.send_and_ping(msg)
+        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.sha256)
+
+        # Now try giving one transaction ahead of time.
+        utxo = self.utxos.pop(0)
+        block = self.build_block_with_transactions(utxo, 5)
+        self.utxos.append([block.vtx[-1].sha256, 0, block.vtx[-1].vout[0].nValue])
+        self.test_node.send_and_ping(msg_tx(block.vtx[1]))
+        assert(block.vtx[1].hash in self.nodes[0].getrawmempool())
+
+        # Prefill 4 out of the 6 transactions, and verify that only the one
+        # that was not in the mempool is requested.
+        comp_block.initialize_from_block(block, prefill_list=[0, 2, 3, 4])
+        self.test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
+        with mininode_lock:
+            assert(self.test_node.last_getblocktxn is not None)
+            absolute_indexes = self.test_node.last_getblocktxn.block_txn_request.to_absolute()
+        assert_equal(absolute_indexes, [5])
+
+        msg.block_transactions = BlockTransactions(block.sha256, [block.vtx[5]])
+        self.test_node.send_and_ping(msg)
+        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.sha256)
+
+        # Now provide all transactions to the node before the block is
+        # announced and verify reconstruction happens immediately.
+        utxo = self.utxos.pop(0)
+        block = self.build_block_with_transactions(utxo, 10)
+        self.utxos.append([block.vtx[-1].sha256, 0, block.vtx[-1].vout[0].nValue])
+        for tx in block.vtx[1:]:
+            self.test_node.send_message(msg_tx(tx))
+        self.test_node.sync_with_ping()
+        # Make sure all transactions were accepted.
+        mempool = self.nodes[0].getrawmempool()
+        for tx in block.vtx[1:]:
+            assert(tx.hash in mempool)
+
+        # Clear out last request.
+        with mininode_lock:
+            self.test_node.last_getblocktxn = None
+
+        # Send compact block
+        comp_block.initialize_from_block(block, prefill_list=[0])
+        self.test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
+        with mininode_lock:
+            # Shouldn't have gotten a request for any transaction
+            assert(self.test_node.last_getblocktxn is None)
+        # Tip should have updated
+        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.sha256)
+
+    # Incorrectly responding to a getblocktxn shouldn't cause the block to be
+    # permanently failed.
+    def test_incorrect_blocktxn_response(self):
+        print("Testing handling of incorrect blocktxn responses...")
+
+        if (len(self.utxos) == 0):
+            self.make_utxos()
+        utxo = self.utxos.pop(0)
+
+        block = self.build_block_with_transactions(utxo, 10)
+        self.utxos.append([block.vtx[-1].sha256, 0, block.vtx[-1].vout[0].nValue])
+        # Relay the first 5 transactions from the block in advance
+        for tx in block.vtx[1:6]:
+            self.test_node.send_message(msg_tx(tx))
+        self.test_node.sync_with_ping()
+        # Make sure all transactions were accepted.
+        mempool = self.nodes[0].getrawmempool()
+        for tx in block.vtx[1:6]:
+            assert(tx.hash in mempool)
+
+        # Send compact block
+        comp_block = HeaderAndShortIDs()
+        comp_block.initialize_from_block(block, prefill_list=[0])
+        self.test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
+        absolute_indexes = []
+        with mininode_lock:
+            assert(self.test_node.last_getblocktxn is not None)
+            absolute_indexes = self.test_node.last_getblocktxn.block_txn_request.to_absolute()
+        assert_equal(absolute_indexes, [6, 7, 8, 9, 10])
+
+        # Now give an incorrect response.
+        # Note that it's possible for bitcoind to be smart enough to know we're
+        # lying, since it could check to see if the shortid matches what we're
+        # sending, and eg disconnect us for misbehavior.  If that behavior
+        # change were made, we could just modify this test by having a
+        # different peer provide the block further down, so that we're still
+        # verifying that the block isn't marked bad permanently. This is good
+        # enough for now.
+        msg = msg_blocktxn()
+        msg.block_transactions = BlockTransactions(block.sha256, [block.vtx[5]] + block.vtx[7:])
+        self.test_node.send_and_ping(msg)
+
+        # Tip should not have updated
+        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.hashPrevBlock)
+
+        # We should receive a getdata request
+        success = wait_until(lambda: self.test_node.last_getdata is not None, timeout=10)
+        assert(success)
+        assert_equal(len(self.test_node.last_getdata.inv), 1)
+        assert_equal(self.test_node.last_getdata.inv[0].type, 2)
+        assert_equal(self.test_node.last_getdata.inv[0].hash, block.sha256)
+
+        # Deliver the block
+        self.test_node.send_and_ping(msg_block(block))
+        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.sha256)
+
+    def test_getblocktxn_handler(self):
+        print("Testing getblocktxn handler...")
+
+        # bitcoind won't respond for blocks whose height is more than 15 blocks
+        # deep.
+        MAX_GETBLOCKTXN_DEPTH = 15
+        chain_height = self.nodes[0].getblockcount()
+        current_height = chain_height
+        while (current_height >= chain_height - MAX_GETBLOCKTXN_DEPTH):
+            block_hash = self.nodes[0].getblockhash(current_height)
+            block = FromHex(CBlock(), self.nodes[0].getblock(block_hash, False))
+
+            msg = msg_getblocktxn()
+            msg.block_txn_request = BlockTransactionsRequest(int(block_hash, 16), [])
+            num_to_request = random.randint(1, len(block.vtx))
+            msg.block_txn_request.from_absolute(sorted(random.sample(range(len(block.vtx)), num_to_request)))
+            self.test_node.send_message(msg)
+            success = wait_until(lambda: self.test_node.last_blocktxn is not None, timeout=10)
+            assert(success)
+
+            [tx.calc_sha256() for tx in block.vtx]
+            with mininode_lock:
+                assert_equal(self.test_node.last_blocktxn.block_transactions.blockhash, int(block_hash, 16))
+                all_indices = msg.block_txn_request.to_absolute()
+                for index in all_indices:
+                    tx = self.test_node.last_blocktxn.block_transactions.transactions.pop(0)
+                    tx.calc_sha256()
+                    assert_equal(tx.sha256, block.vtx[index].sha256)
+                self.test_node.last_blocktxn = None
+            current_height -= 1
+
+        # Next request should be ignored, as we're past the allowed depth.
+        block_hash = self.nodes[0].getblockhash(current_height)
+        msg.block_txn_request = BlockTransactionsRequest(int(block_hash, 16), [0])
+        self.test_node.send_and_ping(msg)
+        with mininode_lock:
+            assert_equal(self.test_node.last_blocktxn, None)
+
+    def test_compactblocks_not_at_tip(self):
+        print("Testing compactblock requests/announcements not at chain tip...")
+
+        # Test that requesting old compactblocks doesn't work.
+        MAX_CMPCTBLOCK_DEPTH = 11
+        new_blocks = []
+        for i in range(MAX_CMPCTBLOCK_DEPTH):
+            self.test_node.clear_block_announcement()
+            new_blocks.append(self.nodes[0].generate(1)[0])
+            wait_until(self.test_node.received_block_announcement, timeout=30)
+
+        self.test_node.clear_block_announcement()
+        self.test_node.send_message(msg_getdata([CInv(4, int(new_blocks[0], 16))]))
+        success = wait_until(lambda: self.test_node.last_cmpctblock is not None, timeout=30)
+        assert(success)
+
+        self.test_node.clear_block_announcement()
+        self.nodes[0].generate(1)
+        wait_until(self.test_node.received_block_announcement, timeout=30)
+        self.test_node.clear_block_announcement()
+        self.test_node.send_message(msg_getdata([CInv(4, int(new_blocks[0], 16))]))
+        success = wait_until(lambda: self.test_node.last_block is not None, timeout=30)
+        assert(success)
+        with mininode_lock:
+            self.test_node.last_block.block.calc_sha256()
+            assert_equal(self.test_node.last_block.block.sha256, int(new_blocks[0], 16))
+
+        # Generate an old compactblock, and verify that it's not accepted.
+        cur_height = self.nodes[0].getblockcount()
+        hashPrevBlock = int(self.nodes[0].getblockhash(cur_height-5), 16)
+        block = self.build_block_on_tip()
+        block.hashPrevBlock = hashPrevBlock
+        block.solve()
+
+        comp_block = HeaderAndShortIDs()
+        comp_block.initialize_from_block(block)
+        self.test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
+
+        tips = self.nodes[0].getchaintips()
+        found = False
+        for x in tips:
+            if x["hash"] == block.hash:
+                assert_equal(x["status"], "headers-only")
+                found = True
+                break
+        assert(found)
+
+        # Requesting this block via getblocktxn should silently fail
+        # (to avoid fingerprinting attacks).
+        msg = msg_getblocktxn()
+        msg.block_txn_request = BlockTransactionsRequest(block.sha256, [0])
+        with mininode_lock:
+            self.test_node.last_blocktxn = None
+        self.test_node.send_and_ping(msg)
+        with mininode_lock:
+            assert(self.test_node.last_blocktxn is None)
+
+    def run_test(self):
+        # Setup the p2p connections and start up the network thread.
+        self.test_node = TestNode()
+
+        connections = []
+        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], self.test_node))
+        self.test_node.add_connection(connections[0])
+
+        NetworkThread().start()  # Start up network handling in another thread
+
+        # Test logic begins here
+        self.test_node.wait_for_verack()
+
+        # We will need UTXOs to construct transactions in later tests.
+        self.make_utxos()
+
+        self.test_sendcmpct()
+        self.test_compactblock_construction()
+        self.test_compactblock_requests()
+        self.test_getblocktxn_requests()
+        self.test_getblocktxn_handler()
+        self.test_compactblocks_not_at_tip()
+        self.test_incorrect_blocktxn_response()
+        self.test_invalid_cmpctblock_message()
+
+
+if __name__ == '__main__':
+    CompactBlocksTest().main()

--- a/qa/rpc-tests/p2p-compactblocks.py
+++ b/qa/rpc-tests/p2p-compactblocks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python2
 # Copyright (c) 2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -81,7 +81,7 @@ class TestNode(SingleNodeConnCB):
 
 class CompactBlocksTest(BitcoinTestFramework):
     def __init__(self):
-        super().__init__()
+        super(CompactBlocksTest, self).__init__()
         self.setup_clean_chain = True
         self.num_nodes = 1
         self.utxos = []

--- a/qa/rpc-tests/p2p-compactblocks.py
+++ b/qa/rpc-tests/p2p-compactblocks.py
@@ -14,6 +14,10 @@ from test_framework.script import CScript, OP_TRUE
 CompactBlocksTest -- test compact blocks (BIP 152)
 '''
 
+# These tweaks work around:
+# 1) XT not yet supporting hight bandwith mode
+# 2) XTs sligtly different, but valid behavior (compared to Core)
+XT_TWEAKS = True
 
 # TestNode: A peer we use to send messages to bitcoind, and store responses.
 class TestNode(SingleNodeConnCB):
@@ -55,6 +59,9 @@ class TestNode(SingleNodeConnCB):
 
     def on_blocktxn(self, conn, message):
         self.last_blocktxn = message
+
+    def on_getheaders(self, conn, message):
+        self.last_getheaders = message
 
     # Requires caller to hold mininode_lock
     def received_block_announcement(self):
@@ -100,13 +107,17 @@ class CompactBlocksTest(BitcoinTestFramework):
         # with segwit.  (After BIP 152 is updated to support segwit, we can
         # test behavior with and without segwit enabled by adding a second node
         # to the test.)
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [["-debug", "-logtimemicros=1", "-bip9params=segwit:0:0"]])
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [[
+            "-prefer-compact-blocks",
+            "-debug", "-logtimemicros=1", "-bip9params=segwit:0:0" ]])
 
     def build_block_on_tip(self):
         height = self.nodes[0].getblockcount()
         tip = self.nodes[0].getbestblockhash()
         mtp = self.nodes[0].getblockheader(tip)['mediantime']
-        block = create_block(int(tip, 16), create_coinbase(height + 1), mtp + 1)
+        block = create_block(int(tip, 16), create_coinbase(absoluteHeight = height + 1), mtp + 1)
+        if XT_TWEAKS:
+            block.nVersion = 4
         block.solve()
         return block
 
@@ -121,6 +132,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         out_value = total_value // 10
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(block.vtx[0].sha256, 0), b''))
+
         for i in range(10):
             tx.vout.append(CTxOut(out_value, CScript([OP_TRUE])))
         tx.rehash()
@@ -191,6 +203,10 @@ class CompactBlocksTest(BitcoinTestFramework):
 
         # Headers sync before next test.
         self.test_node.request_headers_and_sync(locator=[tip])
+
+        if XT_TWEAKS:
+            print("TODO: High bandwith mode NYI. Tests disabled.")
+            return
 
         # Finally, try a SENDCMPCT message with announce=True
         sendcmpct.version = 1
@@ -314,6 +330,15 @@ class CompactBlocksTest(BitcoinTestFramework):
 
             if announce == "inv":
                 self.test_node.send_message(msg_inv([CInv(2, block.sha256)]))
+
+                if XT_TWEAKS:
+                    # If a node is expected to send header announcement, but sends
+                    # inv, XT will send a getheaders. Normally it is likely there
+                    # was a re-org.
+                    success = wait_until(lambda: self.test_node.last_getheaders is not None, timeout = 10)
+                    if success:
+                        self.test_node.send_header_for_blocks([block])
+                        self.test_node.last_getheaders = None
             else:
                 self.test_node.send_header_for_blocks([block])
             success = wait_until(lambda: self.test_node.last_getdata is not None, timeout=30)
@@ -327,6 +352,13 @@ class CompactBlocksTest(BitcoinTestFramework):
             comp_block.header = CBlockHeader(block)
             comp_block.nonce = 0
             comp_block.shortids = [1]  # this is useless, and wrong
+            if XT_TWEAKS:
+                # XT misbehaves the original test due
+                # to shortid being wrong. Fix shortids.
+                [k0, k1] = comp_block.get_siphash_keys()
+                comp_block.shortids = [
+                        calculate_shortid(k0, k1, block.vtx[0].sha256) ]
+
             self.test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
             assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.hashPrevBlock)
             # Expect a getblocktxn message.
@@ -358,6 +390,13 @@ class CompactBlocksTest(BitcoinTestFramework):
         block.solve()
         return block
 
+    # XT does not (yet) accept blocks as announcements
+    # Announce with header before sending a compact block.
+    def announce_with_header(self, block):
+        self.test_node.send_header_for_blocks([block])
+        success = wait_until(lambda: self.test_node.last_getdata is not None, timeout=30)
+
+
     # Test that we only receive getblocktxn requests for transactions that the
     # node needs, and that responding to them causes the block to be
     # reconstructed.
@@ -373,6 +412,9 @@ class CompactBlocksTest(BitcoinTestFramework):
 
         comp_block = HeaderAndShortIDs()
         comp_block.initialize_from_block(block)
+
+        if XT_TWEAKS:
+            self.announce_with_header(block)
 
         self.test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
         with mininode_lock:
@@ -390,6 +432,8 @@ class CompactBlocksTest(BitcoinTestFramework):
 
         # Now try interspersing the prefilled transactions
         comp_block.initialize_from_block(block, prefill_list=[0, 1, 5])
+        if XT_TWEAKS:
+            self.announce_with_header(block)
         self.test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
         with mininode_lock:
             assert(self.test_node.last_getblocktxn is not None)
@@ -409,6 +453,8 @@ class CompactBlocksTest(BitcoinTestFramework):
         # Prefill 4 out of the 6 transactions, and verify that only the one
         # that was not in the mempool is requested.
         comp_block.initialize_from_block(block, prefill_list=[0, 2, 3, 4])
+        if XT_TWEAKS:
+            self.announce_with_header(block)
         self.test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
         with mininode_lock:
             assert(self.test_node.last_getblocktxn is not None)
@@ -438,6 +484,8 @@ class CompactBlocksTest(BitcoinTestFramework):
 
         # Send compact block
         comp_block.initialize_from_block(block, prefill_list=[0])
+        if XT_TWEAKS:
+            self.announce_with_header(block)
         self.test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
         with mininode_lock:
             # Shouldn't have gotten a request for any transaction
@@ -468,6 +516,9 @@ class CompactBlocksTest(BitcoinTestFramework):
         # Send compact block
         comp_block = HeaderAndShortIDs()
         comp_block.initialize_from_block(block, prefill_list=[0])
+        xttweak = True
+        if XT_TWEAKS:
+            self.announce_with_header(block)
         self.test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
         absolute_indexes = []
         with mininode_lock:
@@ -531,6 +582,10 @@ class CompactBlocksTest(BitcoinTestFramework):
                     assert_equal(tx.sha256, block.vtx[index].sha256)
                 self.test_node.last_blocktxn = None
             current_height -= 1
+
+        # XT does have a special depth criteria for compact block re-requests.
+        if XT_TWEAKS:
+            return
 
         # Next request should be ignored, as we're past the allowed depth.
         block_hash = self.nodes[0].getblockhash(current_height)

--- a/qa/rpc-tests/proxy_test.py
+++ b/qa/rpc-tests/proxy_test.py
@@ -34,8 +34,9 @@ addnode connect to onion
 addnode connect to generic DNS name
 '''
 
-class ProxyTest(BitcoinTestFramework):        
+class ProxyTest(BitcoinTestFramework):
     def __init__(self):
+        super(ProxyTest, self).__init__()
         # Create two proxies on different ports
         # ... one unauthenticated
         self.conf1 = Socks5Configuration()

--- a/qa/rpc-tests/test_framework/blocktools.py
+++ b/qa/rpc-tests/test_framework/blocktools.py
@@ -5,7 +5,7 @@
 #
 
 from mininode import *
-from script import CScript, CScriptOp
+from script import CScript, CScriptOp, OP_TRUE
 
 # Create a block (with regtest difficulty)
 def create_block(hashprev, coinbase, nTime=None):
@@ -43,14 +43,14 @@ def create_coinbase(heightAdjust = 0, absoluteHeight = None):
     global counter
     height = absoluteHeight if absoluteHeight is not None else counter+heightAdjust
     coinbase = CTransaction()
-    coinbase.vin.append(CTxIn(COutPoint(0, 0xffffffff), 
+    coinbase.vin.append(CTxIn(COutPoint(0, 0xffffffff),
                 ser_string(serialize_script_num(height)), 0xffffffff))
     counter += 1
     coinbaseoutput = CTxOut()
     coinbaseoutput.nValue = 50*100000000
     halvings = int((height)/150) # regtest
     coinbaseoutput.nValue >>= halvings
-    coinbaseoutput.scriptPubKey = ""
+    coinbaseoutput.scriptPubKey = CScript([OP_TRUE])
     coinbase.vout = [ coinbaseoutput ]
     coinbase.calc_sha256()
     return coinbase

--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -38,9 +38,9 @@ class TestNode(NodeConnCB):
         self.tx_store = tx_store
         self.tx_request_map = {}
 
-        # When the pingmap is non-empty we're waiting for 
+        # When the pingmap is non-empty we're waiting for
         # a response
-        self.pingMap = {} 
+        self.pingMap = {}
         self.lastInv = []
 
     def add_connection(self, conn):
@@ -104,7 +104,7 @@ class TestNode(NodeConnCB):
 # comptool.
 #
 # "blocks_and_transactions" should be an array of [obj, True/False/None]:
-#  - obj is either a CBlock or a CTransaction, and 
+#  - obj is either a CBlock or a CTransaction, and
 #  - the second value indicates whether the object should be accepted
 #    into the blockchain or mempool (for tests where we expect a certain
 #    answer), or "None" if we don't expect a certain answer and are just
@@ -113,7 +113,7 @@ class TestNode(NodeConnCB):
 #    nodes will be tested based on the outcome for the block.  If False,
 #    then inv's accumulate until all blocks are processed (or max inv size
 #    is reached) and then sent out in one inv message.  Then the final block
-#    will be synced across all connections, and the outcome of the final 
+#    will be synced across all connections, and the outcome of the final
 #    block will be tested.
 # sync_every_tx: analagous to behavior for sync_every_block, except if outcome
 #    on the final tx is None, then contents of entire mempool are compared
@@ -138,7 +138,7 @@ class TestManager(object):
     def add_all_connections(self, nodes):
         for i in range(len(nodes)):
             # Create a p2p connection to each node
-            self.connections.append(NodeConn('127.0.0.1', p2p_port(i), 
+            self.connections.append(NodeConn('127.0.0.1', p2p_port(i),
                         nodes[i], TestNode(self.block_store, self.tx_store)))
             # Make sure the TestNode (callback class) has a reference to its
             # associated NodeConn

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -724,11 +724,14 @@ class PrefilledTransaction(object):
     def serialize(self, with_witness=False):
         r = b""
         r += ser_compact_size(self.index)
-        if with_witness:
-            r += self.tx.serialize_with_witness()
-        else:
-            r += self.tx.serialize_without_witness()
+        assert(not with_witness) # Witness support not added
+        r += self.tx.serialize()
         return r
+        #if with_witness:
+        #    r += self.tx.serialize_with_witness()
+        #else:
+        #    r += self.tx.serialize_without_witness()
+        #return r
 
     def __repr__(self):
         return "PrefilledTransaction(index=%d, tx=%s)" % (self.index, repr(self.tx))

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -1447,7 +1447,7 @@ class SingleNodeConnCB(NodeConnCB):
         def received_pong():
             return (self.last_pong.nonce == self.ping_counter)
         self.send_message(msg_ping(nonce=self.ping_counter))
-        success = wait_until(received_pong, timeout)
+        success = wait_until(received_pong, timeout=timeout)
         self.ping_counter += 1
         return success
 

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -32,15 +32,16 @@ import logging
 import copy
 import math
 from murmurhash import MurmurHash3
+from siphash import siphash256
 
 BIP0031_VERSION = 60000
-MY_VERSION = 70011 # So we can signal that we don't support merkleblocks (no thin blocks)
-MY_SUBVERSION = "/python-mininode-tester:0.0.1/"
+MY_VERSION = 70014
+MY_SUBVERSION = b"/python-mininode-tester:0.0.3/"
 
 MAX_INV_SZ = 50000
 
 # Keep our own socket map for asyncore, so that we can track disconnects
-# ourselves (to workaround an issue with closing an asyncore socket when 
+# ourselves (to workaround an issue with closing an asyncore socket when
 # using select)
 mininode_socket_map = dict()
 
@@ -273,7 +274,9 @@ class CInv(object):
     typemap = {
         0: "Error",
         1: "TX",
-        2: "Block"}
+        2: "Block",
+        4: "CompactBlock"
+    }
 
     def __init__(self, t=0, h=0L):
         self.type = t
@@ -708,6 +711,187 @@ class CBloomFilter(object):
             % (len(self.vData), self.nHashFuncs, self.nTweak, self.nFlags)
 
 
+class PrefilledTransaction(object):
+    def __init__(self, index=0, tx = None):
+        self.index = index
+        self.tx = tx
+
+    def deserialize(self, f):
+        self.index = deser_compact_size(f)
+        self.tx = CTransaction()
+        self.tx.deserialize(f)
+
+    def serialize(self, with_witness=False):
+        r = b""
+        r += ser_compact_size(self.index)
+        if with_witness:
+            r += self.tx.serialize_with_witness()
+        else:
+            r += self.tx.serialize_without_witness()
+        return r
+
+    def __repr__(self):
+        return "PrefilledTransaction(index=%d, tx=%s)" % (self.index, repr(self.tx))
+
+# This is what we send on the wire, in a cmpctblock message.
+class P2PHeaderAndShortIDs(object):
+    def __init__(self):
+        self.header = CBlockHeader()
+        self.nonce = 0
+        self.shortids_length = 0
+        self.shortids = []
+        self.prefilled_txn_length = 0
+        self.prefilled_txn = []
+
+    def deserialize(self, f):
+        self.header.deserialize(f)
+        self.nonce = struct.unpack("<Q", f.read(8))[0]
+        self.shortids_length = deser_compact_size(f)
+        for i in range(self.shortids_length):
+            # shortids are defined to be 6 bytes in the spec, so append
+            # two zero bytes and read it in as an 8-byte number
+            self.shortids.append(struct.unpack("<Q", f.read(6) + b'\x00\x00')[0])
+        self.prefilled_txn = deser_vector(f, PrefilledTransaction)
+        self.prefilled_txn_length = len(self.prefilled_txn)
+
+    def serialize(self, with_witness=False):
+        r = b""
+        r += self.header.serialize()
+        r += struct.pack("<Q", self.nonce)
+        r += ser_compact_size(self.shortids_length)
+        for x in self.shortids:
+            # We only want the first 6 bytes
+            r += struct.pack("<Q", x)[0:6]
+        r += ser_vector(self.prefilled_txn)
+        return r
+
+    def __repr__(self):
+        return "P2PHeaderAndShortIDs(header=%s, nonce=%d, shortids_length=%d, shortids=%s, prefilled_txn_length=%d, prefilledtxn=%s" % (repr(self.header), self.nonce, self.shortids_length, repr(self.shortids), self.prefilled_txn_length, repr(self.prefilled_txn))
+
+
+# Calculate the BIP 152-compact blocks shortid for a given transaction hash
+def calculate_shortid(k0, k1, tx_hash):
+    expected_shortid = siphash256(k0, k1, tx_hash)
+    expected_shortid &= 0x0000ffffffffffff
+    return expected_shortid
+
+# This version gets rid of the array lengths, and reinterprets the differential
+# encoding into indices that can be used for lookup.
+class HeaderAndShortIDs(object):
+    def __init__(self, p2pheaders_and_shortids = None):
+        self.header = CBlockHeader()
+        self.nonce = 0
+        self.shortids = []
+        self.prefilled_txn = []
+
+        if p2pheaders_and_shortids != None:
+            self.header = p2pheaders_and_shortids.header
+            self.nonce = p2pheaders_and_shortids.nonce
+            self.shortids = p2pheaders_and_shortids.shortids
+            last_index = -1
+            for x in p2pheaders_and_shortids.prefilled_txn:
+                self.prefilled_txn.append(PrefilledTransaction(x.index + last_index + 1, x.tx))
+                last_index = self.prefilled_txn[-1].index
+
+    def to_p2p(self):
+        ret = P2PHeaderAndShortIDs()
+        ret.header = self.header
+        ret.nonce = self.nonce
+        ret.shortids_length = len(self.shortids)
+        ret.shortids = self.shortids
+        ret.prefilled_txn_length = len(self.prefilled_txn)
+        ret.prefilled_txn = []
+        last_index = -1
+        for x in self.prefilled_txn:
+            ret.prefilled_txn.append(PrefilledTransaction(x.index - last_index - 1, x.tx))
+            last_index = x.index
+        return ret
+
+    def get_siphash_keys(self):
+        header_nonce = self.header.serialize()
+        header_nonce += struct.pack("<Q", self.nonce)
+        hash_header_nonce_as_str = sha256(header_nonce)
+        key0 = struct.unpack("<Q", hash_header_nonce_as_str[0:8])[0]
+        key1 = struct.unpack("<Q", hash_header_nonce_as_str[8:16])[0]
+        return [ key0, key1 ]
+
+    def initialize_from_block(self, block, nonce=0, prefill_list = [0]):
+        self.header = CBlockHeader(block)
+        self.nonce = nonce
+        self.prefilled_txn = [ PrefilledTransaction(i, block.vtx[i]) for i in prefill_list ]
+        self.shortids = []
+        [k0, k1] = self.get_siphash_keys()
+        for i in range(len(block.vtx)):
+            if i not in prefill_list:
+                self.shortids.append(calculate_shortid(k0, k1, block.vtx[i].sha256))
+
+    def __repr__(self):
+        return "HeaderAndShortIDs(header=%s, nonce=%d, shortids=%s, prefilledtxn=%s" % (repr(self.header), self.nonce, repr(self.shortids), repr(self.prefilled_txn))
+
+
+class BlockTransactionsRequest(object):
+
+    def __init__(self, blockhash=0, indexes = None):
+        self.blockhash = blockhash
+        self.indexes = indexes if indexes != None else []
+
+    def deserialize(self, f):
+        self.blockhash = deser_uint256(f)
+        indexes_length = deser_compact_size(f)
+        for i in range(indexes_length):
+            self.indexes.append(deser_compact_size(f))
+
+    def serialize(self):
+        r = b""
+        r += ser_uint256(self.blockhash)
+        r += ser_compact_size(len(self.indexes))
+        for x in self.indexes:
+            r += ser_compact_size(x)
+        return r
+
+    # helper to set the differentially encoded indexes from absolute ones
+    def from_absolute(self, absolute_indexes):
+        self.indexes = []
+        last_index = -1
+        for x in absolute_indexes:
+            self.indexes.append(x-last_index-1)
+            last_index = x
+
+    def to_absolute(self):
+        absolute_indexes = []
+        last_index = -1
+        for x in self.indexes:
+            absolute_indexes.append(x+last_index+1)
+            last_index = absolute_indexes[-1]
+        return absolute_indexes
+
+    def __repr__(self):
+        return "BlockTransactionsRequest(hash=%064x indexes=%s)" % (self.blockhash, repr(self.indexes))
+
+
+class BlockTransactions(object):
+
+    def __init__(self, blockhash=0, transactions = None):
+        self.blockhash = blockhash
+        self.transactions = transactions if transactions != None else []
+
+    def deserialize(self, f):
+        self.blockhash = deser_uint256(f)
+        self.transactions = deser_vector(f, CTransaction)
+
+    def serialize(self, with_witness=False):
+        r = b""
+        r += ser_uint256(self.blockhash)
+        if with_witness:
+            r += ser_vector(self.transactions, "serialize_with_witness")
+        else:
+            r += ser_vector(self.transactions)
+        return r
+
+    def __repr__(self):
+        return "BlockTransactions(hash=%064x transactions=%s)" % (self.blockhash, repr(self.transactions))
+
+
 # Objects that correspond to messages on the wire
 class msg_version(object):
     command = "version"
@@ -1116,6 +1300,79 @@ class msg_filterload(object):
         return "msg_filterload(filter=%r)" % (self.filter)
 
 
+class msg_sendcmpct(object):
+    command = b"sendcmpct"
+
+    def __init__(self):
+        self.announce = False
+        self.version = 1
+
+    def deserialize(self, f):
+        self.announce = struct.unpack("<?", f.read(1))[0]
+        self.version = struct.unpack("<Q", f.read(8))[0]
+
+    def serialize(self):
+        r = b""
+        r += struct.pack("<?", self.announce)
+        r += struct.pack("<Q", self.version)
+        return r
+
+    def __repr__(self):
+        return "msg_sendcmpct(announce=%s, version=%lu)" % (self.announce, self.version)
+
+class msg_cmpctblock(object):
+    command = b"cmpctblock"
+
+    def __init__(self, header_and_shortids = None):
+        self.header_and_shortids = header_and_shortids
+
+    def deserialize(self, f):
+        self.header_and_shortids = P2PHeaderAndShortIDs()
+        self.header_and_shortids.deserialize(f)
+
+    def serialize(self):
+        r = b""
+        r += self.header_and_shortids.serialize()
+        return r
+
+    def __repr__(self):
+        return "msg_cmpctblock(HeaderAndShortIDs=%s)" % repr(self.header_and_shortids)
+
+class msg_getblocktxn(object):
+    command = b"getblocktxn"
+
+    def __init__(self):
+        self.block_txn_request = None
+
+    def deserialize(self, f):
+        self.block_txn_request = BlockTransactionsRequest()
+        self.block_txn_request.deserialize(f)
+
+    def serialize(self):
+        r = b""
+        r += self.block_txn_request.serialize()
+        return r
+
+    def __repr__(self):
+        return "msg_getblocktxn(block_txn_request=%s)" % (repr(self.block_txn_request))
+
+class msg_blocktxn(object):
+    command = b"blocktxn"
+
+    def __init__(self):
+        self.block_transactions = BlockTransactions()
+
+    def deserialize(self, f):
+        self.block_transactions.deserialize(f)
+
+    def serialize(self):
+        r = b""
+        r += self.block_transactions.serialize()
+        return r
+
+    def __repr__(self):
+        return "msg_blocktxn(block_transactions=%s)" % (repr(self.block_transactions))
+
 # This is what a callback should look like for NodeConn
 # Reimplement the on_* functions to provide handling for events
 class NodeConnCB(object):
@@ -1198,6 +1455,11 @@ class NodeConnCB(object):
     def on_close(self, conn): pass
     def on_mempool(self, conn): pass
     def on_pong(self, conn, message): pass
+    def on_sendheaders(self, conn, message): pass
+    def on_sendcmpct(self, conn, message): pass
+    def on_cmpctblock(self, conn, message): pass
+    def on_getblocktxn(self, conn, message): pass
+    def on_blocktxn(self, conn, message): pass
 
 # More useful callbacks and functions for NodeConnCB's which have a single NodeConn
 class SingleNodeConnCB(NodeConnCB):
@@ -1213,6 +1475,10 @@ class SingleNodeConnCB(NodeConnCB):
     # Wrapper for the NodeConn's send_message function
     def send_message(self, message):
         self.connection.send_message(message)
+
+    def send_and_ping(self, message):
+        self.send_message(message)
+        self.sync_with_ping()
 
     def on_pong(self, conn, message):
         self.last_pong = message
@@ -1246,7 +1512,12 @@ class NodeConn(asyncore.dispatcher):
         "getheaders": msg_getheaders,
         "reject": msg_reject,
         "mempool": msg_mempool,
-        "filterload": msg_filterload
+        "filterload": msg_filterload,
+        "sendheaders": msg_sendheaders,
+        "sendcmpct": msg_sendcmpct,
+        "cmpctblock": msg_cmpctblock,
+        "getblocktxn": msg_getblocktxn,
+        "blocktxn": msg_blocktxn
     }
     MAGIC_BYTES = {
         "mainnet": "\xf9\xbe\xb4\xd9",   # mainnet

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -1083,6 +1083,20 @@ class msg_reject(object):
         return "msg_reject: %s %d %s [%064x]" \
             % (self.message, self.code, self.reason, self.data)
 
+# Helper function
+def wait_until(predicate, attempts=float('inf'), timeout=float('inf')):
+    attempt = 0
+    elapsed = 0
+
+    while attempt < attempts and elapsed < timeout:
+        with mininode_lock:
+            if predicate():
+                return True
+        attempt += 1
+        elapsed += 0.05
+        time.sleep(0.05)
+
+    return False
 
 class msg_filterload(object):
     command = "filterload"
@@ -1185,6 +1199,32 @@ class NodeConnCB(object):
     def on_mempool(self, conn): pass
     def on_pong(self, conn, message): pass
 
+# More useful callbacks and functions for NodeConnCB's which have a single NodeConn
+class SingleNodeConnCB(NodeConnCB):
+    def __init__(self):
+        NodeConnCB.__init__(self)
+        self.connection = None
+        self.ping_counter = 1
+        self.last_pong = msg_pong()
+
+    def add_connection(self, conn):
+        self.connection = conn
+
+    # Wrapper for the NodeConn's send_message function
+    def send_message(self, message):
+        self.connection.send_message(message)
+
+    def on_pong(self, conn, message):
+        self.last_pong = message
+
+    # Sync up with the node
+    def sync_with_ping(self, timeout=30):
+        def received_pong():
+            return (self.last_pong.nonce == self.ping_counter)
+        self.send_message(msg_ping(nonce=self.ping_counter))
+        success = wait_until(received_pong, timeout)
+        self.ping_counter += 1
+        return success
 
 # The actual NodeConn class
 # This class provides an interface for a p2p connection to a specified node

--- a/qa/rpc-tests/test_framework/siphash.py
+++ b/qa/rpc-tests/test_framework/siphash.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# Copyright (c) 2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# siphash.py - Specialized SipHash-2-4 implementations
+#
+# This implements SipHash-2-4 for 256-bit integers.
+
+def rotl64(n, b):
+    return n >> (64 - b) | (n & ((1 << (64 - b)) - 1)) << b
+
+def siphash_round(v0, v1, v2, v3):
+    v0 = (v0 + v1) & ((1 << 64) - 1)
+    v1 = rotl64(v1, 13)
+    v1 ^= v0
+    v0 = rotl64(v0, 32)
+    v2 = (v2 + v3) & ((1 << 64) - 1)
+    v3 = rotl64(v3, 16)
+    v3 ^= v2
+    v0 = (v0 + v3) & ((1 << 64) - 1)
+    v3 = rotl64(v3, 21)
+    v3 ^= v0
+    v2 = (v2 + v1) & ((1 << 64) - 1)
+    v1 = rotl64(v1, 17)
+    v1 ^= v2
+    v2 = rotl64(v2, 32)
+    return (v0, v1, v2, v3)
+
+def siphash256(k0, k1, h):
+    n0 = h & ((1 << 64) - 1)
+    n1 = (h >> 64) & ((1 << 64) - 1)
+    n2 = (h >> 128) & ((1 << 64) - 1)
+    n3 = (h >> 192) & ((1 << 64) - 1)
+    v0 = 0x736f6d6570736575 ^ k0
+    v1 = 0x646f72616e646f6d ^ k1
+    v2 = 0x6c7967656e657261 ^ k0
+    v3 = 0x7465646279746573 ^ k1 ^ n0
+    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
+    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
+    v0 ^= n0
+    v3 ^= n1
+    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
+    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
+    v0 ^= n1
+    v3 ^= n2
+    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
+    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
+    v0 ^= n2
+    v3 ^= n3
+    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
+    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
+    v0 ^= n3
+    v3 ^= 0x2000000000000000
+    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
+    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
+    v0 ^= 0x2000000000000000
+    v2 ^= 0xFF
+    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
+    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
+    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
+    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
+    return v0 ^ v1 ^ v2 ^ v3

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -19,6 +19,10 @@ from util import *
 
 class BitcoinTestFramework(object):
 
+    def __init__(self):
+        self.setup_clean_chain = False
+        self.num_nodes = 4
+
     # These may be over-ridden by subclasses:
     def run_test(self):
         for node in self.nodes:
@@ -29,8 +33,13 @@ class BitcoinTestFramework(object):
         pass
 
     def setup_chain(self):
-        print("Initializing test directory "+self.options.tmpdir)
-        initialize_chain(self.options.tmpdir)
+        print("Initializing test directory "+self.options.tmpdir \
+                + " (clean: %s)" % self.setup_clean_chain)
+
+        if self.setup_clean_chain:
+            initialize_chain_clean(self.options.tmpdir, self.num_nodes)
+        else:
+            initialize_chain(self.options.tmpdir)
 
     def setup_nodes(self):
         return start_nodes(4, self.options.tmpdir)
@@ -157,7 +166,9 @@ class ComparisonTestFramework(BitcoinTestFramework):
 
     # Can override the num_nodes variable to indicate how many nodes to run.
     def __init__(self):
+        super(ComparisonTestFramework, self).__init__()
         self.num_nodes = 2
+        self.setup_clean_chain = True
 
     def add_options(self, parser):
         parser.add_option("--testbinary", dest="testbinary",

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -78,6 +78,7 @@ BITCOIN_CORE_H = \
   base58.h \
   blockannounce.h \
   blockheaderprocessor.h \
+  blockencodings.h \
   blocksender.h \
   bloom.h \
   bloomthin.h \
@@ -198,6 +199,7 @@ libbitcoin_server_a_SOURCES = \
   addrman.cpp \
   blockannounce.cpp \
   blockheaderprocessor.cpp \
+  blockencodings.cpp \
   blocksender.cpp \
   bloom.cpp \
   bloomthin.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -79,6 +79,7 @@ BITCOIN_CORE_H = \
   blockannounce.h \
   blockheaderprocessor.h \
   blockencodings.h \
+  blockprocessor.h \
   blocksender.h \
   bloom.h \
   bloomthin.h \
@@ -101,6 +102,8 @@ BITCOIN_CORE_H = \
   consensus/validation.h \
   core_io.h \
   curl_wrapper.h \
+  compactblockprocessor.h \
+  compactthin.h \
   core_memusage.h \
   dummythin.h \
   hash.h \
@@ -200,11 +203,14 @@ libbitcoin_server_a_SOURCES = \
   blockannounce.cpp \
   blockheaderprocessor.cpp \
   blockencodings.cpp \
+  blockprocessor.cpp \
   blocksender.cpp \
   bloom.cpp \
   bloomthin.cpp \
   chain.cpp \
   checkpoints.cpp \
+  compactblockprocessor.cpp \
+  compactthin.cpp \
   curl_wrapper.cpp \
   inflightindex.cpp \
   init.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -105,6 +105,7 @@ BITCOIN_CORE_H = \
   compactblockprocessor.h \
   compactprefiller.h \
   compactthin.h \
+  compacttxfinder.h \
   core_memusage.h \
   dummythin.h \
   hash.h \
@@ -213,6 +214,7 @@ libbitcoin_server_a_SOURCES = \
   compactblockprocessor.cpp \
   compactprefiller.cpp \
   compactthin.cpp \
+  compacttxfinder.cpp \
   curl_wrapper.cpp \
   inflightindex.cpp \
   init.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -103,6 +103,7 @@ BITCOIN_CORE_H = \
   core_io.h \
   curl_wrapper.h \
   compactblockprocessor.h \
+  compactprefiller.h \
   compactthin.h \
   core_memusage.h \
   dummythin.h \
@@ -210,6 +211,7 @@ libbitcoin_server_a_SOURCES = \
   chain.cpp \
   checkpoints.cpp \
   compactblockprocessor.cpp \
+  compactprefiller.cpp \
   compactthin.cpp \
   curl_wrapper.cpp \
   inflightindex.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -50,6 +50,7 @@ BITCOIN_TESTS =\
   test/Checkpoints_tests.cpp \
   test/clientversion_tests.cpp \
   test/coins_tests.cpp \
+  test/compactprefiller_tests.cpp \
   test/compactthin_tests.cpp \
   test/compress_tests.cpp \
   test/crypto_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -50,6 +50,7 @@ BITCOIN_TESTS =\
   test/Checkpoints_tests.cpp \
   test/clientversion_tests.cpp \
   test/coins_tests.cpp \
+  test/compactthin_tests.cpp \
   test/compress_tests.cpp \
   test/crypto_tests.cpp \
   test/curl_tests.cpp \
@@ -84,6 +85,7 @@ BITCOIN_TESTS =\
   test/test_bitcoin.cpp \
   test/test_bitcoin.h \
   test/testutil.h \
+  test/thinblock_tests.cpp \
   test/thinblockbuilder_tests.cpp \
   test/thinblockconcluder_tests.cpp \
   test/thinblockmanager_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -44,6 +44,7 @@ BITCOIN_TESTS =\
   test/blockannounce_tests.cpp \
   test/blockheaderprocessor_tests.cpp \
   test/blocksender_tests.cpp \
+  test/blockencodings_tests.cpp \
   test/bloom_tests.cpp \
   test/checkblock_tests.cpp \
   test/Checkpoints_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -52,6 +52,7 @@ BITCOIN_TESTS =\
   test/coins_tests.cpp \
   test/compactprefiller_tests.cpp \
   test/compactthin_tests.cpp \
+  test/compacttxfinder_tests.cpp \
   test/compress_tests.cpp \
   test/crypto_tests.cpp \
   test/curl_tests.cpp \

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -1,0 +1,158 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "blockencodings.h"
+#include "consensus/consensus.h"
+#include "consensus/validation.h"
+#include "chainparams.h"
+#include "hash.h"
+#include "random.h"
+#include "streams.h"
+#include "txmempool.h"
+#include "main.h"
+
+#include <unordered_map>
+
+#define MIN_TRANSACTION_SIZE (::GetSerializeSize(CTransaction(), SER_NETWORK, PROTOCOL_VERSION))
+
+CBlockHeaderAndShortTxIDs::CBlockHeaderAndShortTxIDs(const CBlock& block) :
+        nonce(GetRand(std::numeric_limits<uint64_t>::max())),
+        shorttxids(block.vtx.size() - 1), prefilledtxn(1), header(block) {
+    FillShortTxIDSelector();
+    //TODO: Use our mempool prior to block acceptance to predictively fill more than just the coinbase
+    prefilledtxn[0] = {0, block.vtx[0]};
+    for (size_t i = 1; i < block.vtx.size(); i++) {
+        const CTransaction& tx = block.vtx[i];
+        shorttxids[i - 1] = GetShortID(tx.GetHash());
+    }
+}
+
+void CBlockHeaderAndShortTxIDs::FillShortTxIDSelector() const {
+    CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+    stream << header << nonce;
+    CSHA256 hasher;
+    hasher.Write((unsigned char*)&(*stream.begin()), stream.end() - stream.begin());
+    uint256 shorttxidhash;
+    hasher.Finalize(shorttxidhash.begin());
+    shorttxidk0 = shorttxidhash.GetUint64(0);
+    shorttxidk1 = shorttxidhash.GetUint64(1);
+}
+
+uint64_t CBlockHeaderAndShortTxIDs::GetShortID(const uint256& txhash) const {
+    static_assert(SHORTTXIDS_LENGTH == 6, "shorttxids calculation assumes 6-byte shorttxids");
+    return SipHashUint256(shorttxidk0, shorttxidk1, txhash) & 0xffffffffffffL;
+}
+
+
+
+ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& cmpctblock) {
+    if (cmpctblock.header.IsNull() || (cmpctblock.shorttxids.empty() && cmpctblock.prefilledtxn.empty()))
+        return READ_STATUS_INVALID;
+    if (cmpctblock.shorttxids.size() + cmpctblock.prefilledtxn.size() > MAX_BLOCK_SIZE / MIN_TRANSACTION_SIZE)
+        return READ_STATUS_INVALID;
+
+    assert(header.IsNull() && txn_available.empty());
+    header = cmpctblock.header;
+    txn_available.resize(cmpctblock.BlockTxCount());
+
+    int32_t lastprefilledindex = -1;
+    for (size_t i = 0; i < cmpctblock.prefilledtxn.size(); i++) {
+        if (cmpctblock.prefilledtxn[i].tx.IsNull())
+            return READ_STATUS_INVALID;
+
+        lastprefilledindex += cmpctblock.prefilledtxn[i].index + 1; //index is a uint16_t, so cant overflow here
+        if (lastprefilledindex > std::numeric_limits<uint16_t>::max())
+            return READ_STATUS_INVALID;
+        if ((uint32_t)lastprefilledindex > cmpctblock.shorttxids.size() + i) {
+            // If we are inserting a tx at an index greater than our full list of shorttxids
+            // plus the number of prefilled txn we've inserted, then we have txn for which we
+            // have neither a prefilled txn or a shorttxid!
+            return READ_STATUS_INVALID;
+        }
+        txn_available[lastprefilledindex] = std::make_shared<CTransaction>(cmpctblock.prefilledtxn[i].tx);
+    }
+
+    // Calculate map of txids -> positions and check mempool to see what we have (or dont)
+    // Because well-formed cmpctblock messages will have a (relatively) uniform distribution
+    // of short IDs, any highly-uneven distribution of elements can be safely treated as a
+    // READ_STATUS_FAILED.
+    std::unordered_map<uint64_t, uint16_t> shorttxids(cmpctblock.shorttxids.size());
+    uint16_t index_offset = 0;
+    for (size_t i = 0; i < cmpctblock.shorttxids.size(); i++) {
+        while (txn_available[i + index_offset])
+            index_offset++;
+        shorttxids[cmpctblock.shorttxids[i]] = i + index_offset;
+        // Bucket selection is a simple Binomial distribution. If we assume blocks of
+        // 10,000 transactions, allowing up to 12 elements per bucket should only fail
+        // once every ~1.3 million blocks and once every 74,000 blocks in a worst-case
+        // 16,000-transaction block.
+        if (shorttxids.bucket_size(shorttxids.bucket(cmpctblock.shorttxids[i])) > 12)
+            return READ_STATUS_FAILED;
+    }
+    // TODO: in the shortid-collision case, we should instead request both transactions
+    // which collided. Falling back to full-block-request here is overkill.
+    if (shorttxids.size() != cmpctblock.shorttxids.size())
+        return READ_STATUS_FAILED; // Short ID collision
+
+    std::vector<bool> have_txn(txn_available.size());
+    LOCK(pool->cs);
+    for (CTxMemPool::txiter it = pool->mapTx.begin(); it != pool->mapTx.end(); it++) {
+        std::unordered_map<uint64_t, uint16_t>::iterator idit = shorttxids.find(cmpctblock.GetShortID(it->GetTx().GetHash()));
+        if (idit != shorttxids.end()) {
+            if (!have_txn[idit->second]) {
+                txn_available[idit->second] = it->GetSharedTx();
+                have_txn[idit->second]  = true;
+            } else {
+                // If we find two mempool txn that match the short id, just request it.
+                // This should be rare enough that the extra bandwidth doesn't matter,
+                // but eating a round-trip due to FillBlock failure would be annoying
+                txn_available[idit->second].reset();
+            }
+        }
+        // Though ideally we'd continue scanning for the two-txn-match-shortid case,
+        // the performance win of an early exit here is too good to pass up and worth
+        // the extra risk.
+        if (mempool_count == shorttxids.size())
+            break;
+    }
+
+    return READ_STATUS_OK;
+}
+
+bool PartiallyDownloadedBlock::IsTxAvailable(size_t index) const {
+    assert(!header.IsNull());
+    assert(index < txn_available.size());
+    return txn_available[index] ? true : false;
+}
+
+ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const std::vector<CTransaction>& vtx_missing) const {
+    assert(!header.IsNull());
+    block = header;
+    block.vtx.resize(txn_available.size());
+
+    size_t tx_missing_offset = 0;
+    for (size_t i = 0; i < txn_available.size(); i++) {
+        if (!txn_available[i]) {
+            if (vtx_missing.size() <= tx_missing_offset)
+                return READ_STATUS_INVALID;
+            block.vtx[i] = vtx_missing[tx_missing_offset++];
+        } else
+            block.vtx[i] = *txn_available[i];
+    }
+    if (vtx_missing.size() != tx_missing_offset)
+        return READ_STATUS_INVALID;
+
+    CValidationState state;
+    if (!CheckBlock(block, state, Params().GetConsensus())) {
+        // TODO: We really want to just check merkle tree manually here,
+        // but that is expensive, and CheckBlock caches a block's
+        // "checked-status" (in the CBlock?). CBlock should be able to
+        // check its own merkle root and cache that check.
+        if (state.CorruptionPossible())
+            return READ_STATUS_FAILED; // Possible Short ID collision
+        return READ_STATUS_INVALID;
+    }
+
+    return READ_STATUS_OK;
+}

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -11,6 +11,7 @@
 #include "streams.h"
 #include "txmempool.h"
 #include "main.h"
+#include "util.h"
 
 #include <unordered_map>
 
@@ -72,6 +73,7 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
         }
         txn_available[lastprefilledindex] = std::make_shared<CTransaction>(cmpctblock.prefilledtxn[i].tx);
     }
+    prefilled_count = cmpctblock.prefilledtxn.size();
 
     // Calculate map of txids -> positions and check mempool to see what we have (or dont)
     // Because well-formed cmpctblock messages will have a (relatively) uniform distribution
@@ -103,11 +105,15 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
             if (!have_txn[idit->second]) {
                 txn_available[idit->second] = it->GetSharedTx();
                 have_txn[idit->second]  = true;
+                mempool_count++;
             } else {
                 // If we find two mempool txn that match the short id, just request it.
                 // This should be rare enough that the extra bandwidth doesn't matter,
                 // but eating a round-trip due to FillBlock failure would be annoying
-                txn_available[idit->second].reset();
+                if (txn_available[idit->second]) {
+                    txn_available[idit->second].reset();
+                    mempool_count--;
+                }
             }
         }
         // Though ideally we'd continue scanning for the two-txn-match-shortid case,
@@ -116,6 +122,8 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
         if (mempool_count == shorttxids.size())
             break;
     }
+
+    LogPrint("cmpctblock", "Initialized PartiallyDownloadedBlock for block %s using a cmpctblock of size %lu\n", cmpctblock.header.GetHash().ToString(), cmpctblock.GetSerializeSize(SER_NETWORK, PROTOCOL_VERSION));
 
     return READ_STATUS_OK;
 }
@@ -152,6 +160,12 @@ ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const std::vector<
         if (state.CorruptionPossible())
             return READ_STATUS_FAILED; // Possible Short ID collision
         return READ_STATUS_INVALID;
+    }
+
+    LogPrint("cmpctblock", "Successfully reconstructed block %s with %lu txn prefilled, %lu txn from mempool and %lu txn requested\n", header.GetHash().ToString(), prefilled_count, mempool_count, vtx_missing.size());
+    if (vtx_missing.size() < 5) {
+        for(const CTransaction& tx : vtx_missing)
+            LogPrint("cmpctblock", "Reconstructed block %s required tx %s\n", header.GetHash().ToString(), tx.GetHash().ToString());
     }
 
     return READ_STATUS_OK;

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -71,7 +71,7 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
             // have neither a prefilled txn or a shorttxid!
             return READ_STATUS_INVALID;
         }
-        txn_available[lastprefilledindex] = std::make_shared<CTransaction>(cmpctblock.prefilledtxn[i].tx);
+        txn_available[lastprefilledindex].reset(new CTransaction(cmpctblock.prefilledtxn[i].tx));
     }
     prefilled_count = cmpctblock.prefilledtxn.size();
 
@@ -103,7 +103,7 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
         std::unordered_map<uint64_t, uint16_t>::iterator idit = shorttxids.find(cmpctblock.GetShortID(it->GetTx().GetHash()));
         if (idit != shorttxids.end()) {
             if (!have_txn[idit->second]) {
-                txn_available[idit->second] = it->GetSharedTx();
+                txn_available[idit->second].reset(new CTransaction(it->GetTx()));
                 have_txn[idit->second]  = true;
                 mempool_count++;
             } else {
@@ -152,7 +152,7 @@ ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const std::vector<
         return READ_STATUS_INVALID;
 
     CValidationState state;
-    if (!CheckBlock(block, state, Params().GetConsensus())) {
+    if (!CheckBlock(block, state)) {
         // TODO: We really want to just check merkle tree manually here,
         // but that is expensive, and CheckBlock caches a block's
         // "checked-status" (in the CBlock?). CBlock should be able to

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2016 The Bitcoin Core developers
+// Copyright (c) 2016 The Bitcoin XT developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -15,21 +16,45 @@
 
 #include <unordered_map>
 
+uint64_t GetShortID(
+        const uint64_t& shorttxidk0,
+        const uint64_t& shorttxidk1,
+        const uint256& txhash)
+{
+    static_assert(CompactBlock::SHORTTXIDS_LENGTH == 6, "shorttxids calculation assumes 6-byte shorttxids");
+    return SipHashUint256(shorttxidk0, shorttxidk1, txhash) & 0xffffffffffffL;
+}
+
 #define MIN_TRANSACTION_SIZE (::GetSerializeSize(CTransaction(), SER_NETWORK, PROTOCOL_VERSION))
 
-CBlockHeaderAndShortTxIDs::CBlockHeaderAndShortTxIDs(const CBlock& block) :
-        nonce(GetRand(std::numeric_limits<uint64_t>::max())),
-        shorttxids(block.vtx.size() - 1), prefilledtxn(1), header(block) {
+CompactBlock::CompactBlock(const CBlock& block,
+    const CRollingBloomFilter* inventoryKnown) :
+        nonce(GetRand(std::numeric_limits<uint64_t>::max())), header(block)
+{
     FillShortTxIDSelector();
-    //TODO: Use our mempool prior to block acceptance to predictively fill more than just the coinbase
-    prefilledtxn[0] = {0, block.vtx[0]};
+
+    if (block.vtx.empty())
+        throw std::invalid_argument(__func__ + std::string(" expects coinbase tx"));
+
+    //< Index of a prefilled tx is its diff from last index.
+    size_t prevIndex = 0;
+    prefilledtxn.push_back(PrefilledTransaction{0, block.vtx[0]});
+
     for (size_t i = 1; i < block.vtx.size(); i++) {
         const CTransaction& tx = block.vtx[i];
-        shorttxids[i - 1] = GetShortID(tx.GetHash());
+
+        if (inventoryKnown && !inventoryKnown->contains(tx.GetHash()))
+        {
+            prefilledtxn.push_back(PrefilledTransaction{
+                    static_cast<uint16_t>(i - prevIndex), tx});
+            prevIndex = i;
+        }
+        else
+            shorttxids.push_back(GetShortID(tx.GetHash()));
     }
 }
 
-void CBlockHeaderAndShortTxIDs::FillShortTxIDSelector() const {
+void CompactBlock::FillShortTxIDSelector() const {
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
     stream << header << nonce;
     CSHA256 hasher;
@@ -40,133 +65,31 @@ void CBlockHeaderAndShortTxIDs::FillShortTxIDSelector() const {
     shorttxidk1 = shorttxidhash.GetUint64(1);
 }
 
-uint64_t CBlockHeaderAndShortTxIDs::GetShortID(const uint256& txhash) const {
-    static_assert(SHORTTXIDS_LENGTH == 6, "shorttxids calculation assumes 6-byte shorttxids");
-    return SipHashUint256(shorttxidk0, shorttxidk1, txhash) & 0xffffffffffffL;
+uint64_t CompactBlock::GetShortID(const uint256& txhash) const {
+    return ::GetShortID(shorttxidk0, shorttxidk1, txhash);
 }
 
-
-
-ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& cmpctblock) {
+void validateCompactBlock(const CompactBlock& cmpctblock) {
     if (cmpctblock.header.IsNull() || (cmpctblock.shorttxids.empty() && cmpctblock.prefilledtxn.empty()))
-        return READ_STATUS_INVALID;
-    if (cmpctblock.shorttxids.size() + cmpctblock.prefilledtxn.size() > MAX_BLOCK_SIZE / MIN_TRANSACTION_SIZE)
-        return READ_STATUS_INVALID;
+        throw std::invalid_argument("empty data in compact block");
 
-    assert(header.IsNull() && txn_available.empty());
-    header = cmpctblock.header;
-    txn_available.resize(cmpctblock.BlockTxCount());
+    if (cmpctblock.shorttxids.size() + cmpctblock.prefilledtxn.size() > MAX_BLOCK_SIZE / MIN_TRANSACTION_SIZE)
+        throw std::invalid_argument("compact block exceeds max txs in a block");
 
     int32_t lastprefilledindex = -1;
     for (size_t i = 0; i < cmpctblock.prefilledtxn.size(); i++) {
         if (cmpctblock.prefilledtxn[i].tx.IsNull())
-            return READ_STATUS_INVALID;
+            throw std::invalid_argument("null tx in compact block");
 
         lastprefilledindex += cmpctblock.prefilledtxn[i].index + 1; //index is a uint16_t, so cant overflow here
         if (lastprefilledindex > std::numeric_limits<uint16_t>::max())
-            return READ_STATUS_INVALID;
-        if ((uint32_t)lastprefilledindex > cmpctblock.shorttxids.size() + i) {
+            throw std::invalid_argument("tx index overflows");
+
+        if (static_cast<uint32_t>(lastprefilledindex) > cmpctblock.shorttxids.size() + i) {
             // If we are inserting a tx at an index greater than our full list of shorttxids
             // plus the number of prefilled txn we've inserted, then we have txn for which we
             // have neither a prefilled txn or a shorttxid!
-            return READ_STATUS_INVALID;
+            throw std::invalid_argument("invalid index for tx");
         }
-        txn_available[lastprefilledindex].reset(new CTransaction(cmpctblock.prefilledtxn[i].tx));
     }
-    prefilled_count = cmpctblock.prefilledtxn.size();
-
-    // Calculate map of txids -> positions and check mempool to see what we have (or dont)
-    // Because well-formed cmpctblock messages will have a (relatively) uniform distribution
-    // of short IDs, any highly-uneven distribution of elements can be safely treated as a
-    // READ_STATUS_FAILED.
-    std::unordered_map<uint64_t, uint16_t> shorttxids(cmpctblock.shorttxids.size());
-    uint16_t index_offset = 0;
-    for (size_t i = 0; i < cmpctblock.shorttxids.size(); i++) {
-        while (txn_available[i + index_offset])
-            index_offset++;
-        shorttxids[cmpctblock.shorttxids[i]] = i + index_offset;
-        // Bucket selection is a simple Binomial distribution. If we assume blocks of
-        // 10,000 transactions, allowing up to 12 elements per bucket should only fail
-        // once every ~1.3 million blocks and once every 74,000 blocks in a worst-case
-        // 16,000-transaction block.
-        if (shorttxids.bucket_size(shorttxids.bucket(cmpctblock.shorttxids[i])) > 12)
-            return READ_STATUS_FAILED;
-    }
-    // TODO: in the shortid-collision case, we should instead request both transactions
-    // which collided. Falling back to full-block-request here is overkill.
-    if (shorttxids.size() != cmpctblock.shorttxids.size())
-        return READ_STATUS_FAILED; // Short ID collision
-
-    std::vector<bool> have_txn(txn_available.size());
-    LOCK(pool->cs);
-    for (CTxMemPool::txiter it = pool->mapTx.begin(); it != pool->mapTx.end(); it++) {
-        std::unordered_map<uint64_t, uint16_t>::iterator idit = shorttxids.find(cmpctblock.GetShortID(it->GetTx().GetHash()));
-        if (idit != shorttxids.end()) {
-            if (!have_txn[idit->second]) {
-                txn_available[idit->second].reset(new CTransaction(it->GetTx()));
-                have_txn[idit->second]  = true;
-                mempool_count++;
-            } else {
-                // If we find two mempool txn that match the short id, just request it.
-                // This should be rare enough that the extra bandwidth doesn't matter,
-                // but eating a round-trip due to FillBlock failure would be annoying
-                if (txn_available[idit->second]) {
-                    txn_available[idit->second].reset();
-                    mempool_count--;
-                }
-            }
-        }
-        // Though ideally we'd continue scanning for the two-txn-match-shortid case,
-        // the performance win of an early exit here is too good to pass up and worth
-        // the extra risk.
-        if (mempool_count == shorttxids.size())
-            break;
-    }
-
-    LogPrint("cmpctblock", "Initialized PartiallyDownloadedBlock for block %s using a cmpctblock of size %lu\n", cmpctblock.header.GetHash().ToString(), cmpctblock.GetSerializeSize(SER_NETWORK, PROTOCOL_VERSION));
-
-    return READ_STATUS_OK;
-}
-
-bool PartiallyDownloadedBlock::IsTxAvailable(size_t index) const {
-    assert(!header.IsNull());
-    assert(index < txn_available.size());
-    return txn_available[index] ? true : false;
-}
-
-ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const std::vector<CTransaction>& vtx_missing) const {
-    assert(!header.IsNull());
-    block = header;
-    block.vtx.resize(txn_available.size());
-
-    size_t tx_missing_offset = 0;
-    for (size_t i = 0; i < txn_available.size(); i++) {
-        if (!txn_available[i]) {
-            if (vtx_missing.size() <= tx_missing_offset)
-                return READ_STATUS_INVALID;
-            block.vtx[i] = vtx_missing[tx_missing_offset++];
-        } else
-            block.vtx[i] = *txn_available[i];
-    }
-    if (vtx_missing.size() != tx_missing_offset)
-        return READ_STATUS_INVALID;
-
-    CValidationState state;
-    if (!CheckBlock(block, state)) {
-        // TODO: We really want to just check merkle tree manually here,
-        // but that is expensive, and CheckBlock caches a block's
-        // "checked-status" (in the CBlock?). CBlock should be able to
-        // check its own merkle root and cache that check.
-        if (state.CorruptionPossible())
-            return READ_STATUS_FAILED; // Possible Short ID collision
-        return READ_STATUS_INVALID;
-    }
-
-    LogPrint("cmpctblock", "Successfully reconstructed block %s with %lu txn prefilled, %lu txn from mempool and %lu txn requested\n", header.GetHash().ToString(), prefilled_count, mempool_count, vtx_missing.size());
-    if (vtx_missing.size() < 5) {
-        for(const CTransaction& tx : vtx_missing)
-            LogPrint("cmpctblock", "Reconstructed block %s required tx %s\n", header.GetHash().ToString(), tx.GetHash().ToString());
-    }
-
-    return READ_STATUS_OK;
 }

--- a/src/blockencodings.h
+++ b/src/blockencodings.h
@@ -1,0 +1,205 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_BLOCK_ENCODINGS_H
+#define BITCOIN_BLOCK_ENCODINGS_H
+
+#include "primitives/block.h"
+
+#include <memory>
+
+class CTxMemPool;
+
+// Dumb helper to handle CTransaction compression at serialize-time
+struct TransactionCompressor {
+private:
+    CTransaction& tx;
+public:
+    TransactionCompressor(CTransaction& txIn) : tx(txIn) {}
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(tx); //TODO: Compress tx encoding
+    }
+};
+
+class BlockTransactionsRequest {
+public:
+    // A BlockTransactionsRequest message
+    uint256 blockhash;
+    std::vector<uint16_t> indexes;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(blockhash);
+        uint64_t indexes_size = (uint64_t)indexes.size();
+        READWRITE(COMPACTSIZE(indexes_size));
+        if (ser_action.ForRead()) {
+            size_t i = 0;
+            while (indexes.size() < indexes_size) {
+                indexes.resize(std::min((uint64_t)(1000 + indexes.size()), indexes_size));
+                for (; i < indexes.size(); i++) {
+                    uint64_t index = 0;
+                    READWRITE(COMPACTSIZE(index));
+                    if (index > std::numeric_limits<uint16_t>::max())
+                        throw std::ios_base::failure("index overflowed 16 bits");
+                    indexes[i] = index;
+                }
+            }
+
+            uint16_t offset = 0;
+            for (size_t i = 0; i < indexes.size(); i++) {
+                if (uint64_t(indexes[i]) + uint64_t(offset) > std::numeric_limits<uint16_t>::max())
+                    throw std::ios_base::failure("indexes overflowed 16 bits");
+                indexes[i] = indexes[i] + offset;
+                offset = indexes[i] + 1;
+            }
+        } else {
+            for (size_t i = 0; i < indexes.size(); i++) {
+                uint64_t index = indexes[i] - (i == 0 ? 0 : (indexes[i - 1] + 1));
+                READWRITE(COMPACTSIZE(index));
+            }
+        }
+    }
+};
+
+class BlockTransactions {
+public:
+    // A BlockTransactions message
+    uint256 blockhash;
+    std::vector<CTransaction> txn;
+
+    BlockTransactions() {}
+    BlockTransactions(const BlockTransactionsRequest& req) :
+        blockhash(req.blockhash), txn(req.indexes.size()) {}
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(blockhash);
+        uint64_t txn_size = (uint64_t)txn.size();
+        READWRITE(COMPACTSIZE(txn_size));
+        if (ser_action.ForRead()) {
+            size_t i = 0;
+            while (txn.size() < txn_size) {
+                txn.resize(std::min((uint64_t)(1000 + txn.size()), txn_size));
+                for (; i < txn.size(); i++)
+                    READWRITE(REF(TransactionCompressor(txn[i])));
+            }
+        } else {
+            for (size_t i = 0; i < txn.size(); i++)
+                READWRITE(REF(TransactionCompressor(txn[i])));
+        }
+    }
+};
+
+// Dumb serialization/storage-helper for CBlockHeaderAndShortTxIDs and PartiallyDownlaodedBlock
+struct PrefilledTransaction {
+    // Used as an offset since last prefilled tx in CBlockHeaderAndShortTxIDs,
+    // as a proper transaction-in-block-index in PartiallyDownloadedBlock
+    uint16_t index;
+    CTransaction tx;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        uint64_t idx = index;
+        READWRITE(COMPACTSIZE(idx));
+        if (idx > std::numeric_limits<uint16_t>::max())
+            throw std::ios_base::failure("index overflowed 16-bits");
+        index = idx;
+        READWRITE(REF(TransactionCompressor(tx)));
+    }
+};
+
+typedef enum ReadStatus_t
+{
+    READ_STATUS_OK,
+    READ_STATUS_INVALID, // Invalid object, peer is sending bogus crap
+    READ_STATUS_FAILED, // Failed to process object
+} ReadStatus;
+
+class CBlockHeaderAndShortTxIDs {
+private:
+    mutable uint64_t shorttxidk0, shorttxidk1;
+    uint64_t nonce;
+
+    void FillShortTxIDSelector() const;
+
+    friend class PartiallyDownloadedBlock;
+
+    static const int SHORTTXIDS_LENGTH = 6;
+protected:
+    std::vector<uint64_t> shorttxids;
+    std::vector<PrefilledTransaction> prefilledtxn;
+
+public:
+    CBlockHeader header;
+
+    // Dummy for deserialization
+    CBlockHeaderAndShortTxIDs() {}
+
+    CBlockHeaderAndShortTxIDs(const CBlock& block);
+
+    uint64_t GetShortID(const uint256& txhash) const;
+
+    size_t BlockTxCount() const { return shorttxids.size() + prefilledtxn.size(); }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(header);
+        READWRITE(nonce);
+
+        uint64_t shorttxids_size = (uint64_t)shorttxids.size();
+        READWRITE(COMPACTSIZE(shorttxids_size));
+        if (ser_action.ForRead()) {
+            size_t i = 0;
+            while (shorttxids.size() < shorttxids_size) {
+                shorttxids.resize(std::min((uint64_t)(1000 + shorttxids.size()), shorttxids_size));
+                for (; i < shorttxids.size(); i++) {
+                    uint32_t lsb = 0; uint16_t msb = 0;
+                    READWRITE(lsb);
+                    READWRITE(msb);
+                    shorttxids[i] = (uint64_t(msb) << 32) | uint64_t(lsb);
+                    static_assert(SHORTTXIDS_LENGTH == 6, "shorttxids serialization assumes 6-byte shorttxids");
+                }
+            }
+        } else {
+            for (size_t i = 0; i < shorttxids.size(); i++) {
+                uint32_t lsb = shorttxids[i] & 0xffffffff;
+                uint16_t msb = (shorttxids[i] >> 32) & 0xffff;
+                READWRITE(lsb);
+                READWRITE(msb);
+            }
+        }
+
+        READWRITE(prefilledtxn);
+
+        if (ser_action.ForRead())
+            FillShortTxIDSelector();
+    }
+};
+
+class PartiallyDownloadedBlock {
+protected:
+    std::vector<std::shared_ptr<const CTransaction> > txn_available;
+    CTxMemPool* pool;
+public:
+    CBlockHeader header;
+    PartiallyDownloadedBlock(CTxMemPool* poolIn) : pool(poolIn) {}
+
+    ReadStatus InitData(const CBlockHeaderAndShortTxIDs& cmpctblock);
+    bool IsTxAvailable(size_t index) const;
+    ReadStatus FillBlock(CBlock& block, const std::vector<CTransaction>& vtx_missing) const;
+};
+
+#endif

--- a/src/blockencodings.h
+++ b/src/blockencodings.h
@@ -192,6 +192,7 @@ public:
 class PartiallyDownloadedBlock {
 protected:
     std::vector<std::shared_ptr<const CTransaction> > txn_available;
+    size_t prefilled_count = 0, mempool_count = 0;
     CTxMemPool* pool;
 public:
     CBlockHeader header;

--- a/src/blockencodings.h
+++ b/src/blockencodings.h
@@ -191,7 +191,7 @@ public:
 
 class PartiallyDownloadedBlock {
 protected:
-    std::vector<std::shared_ptr<const CTransaction> > txn_available;
+    std::vector<std::unique_ptr<CTransaction> > txn_available;
     size_t prefilled_count = 0, mempool_count = 0;
     CTxMemPool* pool;
 public:

--- a/src/blockprocessor.cpp
+++ b/src/blockprocessor.cpp
@@ -1,0 +1,63 @@
+#include "blockprocessor.h"
+#include "blockheaderprocessor.h"
+#include "consensus/validation.h"
+#include "main.h" // Misbehaving
+#include "thinblock.h"
+#include "util.h"
+#include "utilprocessmsg.h"
+
+void BlockProcessor::misbehave(int howmuch) {
+    Misbehaving(from.id, howmuch);
+}
+
+void BlockProcessor::rejectBlock(
+        const uint256& block, const std::string& reason, int misbehave)
+{
+    LogPrintf("rejecting %s from peer=%d - %s\n",
+        netcmd, from.id, reason);
+
+    from.PushMessage("reject", netcmd, REJECT_MALFORMED, reason, block);
+
+    this->misbehave(misbehave);
+    worker.setAvailable();
+}
+
+bool BlockProcessor::processHeader(const CBlockHeader& header) {
+
+        std::vector<CBlockHeader> h(1, header);
+
+        if (!headerProcessor(h, false, false)) {
+            rejectBlock(header.GetHash(), "invalid header", 20);
+            return false;
+        }
+        return true;
+}
+
+bool BlockProcessor::setToWork(const uint256& hash) {
+
+    if (HaveBlockData(hash)) {
+        LogPrint("thin", "already had block %s, "
+                "ignoring %s peer=%d\n",
+            hash.ToString(), netcmd, from.id);
+        worker.setAvailable();
+	    return false;
+    }
+
+    if (worker.isAvailable()) {
+        // Happens if:
+        // * We did not request block.
+        // * We already received block (after requesting it) and
+        //    found it to be invalid.
+        LogPrint("thin", "ignoring %s %s that peer is not working "
+                "on peer=%d\n", netcmd, hash.ToString(), from.id);
+        return false;
+    }
+
+    if (worker.blockHash() != hash) {
+        LogPrint("thin", "ignoring %s %s from peer=%d, "
+                "expecting block %s\n",
+		    netcmd, hash.ToString(), from.id, worker.blockStr());
+        return false;
+    }
+    return true;
+}

--- a/src/blockprocessor.h
+++ b/src/blockprocessor.h
@@ -1,0 +1,37 @@
+#ifndef BLOCKPROCESSOR_H
+#define BLOCKPROCESSOR_H
+
+#include <string>
+class CNode;
+class ThinBlockWorker;
+class BlockHeaderProcessor;
+class CBlockHeader;
+class uint256;
+
+class BlockProcessor {
+
+    public:
+        BlockProcessor(CNode& f, ThinBlockWorker& w, 
+                const std::string& netcmd, BlockHeaderProcessor& h) : 
+            from(f), worker(w), netcmd(netcmd), headerProcessor(h)
+        {
+        }
+
+        virtual ~BlockProcessor() = 0;
+        void rejectBlock(const uint256& block, const std::string& reason, int misbehave);
+        bool processHeader(const CBlockHeader& header);
+        bool setToWork(const uint256& hash);
+
+    protected:
+        CNode& from;
+        ThinBlockWorker& worker;
+        virtual void misbehave(int howmuch);
+        
+    private:
+        std::string netcmd;
+        BlockHeaderProcessor& headerProcessor;
+};
+
+inline BlockProcessor::~BlockProcessor() { }
+
+#endif

--- a/src/blocksender.cpp
+++ b/src/blocksender.cpp
@@ -138,12 +138,7 @@ void BlockSender::sendBlock(CNode& node,
     }
 
     if (invType == MSG_CMPCT_BLOCK && NodeStatePtr(node.id)->supportsCompactBlocks) {
-        std::unique_ptr<CRollingBloomFilter> filter;
-        {
-            LOCK(node.cs_inventory);
-            filter.reset(new CRollingBloomFilter(node.filterInventoryKnown));
-        }
-        CompactBlock cmpct(block, filter.get());
+        CompactBlock cmpct(block, *choosePrefiller(node));
         node.PushMessage("cmpctblock", cmpct);
         return;
     }

--- a/src/blocksender.h
+++ b/src/blocksender.h
@@ -28,7 +28,7 @@ class BlockSender {
             CBlockIndex& blockIndex, const CInv& inv);
 
         void sendBlock(CNode& node,
-            const CBlockIndex& blockIndex, int invType);
+            const CBlockIndex& blockIndex, int invType, int activeChainHeight);
 
         // Creates a response for a re-request for transactions missing
         // from a thin block.

--- a/src/blocksender.h
+++ b/src/blocksender.h
@@ -10,6 +10,7 @@ class CInv;
 class CNode;
 class CBlock;
 class XThinReRequest;
+class CompactReRequest;
 
 // Handles network 'getdata' requests for blocks.
 class BlockSender {
@@ -33,6 +34,11 @@ class BlockSender {
         // from a thin block.
         void sendReReqReponse(CNode& node, const CBlockIndex& blockIndex,
             const XThinReRequest& req);
+
+        // Creates a response for a re-request for transactions missing
+        // from a compact thin block.
+        void sendReReqReponse(CNode& node, const CBlockIndex& blockIndex,
+            const CompactReRequest& req);
 
     protected: // used in unit tests
         void triggerNextRequest(const CChain& activeChain, const CInv& inv, CNode& node);

--- a/src/compactblockprocessor.cpp
+++ b/src/compactblockprocessor.cpp
@@ -1,0 +1,82 @@
+#include "compactblockprocessor.h"
+#include "compactthin.h"
+#include "blockencodings.h"
+#include "thinblock.h"
+#include "streams.h"
+#include "util.h" // LogPrintf
+#include "net.h"
+#include "utilprocessmsg.h"
+#include "consensus/validation.h"
+
+void CompactBlockProcessor::operator()(CDataStream& vRecv, const TxFinder& txfinder)
+{
+    CompactBlock block;
+    vRecv >> block;
+
+    const uint256 hash = block.header.GetHash();
+
+    LogPrintf("received compactblock %s from peer=%d\n",
+            hash.ToString(), worker.nodeID());
+
+    try {
+        validateCompactBlock(block);
+    }
+    catch (const std::exception& e) {
+        LogPrint("thin", "Invalid compact block %s\n", e.what());
+        rejectBlock(hash, e.what(), 20);
+        return;
+    }
+
+    processHeader(block.header);
+
+    from.AddInventoryKnown(CInv(MSG_CMPCT_BLOCK, hash));
+
+    if (!setToWork(hash))
+        return;
+
+    std::unique_ptr<CompactStub> stub;
+    try {
+        stub.reset(new CompactStub(block));
+        worker.buildStub(*stub, txfinder);
+    }
+    catch (const thinblock_error& e) {
+        rejectBlock(hash, e.what(), 10);
+        return;
+    }
+
+    // If the stub was enough to finish the block then
+    // the worker will be available.
+    if (worker.isAvailable())
+        return;
+
+    // Request missing
+    std::vector<ThinTx> missing = worker.getTxsMissing();
+    assert(!missing.empty());
+
+    CompactReRequest req;
+    req.blockhash = hash;
+
+    std::vector<ThinTx> all = stub->allTransactions();
+
+    for (auto& tx : missing) {
+
+        auto res = std::find_if(begin(all), end(all), [&tx](const ThinTx& b) {
+            return tx.equals(b);
+        });
+        if (res == end(all)) {
+            std::stringstream ss;
+            ss << "Error: Did not find " << tx.obfuscated() << " missing, has: ";
+            for (auto& a : all)
+                ss << a.obfuscated() << "; ";
+            throw std::runtime_error(ss.str());
+        }
+
+        size_t index = std::distance(begin(all), res);
+
+        req.indexes.push_back(index);
+    }
+
+    LogPrint("thin", "re-requesting %d compact txs for %s peer=%d\n",
+            req.indexes.size(), hash.ToString(), from.id);
+    from.PushMessage("getblocktxn", req);
+}

--- a/src/compactblockprocessor.cpp
+++ b/src/compactblockprocessor.cpp
@@ -7,8 +7,9 @@
 #include "net.h"
 #include "utilprocessmsg.h"
 #include "consensus/validation.h"
+#include "compacttxfinder.h"
 
-void CompactBlockProcessor::operator()(CDataStream& vRecv, const TxFinder& txfinder)
+void CompactBlockProcessor::operator()(CDataStream& vRecv, const CTxMemPool& mempool)
 {
     CompactBlock block;
     vRecv >> block;
@@ -26,6 +27,9 @@ void CompactBlockProcessor::operator()(CDataStream& vRecv, const TxFinder& txfin
         rejectBlock(hash, e.what(), 20);
         return;
     }
+
+    CompactTxFinder txfinder(mempool,
+            block.shorttxidk0, block.shorttxidk1);
 
     processHeader(block.header);
 

--- a/src/compactblockprocessor.h
+++ b/src/compactblockprocessor.h
@@ -1,0 +1,20 @@
+#ifndef COMPACTBLOCKPROCESSOR_H
+#define COMPACTBLOCKPROCESSOR_H
+
+#include "blockprocessor.h"
+
+class CDataStream;
+class TxFinder;
+
+class CompactBlockProcessor : public BlockProcessor {
+    public:
+
+        CompactBlockProcessor(CNode& f, ThinBlockWorker& w, BlockHeaderProcessor& h) :
+            BlockProcessor(f, w, "cmpctblock", h)
+        {
+        }
+
+        void operator()(CDataStream& vRecv, const TxFinder& txfinde);
+};
+
+#endif

--- a/src/compactblockprocessor.h
+++ b/src/compactblockprocessor.h
@@ -4,7 +4,7 @@
 #include "blockprocessor.h"
 
 class CDataStream;
-class TxFinder;
+class CTxMemPool;
 
 class CompactBlockProcessor : public BlockProcessor {
     public:
@@ -14,7 +14,7 @@ class CompactBlockProcessor : public BlockProcessor {
         {
         }
 
-        void operator()(CDataStream& vRecv, const TxFinder& txfinde);
+        void operator()(CDataStream& vRecv, const CTxMemPool& mempool);
 };
 
 #endif

--- a/src/compactprefiller.cpp
+++ b/src/compactprefiller.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) 2016 The Bitcoin XT developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include "compactprefiller.h"
+#include "bloom.h"
+#include "net.h" // for CNode
+#include "primitives/block.h"
+#include "serialize.h"
+#include "sync.h"
+#include "version.h"
+#include "util.h"
+
+std::vector<PrefilledTransaction> CoinbaseOnlyPrefiller::fillFrom(
+        const CBlock& block) const {
+    return { PrefilledTransaction{0, block.vtx[0]} };
+};
+
+std::vector<PrefilledTransaction> InventoryKnownPrefiller::fillFrom(
+        const CBlock& block) const {
+
+    std::vector<PrefilledTransaction> filled;
+
+    size_t prevIndex = 0;
+    filled.push_back(PrefilledTransaction{0, block.vtx[0]});
+
+    const unsigned MAX_PREFILLED_SIZE = 10 * 1000; // 10KB
+    unsigned int txsSize = ::GetSerializeSize(
+            filled[0].tx, SER_NETWORK, PROTOCOL_VERSION);
+
+    for (size_t i = 1; i < block.vtx.size(); i++) {
+        const CTransaction& tx = block.vtx[i];
+
+        if (inventoryKnown->contains(tx.GetHash()))
+            continue;
+
+        txsSize += ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
+        if (txsSize > MAX_PREFILLED_SIZE) {
+            // Appending more would exceed MAX_PREFILLED_SIZE,
+            // just return what we have.
+            return filled;
+        }
+
+        filled.push_back(PrefilledTransaction{
+                static_cast<uint16_t>(i - (prevIndex + 1)), tx});
+        prevIndex = i;
+    }
+    return filled;
+}
+
+InventoryKnownPrefiller::InventoryKnownPrefiller(
+        std::unique_ptr<CRollingBloomFilter> inventoryKnown) :
+    inventoryKnown(std::move(inventoryKnown))
+{
+}
+
+InventoryKnownPrefiller::~InventoryKnownPrefiller() { }
+
+std::unique_ptr<CompactPrefiller> choosePrefiller(CNode& node) {
+
+    if (!node.fRelayTxes) {
+        // Peer does not want us to relay transactions to it.
+        // We cannot assume anything about this peers mempool state.
+        // Fall back to the dumbest strategy.
+        return std::unique_ptr<CompactPrefiller>(new CoinbaseOnlyPrefiller);
+    }
+
+    // Ideas for future:
+    // * Strategy to prefill transactions that were not in our own mempool
+    //   at the time we received the block.
+    // * Prefill RBF transactions for non-Core nodes. A replaced RBP tx is
+    //   likely to be ignored as duplicate by all except for Core.
+
+    LOCK(node.cs_inventory);
+    std::unique_ptr<CRollingBloomFilter> copy(
+            new CRollingBloomFilter(node.filterInventoryKnown));
+    return std::unique_ptr<CompactPrefiller>(new InventoryKnownPrefiller(std::move(copy)));
+}

--- a/src/compactprefiller.h
+++ b/src/compactprefiller.h
@@ -1,0 +1,84 @@
+// Copyright (c) 2016 The Bitcoin XT developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_COMPACT_PREFILLER_H
+#define BITCOIN_COMPACT_PREFILLER_H
+
+#include <memory>
+#include "serialize.h"
+#include "primitives/transaction.h"
+
+class CBlock;
+class CNode;
+class CTransaction;
+class CRollingBloomFilter;
+
+// When sending a compact block to a peer, one should attempt
+// to prefill transactions that they are likely to be missing.
+
+// Dumb helper to handle CTransaction compression at serialize-time
+struct TransactionCompressor {
+private:
+    CTransaction& tx;
+public:
+    TransactionCompressor(CTransaction& txIn) : tx(txIn) {}
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(tx); //TODO: Compress tx encoding
+    }
+};
+
+struct PrefilledTransaction {
+    // Used as an offset since last prefilled tx in CompactBlock,
+    uint16_t index;
+    CTransaction tx;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        uint64_t idx = index;
+        READWRITE(COMPACTSIZE(idx));
+        if (idx > std::numeric_limits<uint16_t>::max())
+            throw std::ios_base::failure("index overflowed 16-bits");
+        index = idx;
+        READWRITE(REF(TransactionCompressor(tx)));
+    }
+};
+
+class CompactPrefiller {
+    public:
+        virtual std::vector<PrefilledTransaction> fillFrom(
+                const CBlock&) const = 0;
+
+        virtual ~CompactPrefiller() = 0;
+};
+inline CompactPrefiller::~CompactPrefiller() { }
+
+// Sends coinebase only. This is the same strategy that Core deploys in
+// Bitcoin Core 0.13. This strategy causes the most re-request round trips.
+class CoinbaseOnlyPrefiller : public CompactPrefiller {
+    public:
+        std::vector<PrefilledTransaction> fillFrom(const CBlock&) const override;
+};
+
+// This prefill strategy uses the inventory known filter to determine
+// what transactions the peer is missing.
+class InventoryKnownPrefiller : public CompactPrefiller {
+    public:
+        InventoryKnownPrefiller(std::unique_ptr<CRollingBloomFilter> inventoryKnown);
+        ~InventoryKnownPrefiller();
+
+        std::vector<PrefilledTransaction> fillFrom(const CBlock&) const override;
+    private:
+        const std::unique_ptr<CRollingBloomFilter> inventoryKnown;
+};
+
+// Since we're guessing what txs the peer needs, we need to pick a sane strategy
+// for each particular peer.
+std::unique_ptr<CompactPrefiller> choosePrefiller(CNode&);
+
+#endif

--- a/src/compactthin.cpp
+++ b/src/compactthin.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2016- The Bitcoin XT developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "compactthin.h"
+#include "protocol.h"
+#include <sstream>
+
+CompactWorker::CompactWorker(ThinBlockManager& m, NodeId n) :
+    ThinBlockWorker(m, n)
+{
+}
+
+void CompactWorker::requestBlock(const uint256& block,
+        std::vector<CInv>& getDataReq, CNode& node) {
+
+    getDataReq.push_back(CInv(MSG_CMPCT_BLOCK, block));
+}
+
+std::vector<ThinTx> CompactStub::allTransactions() const {
+
+    std::vector<ThinTx> all(block.BlockTxCount(), ThinTx(uint256()));
+
+    int lastIndex = -1;
+    for (size_t i = 0; i < block.prefilledtxn.size(); ++i) {
+        lastIndex += block.prefilledtxn.at(i).index + 1;
+        all.at(lastIndex) = ThinTx(
+            block.prefilledtxn.at(i).tx.GetHash());
+
+    }
+
+    uint64_t offset = 0;
+    for (size_t i = 0; i < block.shorttxids.size(); ++i) {
+        while (all.at(i + offset).hasFull())
+            ++offset;
+
+        all.at(i + offset) = ThinTx(block.shorttxids.at(i),
+                    block.shorttxidk0, block.shorttxidk1);
+    }
+
+    for (size_t i = 0; i < all.size(); ++i) {
+        if (!all[i].isNull())
+            continue;
+        std::stringstream err;
+        err << "Failed to read all tx ids from block. "
+            << "Tx at index " << i << " is null "
+            << " (total " <<  all.size() << "txs)";
+        throw thinblock_error(err.str());
+    }
+    return all;
+}

--- a/src/compactthin.h
+++ b/src/compactthin.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2016- The Bitcoin XT developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_COMPACTTHIN_H
+#define BITCOIN_COMPACTTHIN_H
+
+#include "blockencodings.h"
+#include "thinblock.h"
+#include "util.h"
+
+// Core also wanted to make their own thin
+// blocks solution; Compact Blocks (BIP152)
+//
+// This is our implementation of it.
+
+class CompactWorker : public ThinBlockWorker {
+
+    public:
+        CompactWorker(ThinBlockManager&, NodeId);
+
+        void requestBlock(const uint256& block,
+                std::vector<CInv>& getDataReq, CNode& node) override;
+};
+
+
+struct CompactStub : public StubData {
+    CompactStub(const CompactBlock& b) : block(b) {
+        LogPrint("thin", "Created compact stub for %s, %d transactions.\n",
+                header().GetHash().ToString(), allTransactions().size());
+
+    }
+
+    CBlockHeader header() const override {
+        return block.header;
+    }
+
+    std::vector<ThinTx> allTransactions() const override;
+
+    // Transactions provided in the stub
+    std::vector<CTransaction> missingProvided() const override {
+        std::vector<CTransaction> txs;
+
+        for (auto& p : block.prefilledtxn)
+            txs.push_back(p.tx);
+
+        return txs;
+    }
+
+    private:
+        CompactBlock block;
+};
+
+#endif

--- a/src/compacttxfinder.cpp
+++ b/src/compacttxfinder.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2016 The Bitcoin XT developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include "compacttxfinder.h"
+#include "util.h"
+#include "txmempool.h"
+#include "blockencodings.h" // GetShortID
+
+CompactTxFinder::CompactTxFinder(const CTxMemPool& m,
+        uint64_t idk0, uint64_t idk1) : mempool(m) {
+    initMapping(idk0, idk1);
+}
+
+void CompactTxFinder::initMapping(uint64_t idk0, uint64_t idk1) {
+
+    std::vector<uint256> hashes;
+    mempool.queryHashes(hashes);
+
+    for (auto& t : hashes) {
+        uint64_t shortID = GetShortID(idk0, idk1, t);
+
+        if (mappedMempool.count(shortID)) {
+
+            LogPrint("thin", "ShortID hash collision in mempool");
+
+            // Erase, so the tx re-fetched from peer instead.
+            mappedMempool.erase(shortID);
+            continue;
+        }
+        mappedMempool[shortID] = t;
+    }
+}
+
+CTransaction CompactTxFinder::operator()(const ThinTx& hash) const {
+
+    CTransaction match;
+
+    if (!mappedMempool.count(hash.obfuscated()))
+        return match;
+
+    uint256 realHash = mappedMempool.find(hash.obfuscated())->second;
+
+    // Tx may not exist anymore in mempool.
+    // Lookup leaves match empty if it does not.
+    mempool.lookup(realHash, match);
+    return match;
+}
+

--- a/src/compacttxfinder.h
+++ b/src/compacttxfinder.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2016 The Bitcoin XT developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#ifndef CompactTxFinderH
+#define CompactTxFinderH
+
+#include "uint256.h"
+#include "thinblock.h" // TxFinder
+#include <unordered_map>
+
+class CTxMemPool;
+class CTransaction;
+class ThinTx;
+
+// Specialized tx finder for looking up
+// compact block transactions in mempool
+//
+// The generic tx finder is in-efficient for compact blocks
+// due to all mempool txs being hashed for every lookup.
+class CompactTxFinder : public TxFinder {
+    public:
+
+        CompactTxFinder(const CTxMemPool& m,
+            uint64_t idk0, uint64_t idk1);
+
+        void initMapping(uint64_t idk0, uint64_t idk1);
+
+        CTransaction operator()(const ThinTx& hash) const override;
+
+    private:
+        std::unordered_map<uint64_t, uint256> mappedMempool;
+        const CTxMemPool& mempool;
+};
+
+#endif

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -100,11 +100,14 @@ CSipHasher::CSipHasher(uint64_t k0, uint64_t k1)
     v[2] = 0x6c7967656e657261ULL ^ k0;
     v[3] = 0x7465646279746573ULL ^ k1;
     count = 0;
+    tmp = 0;
 }
 
 CSipHasher& CSipHasher::Write(uint64_t data)
 {
     uint64_t v0 = v[0], v1 = v[1], v2 = v[2], v3 = v[3];
+
+    assert(count % 8 == 0);
 
     v3 ^= data;
     SIPROUND;
@@ -116,7 +119,35 @@ CSipHasher& CSipHasher::Write(uint64_t data)
     v[2] = v2;
     v[3] = v3;
 
-    count++;
+    count += 8;
+    return *this;
+}
+
+CSipHasher& CSipHasher::Write(const unsigned char* data, size_t size)
+{
+    uint64_t v0 = v[0], v1 = v[1], v2 = v[2], v3 = v[3];
+    uint64_t t = tmp;
+    int c = count;
+
+    while (size--) {
+        t |= ((uint64_t)(*(data++))) << (8 * (c % 8));
+        c++;
+        if ((c & 7) == 0) {
+            v3 ^= t;
+            SIPROUND;
+            SIPROUND;
+            v0 ^= t;
+            t = 0;
+        }
+    }
+
+    v[0] = v0;
+    v[1] = v1;
+    v[2] = v2;
+    v[3] = v3;
+    count = c;
+    tmp = t;
+
     return *this;
 }
 
@@ -124,10 +155,12 @@ uint64_t CSipHasher::Finalize() const
 {
     uint64_t v0 = v[0], v1 = v[1], v2 = v[2], v3 = v[3];
 
-    v3 ^= ((uint64_t)count) << 59;
+    uint64_t t = tmp | (((uint64_t)count) << 56);
+
+    v3 ^= t;
     SIPROUND;
     SIPROUND;
-    v0 ^= ((uint64_t)count) << 59;
+    v0 ^= t;
     v2 ^= 0xFF;
     SIPROUND;
     SIPROUND;

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -81,3 +81,97 @@ void BIP32Hash(const ChainCode &chainCode, unsigned int nChild, unsigned char he
     num[3] = (nChild >>  0) & 0xFF;
     CHMAC_SHA512(chainCode.begin(), chainCode.size()).Write(&header, 1).Write(data, 32).Write(num, 4).Finalize(output);
 }
+
+#define ROTL(x, b) (uint64_t)(((x) << (b)) | ((x) >> (64 - (b))))
+
+#define SIPROUND do { \
+    v0 += v1; v1 = ROTL(v1, 13); v1 ^= v0; \
+    v0 = ROTL(v0, 32); \
+    v2 += v3; v3 = ROTL(v3, 16); v3 ^= v2; \
+    v0 += v3; v3 = ROTL(v3, 21); v3 ^= v0; \
+    v2 += v1; v1 = ROTL(v1, 17); v1 ^= v2; \
+    v2 = ROTL(v2, 32); \
+} while (0)
+
+CSipHasher::CSipHasher(uint64_t k0, uint64_t k1)
+{
+    v[0] = 0x736f6d6570736575ULL ^ k0;
+    v[1] = 0x646f72616e646f6dULL ^ k1;
+    v[2] = 0x6c7967656e657261ULL ^ k0;
+    v[3] = 0x7465646279746573ULL ^ k1;
+    count = 0;
+}
+
+CSipHasher& CSipHasher::Write(uint64_t data)
+{
+    uint64_t v0 = v[0], v1 = v[1], v2 = v[2], v3 = v[3];
+
+    v3 ^= data;
+    SIPROUND;
+    SIPROUND;
+    v0 ^= data;
+
+    v[0] = v0;
+    v[1] = v1;
+    v[2] = v2;
+    v[3] = v3;
+
+    count++;
+    return *this;
+}
+
+uint64_t CSipHasher::Finalize() const
+{
+    uint64_t v0 = v[0], v1 = v[1], v2 = v[2], v3 = v[3];
+
+    v3 ^= ((uint64_t)count) << 59;
+    SIPROUND;
+    SIPROUND;
+    v0 ^= ((uint64_t)count) << 59;
+    v2 ^= 0xFF;
+    SIPROUND;
+    SIPROUND;
+    SIPROUND;
+    SIPROUND;
+    return v0 ^ v1 ^ v2 ^ v3;
+}
+
+uint64_t SipHashUint256(uint64_t k0, uint64_t k1, const uint256& val)
+{
+    /* Specialized implementation for efficiency */
+    uint64_t d = val.GetUint64(0);
+
+    uint64_t v0 = 0x736f6d6570736575ULL ^ k0;
+    uint64_t v1 = 0x646f72616e646f6dULL ^ k1;
+    uint64_t v2 = 0x6c7967656e657261ULL ^ k0;
+    uint64_t v3 = 0x7465646279746573ULL ^ k1 ^ d;
+
+    SIPROUND;
+    SIPROUND;
+    v0 ^= d;
+    d = val.GetUint64(1);
+    v3 ^= d;
+    SIPROUND;
+    SIPROUND;
+    v0 ^= d;
+    d = val.GetUint64(2);
+    v3 ^= d;
+    SIPROUND;
+    SIPROUND;
+    v0 ^= d;
+    d = val.GetUint64(3);
+    v3 ^= d;
+    SIPROUND;
+    SIPROUND;
+    v0 ^= d;
+    v3 ^= ((uint64_t)4) << 59;
+    SIPROUND;
+    SIPROUND;
+    v0 ^= ((uint64_t)4) << 59;
+    v2 ^= 0xFF;
+    SIPROUND;
+    SIPROUND;
+    SIPROUND;
+    SIPROUND;
+    return v0 ^ v1 ^ v2 ^ v3;
+}

--- a/src/hash.h
+++ b/src/hash.h
@@ -168,4 +168,19 @@ unsigned int MurmurHash3(unsigned int nHashSeed, const std::vector<unsigned char
 
 void BIP32Hash(const ChainCode &chainCode, unsigned int nChild, unsigned char header, const unsigned char data[32], unsigned char output[64]);
 
+/** SipHash-2-4, using a uint64_t-based (rather than byte-based) interface */
+class CSipHasher
+{
+private:
+    uint64_t v[4];
+    int count;
+
+public:
+    CSipHasher(uint64_t k0, uint64_t k1);
+    CSipHasher& Write(uint64_t data);
+    uint64_t Finalize() const;
+};
+
+uint64_t SipHashUint256(uint64_t k0, uint64_t k1, const uint256& val);
+
 #endif // BITCOIN_HASH_H

--- a/src/hash.h
+++ b/src/hash.h
@@ -168,19 +168,38 @@ unsigned int MurmurHash3(unsigned int nHashSeed, const std::vector<unsigned char
 
 void BIP32Hash(const ChainCode &chainCode, unsigned int nChild, unsigned char header, const unsigned char data[32], unsigned char output[64]);
 
-/** SipHash-2-4, using a uint64_t-based (rather than byte-based) interface */
+/** SipHash-2-4 */
 class CSipHasher
 {
 private:
     uint64_t v[4];
+    uint64_t tmp;
     int count;
 
 public:
+    /** Construct a SipHash calculator initialized with 128-bit key (k0, k1) */
     CSipHasher(uint64_t k0, uint64_t k1);
+    /** Hash a 64-bit integer worth of data
+     *  It is treated as if this was the little-endian interpretation of 8 bytes.
+     *  This function can only be used when a multiple of 8 bytes have been written so far.
+     */
     CSipHasher& Write(uint64_t data);
+    /** Hash arbitrary bytes. */
+    CSipHasher& Write(const unsigned char* data, size_t size);
+    /** Compute the 64-bit SipHash-2-4 of the data written so far. The object remains untouched. */
     uint64_t Finalize() const;
 };
 
+/** Optimized SipHash-2-4 implementation for uint256.
+ *
+ *  It is identical to:
+ *    SipHasher(k0, k1)
+ *      .Write(val.GetUint64(0))
+ *      .Write(val.GetUint64(1))
+ *      .Write(val.GetUint64(2))
+ *      .Write(val.GetUint64(3))
+ *      .Finalize()
+ */
 uint64_t SipHashUint256(uint64_t k0, uint64_t k1, const uint256& val);
 
 #endif // BITCOIN_HASH_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -330,7 +330,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-stealth-mode", _("Make this node act like a Bitcoin Core node from the wire perspective"));
     strUsage += HelpMessageOpt("-timeout=<n>", strprintf(_("Specify connection timeout in milliseconds (minimum: 1, default: %d)"), DEFAULT_CONNECT_TIMEOUT));
     strUsage += HelpMessageOpt("-uacomment", _("Add a comment into the user agent visible to other nodes"));
-    strUsage += HelpMessageOpt("-use-thin-blocks", _("Use thin blocks (low bandwidth block relay). (enable: 1, avoid full blocks: 2)"));
+    strUsage += HelpMessageOpt("-use-thin-blocks", _("Use thin blocks (low bandwidth block relay). (enable: 1, avoid full blocks: 2, optimal thin only + avoid: 3)"));
 #ifdef USE_UPNP
 #if USE_UPNP
     strUsage += HelpMessageOpt("-upnp", _("Use UPnP to map the listening port (default: 1 when listening)"));
@@ -341,7 +341,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-whitebind=<addr>", _("Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6"));
     strUsage += HelpMessageOpt("-whitelist=<netmask>", _("Whitelist peers connecting from the given netmask or IP address. Can be specified multiple times.") +
         " " + _("Whitelisted peers cannot be DoS banned and their transactions are always relayed, even if they are already in the mempool, useful e.g. for a gateway"));
-        
+
 
 #ifdef ENABLE_WALLET
     strUsage += HelpMessageGroup(_("Wallet options:"));
@@ -365,7 +365,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-respendnotify=<cmd>", _("Execute command when a network tx respends wallet tx input (%s=respend TxID, %t=wallet TxID)"));
     strUsage += HelpMessageOpt("-zapwallettxes=<mode>", _("Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup") +
         " " + _("(1 = keep tx meta data e.g. account owner and payment request information, 2 = drop tx meta data)"));
-                    
+
 #endif
 
     strUsage += HelpMessageGroup(_("Debugging/Testing options:"));
@@ -971,15 +971,15 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
         std::string warningString;
         std::string errorString;
-        
+
         if (!CWallet::Verify(strWalletFile, warningString, errorString))
             return false;
-        
+
         if (!warningString.empty())
             InitWarning(warningString);
         if (!errorString.empty())
             return InitError(warningString);
-        
+
     } // (!fDisableWallet)
 #endif // ENABLE_WALLET
     // ********************************************************* Step 6: network initialization

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5426,7 +5426,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
             DefaultHeaderProcessor headerp(pfrom, blocksInFlight, thinblockmg,
                     inFlight, CheckBlockIndex);
             CompactBlockProcessor blockp(*pfrom, *(nodestate->thinblock), headerp);
-            blockp(vRecv, TxFinderImpl());
+            blockp(vRecv, mempool);
         }
         catch (...) {
             LogPrintf("Unexpected error receiving cmpctblock from %d\n", pfrom->id);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,11 +9,14 @@
 #include "arith_uint256.h"
 #include "blockannounce.h"
 #include "blockheaderprocessor.h"
+#include "blockencodings.h"
 #include "blocksender.h"
 #include "bloomthin.h"
 #include "chainparams.h"
 #include "checkpoints.h"
 #include "checkqueue.h"
+#include "compactblockprocessor.h"
+#include "compactthin.h"
 #include "consensus/validation.h"
 #include "inflightindex.h"
 #include "init.h"
@@ -4660,21 +4663,18 @@ struct TxFinderImpl : public TxFinder {
         return tx;
     }
 
-    // "Cheap" refers to the hash. This lookup is much more expensive.
-    CTransaction cheapLookup(const uint64_t& h) const {
+    CTransaction lookup(const ThinTx& hash) const {
 
-        { // mempool
+        {
             LOCK(mempool.cs);
-            typedef CTxMemPool::indexed_transaction_set::const_iterator auto_;
-            for (auto_ t = mempool.mapTx.begin(); t != mempool.mapTx.end(); ++t)
-                if (t->GetTx().GetHash().GetCheapHash() == h)
+            for (auto t = mempool.mapTx.begin(); t != mempool.mapTx.end(); ++t)
+                if (hash.equals(t->GetTx().GetHash()))
                     return t->GetTx();
         }
 
-        typedef map<uint256, COrphanTx>::const_iterator auto_;
-        for (auto_ t = mapOrphanTransactions.begin(); t != mapOrphanTransactions.end(); ++t)
-            if (t->second.tx.GetHash().GetCheapHash() == h)
-                return t->second.tx;
+        for (auto t : mapOrphanTransactions)
+            if (hash.equals(t.second.tx.GetHash()))
+                return t.second.tx;
 
         // Skip relay map.
         return CTransaction();
@@ -4682,9 +4682,11 @@ struct TxFinderImpl : public TxFinder {
 
     CTransaction operator()(const ThinTx& hash) const {
         AssertLockHeld(cs_main);
-        return hash.hasFull()
-            ? fullLookup(hash.full())
-            : cheapLookup(hash.cheap());
+
+        if (hash.hasFull())
+            return fullLookup(hash.full()); // faster lookup
+
+        return lookup(hash);
     }
 };
 
@@ -4769,9 +4771,10 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
                 ns->thinblock.reset(new BloomThinWorker(thinblockmg, pfrom->id));
             else { /* keep DummyThinWorker */ }
 
-            bool hasRequiredThinSupport = Opt().XThinBlocksOnly()
-                ? pfrom->SupportsXThinBlocks()
-                : pfrom->SupportsBloomThinBlocks() || pfrom->SupportsXThinBlocks();
+            bool hasRequiredThinSupport = pfrom->SupportsXThinBlocks() || pfrom->SupportsCompactBlocks();
+            if (!Opt().OptimalThinBlocksOnly())
+                hasRequiredThinSupport = hasRequiredThinSupport || pfrom->SupportsBloomThinBlocks();
+
             // Disconnect outbound connections that don't support thin blocks.
             if (Opt().UsingThinBlocks() && !pfrom->fInbound && !hasRequiredThinSupport) {
                 LogPrintf("'%s' - peer=%d does not support thin blocks, disconnecting\n", pfrom->cleanSubVer, pfrom->id);
@@ -4850,11 +4853,9 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
         pfrom->nTimeOffset = nTimeOffset;
         AddTimeData(pfrom->addr, nTimeOffset);
 
+        // Enable bloom thin blocks on peer
         if (Opt().UsingThinBlocks() && pfrom->SupportsBloomThinBlocks() && !pfrom->SupportsXThinBlocks())
-        {
-            LogPrint("thin", "Enabling bloom thin blocks on peer %d\n", pfrom->id);
             pfrom->PushMessage("filterload", CBloomFilter());
-	}
     }
 
 
@@ -4881,6 +4882,20 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
             // non-NODE NETWORK peers can announce blocks (such as pruning
             // nodes)
             pfrom->PushMessage("sendheaders");
+        }
+
+        if (pfrom->nVersion >= SHORT_IDS_BLOCKS_VERSION
+                && !(pfrom->nServices & NODE_THIN)) {
+
+            // We prefer xthin, however if node does not support it,
+            // we ask it for thin block variant compact blocks.
+            //
+            // This also acts as announcement to tell the peer that we
+            // support compact blocks.
+
+            bool highBandwidth = false;
+            uint64_t version = 1;
+            pfrom->PushMessage("sendcmpct", highBandwidth, version);
         }
     }
 
@@ -4951,6 +4966,20 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
             pfrom->fDisconnect = true;
     }
 
+    else if (strCommand == "sendcmpct") {
+        bool highBandwidth = false;
+        uint64_t version = 1;
+        vRecv >> highBandwidth >> version;
+
+        if (version != 1)
+            return true; // Ignore as per BIP152
+
+        LOCK(cs_main);
+        NodeStatePtr(pfrom->id)->supportsCompactBlocks = true;
+        NodeStatePtr(pfrom->id)->thinblock.reset(
+                new CompactWorker(thinblockmg, pfrom->id));
+    }
+
     else if (strCommand == "sendheaders")
     {
         LOCK(cs_main);
@@ -5009,6 +5038,31 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
             pfrom->PushMessage("getdata", vToFetch);
     }
 
+    else if (strCommand == "getblocktxn")
+    {
+        // Remote peer is requesting more transactions as part of compact block
+        // transfer.
+        CompactReRequest req;
+        vRecv >> req;
+
+        LogPrint("thin", "peer=%d is compactthin re-requesting %d transactions for %s\n",
+                pfrom->id, req.indexes.size(), req.blockhash.ToString());
+
+        auto mi = mapBlockIndex.find(req.blockhash);
+        bool haveBlock = mi != mapBlockIndex.end();
+        BlockSender bs;
+        bool canSend = haveBlock && bs.canSend(
+                chainActive, *(mi->second), pindexBestHeader);
+
+        try {
+            if (canSend)
+                bs.sendReReqReponse(*pfrom, *(mi->second), req);
+        }
+        catch (const std::exception& e) {
+            LogPrintf("error in re-request from peer=%d: %s\n",
+                    pfrom->id, e.what());
+        }
+    }
 
     else if (strCommand == "getdata")
     {
@@ -5330,18 +5384,39 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
     }
     else if (strCommand == "xthinblock" && !fImporting && !fReindex) // Ignore blocks received while importing
     {
-        // This is a reponose to a xthin block request.
+        // We are receiving a xthin block.
         try {
             LOCK(cs_main);
             NodeStatePtr nodestate(pfrom->id);
             MarkBlockAsInFlight inFlight;
             DefaultHeaderProcessor headerp(pfrom, blocksInFlight, thinblockmg,
                 inFlight, CheckBlockIndex);
-            XThinBlockProcessor blockp(*pfrom);
-            blockp(vRecv, *(nodestate->thinblock), TxFinderImpl(), headerp);
+            XThinBlockProcessor blockp(*pfrom, *(nodestate->thinblock), headerp);
+            blockp(vRecv, TxFinderImpl());
         }
         catch (...) {
             LogPrintf("Unexpected error receiving xthinblock from %d\n", pfrom->id);
+            LOCK(cs_main);
+            NodeStatePtr nodestate(pfrom->id);
+            nodestate->thinblock->setAvailable();
+            Misbehaving(pfrom->GetId(), 10); // FIXME: Is this DoS policy reasonable? May not be pfrom's fault.
+            throw;
+        }
+    }
+    else if (strCommand == "cmpctblock" && !fImporting && !fReindex) // Ignore blocks received while importing
+    {
+        // We are receiving a compact block.
+        try {
+            LOCK(cs_main);
+            NodeStatePtr nodestate(pfrom->id);
+            MarkBlockAsInFlight inFlight;
+            DefaultHeaderProcessor headerp(pfrom, blocksInFlight, thinblockmg,
+                    inFlight, CheckBlockIndex);
+            CompactBlockProcessor blockp(*pfrom, *(nodestate->thinblock), headerp);
+            blockp(vRecv, TxFinderImpl());
+        }
+        catch (...) {
+            LogPrintf("Unexpected error receiving cmpctblock from %d\n", pfrom->id);
             LOCK(cs_main);
             NodeStatePtr nodestate(pfrom->id);
             nodestate->thinblock->setAvailable();
@@ -5389,7 +5464,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
 
         XThinReRequest req;
         vRecv >> req;
-        LogPrint("thin", "peer=%d is re-requesting %d transactions for %s\n",
+        LogPrint("thin", "peer=%d is xthin re-requesting %d transactions for %s\n",
                 pfrom->id, req.txRequesting.size(), req.block.ToString());
 
         BlockMap::iterator mi = mapBlockIndex.find(req.block);
@@ -5403,7 +5478,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
                 bs.sendReReqReponse(*pfrom, *(mi->second), req);
         }
         catch (const std::exception& e) {
-            LogPrintf("error in re-request from peer=%d: %s\n",
+            LogPrintf("error in xthin re-request from peer=%d: %s\n",
                     pfrom->id, e.what());
         }
     }
@@ -5419,6 +5494,20 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
         LOCK(cs_main);
         NodeStatePtr statePtr(pfrom->id);
         XThinBlockConcluder()(resp, *pfrom, *(statePtr->thinblock));
+    }
+
+    else if (strCommand == "blocktxn") {
+        // This is a response for us requesting missing transactions from
+        // xthinblocks.
+
+        CompactReReqResponse resp;
+        vRecv >> resp;
+        LogPrint("thin", "recieved re-request response from peer=%d with %d txs for %s\n",
+            pfrom->id, resp.txn.size(), resp.blockhash.ToString());
+
+        LOCK(cs_main);
+        NodeStatePtr statePtr(pfrom->id);
+        CompactBlockConcluder()(resp, *pfrom, *(statePtr->thinblock));
     }
 
     // This asymmetric behavior for inbound and outbound connections was introduced
@@ -5777,11 +5866,13 @@ bool WillDownloadFromNode(CNode* pto, const ThinBlockWorker& worker) {
         return true;
 
     // We want thin blocks only, but peer does not support it.
-    if (!(pto->SupportsBloomThinBlocks() || pto->SupportsXThinBlocks()))
+    if (!(pto->SupportsBloomThinBlocks() || pto->SupportsXThinBlocks()
+                || NodeStatePtr(pto->id)->supportsCompactBlocks))
         return false;
 
-    // We want xthin only, but peer does not support it.
-    if (Opt().XThinBlocksOnly() && !pto->SupportsXThinBlocks())
+    // We want optimal thin blocks only, but peer does not support it.
+    if (Opt().OptimalThinBlocksOnly() && !(pto->SupportsXThinBlocks()
+            || NodeStatePtr(pto->id)->supportsCompactBlocks))
         return false;
 
     // Is node busy serving a thin block already?

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4898,7 +4898,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
         }
 
         if (pfrom->nVersion >= SHORT_IDS_BLOCKS_VERSION
-                && !(pfrom->nServices & NODE_THIN)) {
+                && (!(pfrom->nServices & NODE_THIN) || Opt().PreferCompactBlocks())) {
 
             // We prefer xthin, however if node does not support it,
             // we ask it for thin block variant compact blocks.

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2201,3 +2201,11 @@ bool CNode::SupportsBloomThinBlocks() const {
 bool CNode::SupportsXThinBlocks() const {
     return nServices & NODE_THIN;
 }
+
+bool CNode::SupportsCompactBlocks() const {
+
+    // If a Core node activates segwit, it also
+    // disables support for compact blocks v1
+    return nVersion >= SHORT_IDS_BLOCKS_VERSION
+        && !(nServices & NODE_WITNESS);
+}

--- a/src/net.h
+++ b/src/net.h
@@ -661,6 +661,7 @@ public:
 
     bool SupportsBloomThinBlocks() const;
     bool SupportsXThinBlocks() const;
+    bool SupportsCompactBlocks() const;
 };
 
 

--- a/src/nodestate.cpp
+++ b/src/nodestate.cpp
@@ -1,6 +1,8 @@
 #include "nodestate.h"
 #include "dummythin.h"
 #include "net.h" // for CNode
+#include "thinblock.h"
+#include <utility>
 
 CNodeState::CNodeState(NodeId id, ThinBlockManager& thinblockmg) {
     fCurrentlyConnected = false;
@@ -18,6 +20,7 @@ CNodeState::CNodeState(NodeId id, ThinBlockManager& thinblockmg) {
     fPreferredDownload = false;
     prefersHeaders = false;
     initialHeadersReceived = false;
+    supportsCompactBlocks = false;
     thinblock.reset(new DummyThinWorker(thinblockmg, id));
 }
 
@@ -30,4 +33,8 @@ void NodeStatePtr::insert(NodeId nodeid, const CNode *pnode, ThinBlockManager& t
                 nodeid, CNodeState(nodeid, thinblockmg))).first->second;
     state.name = pnode->addrName;
     state.address = pnode->addr;
+}
+
+CNodeState::~CNodeState()
+{
 }

--- a/src/nodestate.h
+++ b/src/nodestate.h
@@ -11,8 +11,6 @@
 #include "inflightindex.h" // QueuedBlock
 #include "sync.h" // CCriticalSection
 
-#include <boost/shared_ptr.hpp>
-
 #include <string>
 #include <set>
 #include <map>
@@ -76,11 +74,14 @@ struct CNodeState {
     // request a block.
     bool initialHeadersReceived;
 
+    bool supportsCompactBlocks;
+
     //! the thin block the node is currently providing to us
-    boost::shared_ptr<ThinBlockWorker> thinblock;
+    std::shared_ptr<ThinBlockWorker> thinblock;
     std::set<uint256> recentThinBlockTx;
 
     CNodeState(NodeId id, ThinBlockManager&);
+    ~CNodeState();
 };
 
 // Class that maintains per-node state, and

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -81,9 +81,11 @@ bool Opt::AvoidFullBlocks() {
         || Args->GetArg("-use-thin-blocks", 1) == 3;
 }
 
-// Makes only outbound connection to xthin-supporting nodes.
+// Makes only outbound connection to nodes that support very effective
+// versions of thin blocks. This includes xthin and compact thin blocks.
+// Disables bloom thin blocks.
 // Implicitly enables "avoid full blocks".
-bool Opt::XThinBlocksOnly() {
+bool Opt::OptimalThinBlocksOnly() {
     return Args->GetArg("-use-thin-blocks", 1) == 3;
 }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -93,6 +93,10 @@ int Opt::ThinBlocksMaxParallel() {
     return Args->GetArg("-thin-blocks-max-parallel", 3);
 }
 
+bool Opt::PreferCompactBlocks() const {
+    return Args->GetBool("-prefer-compact-blocks", false);
+}
+
 std::unique_ptr<ArgReset> SetDummyArgGetter(std::unique_ptr<ArgGetter> getter) {
     Args.reset(getter.release());
     return std::unique_ptr<ArgReset>(new ArgReset);

--- a/src/options.h
+++ b/src/options.h
@@ -20,6 +20,7 @@ struct Opt {
     bool AvoidFullBlocks();
     bool OptimalThinBlocksOnly();
     int ThinBlocksMaxParallel();
+    bool PreferCompactBlocks() const; // Added for rpc test
 };
 
 /** Maximum number of script-checking threads allowed */

--- a/src/options.h
+++ b/src/options.h
@@ -18,7 +18,7 @@ struct Opt {
     // Thin block options
     bool UsingThinBlocks();
     bool AvoidFullBlocks();
-    bool XThinBlocksOnly();
+    bool OptimalThinBlocksOnly();
     int ThinBlocksMaxParallel();
 };
 

--- a/src/process_xthinblock.cpp
+++ b/src/process_xthinblock.cpp
@@ -2,17 +2,16 @@
 #include "blockheaderprocessor.h"
 #include "consensus/validation.h"
 #include "main.h" // Misbehaving, mapBlockIndex
+#include "net.h"
+#include "streams.h"
 #include "thinblock.h"
 #include "util.h"
 #include "utilprocessmsg.h"
 #include "xthin.h"
-#include "thinblock.h"
 
 
 void XThinBlockProcessor::operator()(
-        CDataStream& vRecv, ThinBlockWorker& worker, const TxFinder& txfinder,
-        BlockHeaderProcessor& processHeader)
-
+        CDataStream& vRecv, const TxFinder& txfinder)
 {
     XThinBlock block;
     vRecv >> block;
@@ -24,53 +23,23 @@ void XThinBlockProcessor::operator()(
 
     try {
         block.selfValidate();
-        if (!processHeader(std::vector<CBlockHeader>(1, block.header), false, false))
-            throw std::invalid_argument("invalid header");
     }
     catch (const std::invalid_argument& e) {
-        pfrom.PushMessage("reject", std::string("xthinblock"),
-                REJECT_MALFORMED, std::string(e.what()), hash);
-        worker.setAvailable();
-        misbehave(20);
+        rejectBlock(hash, e.what(), 20);
+    }
+    processHeader(block.header);
+
+    from.AddInventoryKnown(CInv(MSG_XTHINBLOCK, hash));
+
+    if (!setToWork(hash))
         return;
-    }
-
-    pfrom.AddInventoryKnown(CInv(MSG_XTHINBLOCK, hash));
-
-    if (HaveBlockData(hash)) {
-        LogPrint("thin", "already had block %s, "
-                "ignoring xthinblock peer=%d\n",
-            hash.ToString(), pfrom.id);
-        worker.setAvailable();
-	return;
-    }
-
-    if (worker.isAvailable()) {
-        // Happens if:
-        // * We did not request block.
-        // * We already received block (after requesting it) and
-        //    found it to be invalid.
-        LogPrint("thin", "ignoring xthinblock %s that peer is not working "
-                "on peer=%d\n", block.header.GetHash().ToString(), pfrom.id);
-        return;
-    }
-
-    if (worker.blockHash() != hash) {
-        LogPrint("thin", "ignoring xthinblock %s from peer=%d, "
-                "expecting block %s\n",
-		hash.ToString(), pfrom.id, worker.blockStr());
-        return;
-    }
 
     try {
         XThinStub stub(block);
         worker.buildStub(stub, txfinder);
     }
     catch (const thinblock_error& e) {
-        pfrom.PushMessage("reject", std::string("xthinblock"),
-                REJECT_MALFORMED, std::string(e.what()), hash);
-        misbehave(10);
-        worker.setAvailable();
+        rejectBlock(hash, e.what(), 10);
         return;
     }
 
@@ -85,15 +54,13 @@ void XThinBlockProcessor::operator()(
 
     XThinReRequest req;
     req.block = hash;
-    typedef std::vector<ThinTx>::const_iterator auto_;
-    for (auto_ t = missing.begin(); t != missing.end(); ++t)
-        req.txRequesting.insert(t->cheap());
 
-    LogPrintf("re-requesting %d missing transactions for %s from peer=%d\n",
-            missing.size(), hash.ToString(), pfrom.id);
-    pfrom.PushMessage("get_xblocktx", req);
+    for (auto& t : missing)
+        req.txRequesting.insert(t.cheap());
+
+    LogPrintf("re-requesting xthin %d missing transactions for %s from peer=%d\n",
+            missing.size(), hash.ToString(), from.id);
+
+    from.PushMessage("get_xblocktx", req);
 }
 
-void XThinBlockProcessor::misbehave(int howmuch) {
-    Misbehaving(pfrom.id, howmuch);
-}

--- a/src/process_xthinblock.h
+++ b/src/process_xthinblock.h
@@ -1,26 +1,19 @@
 #ifndef PROCESS_XTHINBLOCK_H
 #define PROCESS_XTHINBLOCK_H
 
-class CNode;
+#include "blockprocessor.h"
+
 class CDataStream;
-class ThinBlockWorker;
 class TxFinder;
-class BlockHeaderProcessor;
 
-class XThinBlockProcessor {
+class XThinBlockProcessor : private BlockProcessor {
     public:
-        XThinBlockProcessor(CNode& n) : pfrom(n) { }
-        ~XThinBlockProcessor() { }
+        XThinBlockProcessor(CNode& f, ThinBlockWorker& w, BlockHeaderProcessor& h) :
+            BlockProcessor(f, w, "xthinblock", h)
+        {
+        }
 
-        void operator()(CDataStream& vRecv,
-            ThinBlockWorker& worker, const TxFinder& txfinder,
-            BlockHeaderProcessor& processHeader);
-
-
-        virtual void misbehave(int howmuch);
-
-    private:
-        CNode& pfrom;
+        void operator()(CDataStream& vRecv, const TxFinder& txfinder);
 };
 
 #endif

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -17,7 +17,9 @@ static const char* ppszTypeName[] =
     "ERROR",
     "tx",
     "block",
-    "filtered block"
+    "filtered block",
+    "cmpctblock", // or thinblock
+    "xthinblock"
 };
 
 CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn)

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -81,9 +81,10 @@ enum {
     // Core nodes with protocol >= 70011 do not support bloom-filter unless this bit is advertised.
     NODE_BLOOM = (1 << 2),
 
-    // FIXME: Remove or rename. This one will likely be used for segwit.
-    NODE_RESERVED_1 = (1 << 3),
+    // Indicates that node is sewgit enabled
+    NODE_WITNESS = (1 << 3),
 
+    // Node supports xthin
     NODE_THIN = (1 << 4)
 
     // Bits 24-31 are reserved for temporary experiments. Just pick a bit that
@@ -164,8 +165,13 @@ enum {
     // of the entire block contents.
     MSG_FILTERED_BLOCK,
 
-    // BUIP010 thin block. We don't support these.
+    // BUIP010 thin block. We respond with a full block to these.
     MSG_THINBLOCK,
+
+    // Core didn't play nice and used the value taken by MSG_THINBLOCK for
+    // MSG_CMPCT_BLOCK. Treat this value as MSG_CMPCT_BLOCK only if peer has
+    // sent 'sendcmpct' first.
+    MSG_CMPCT_BLOCK = MSG_THINBLOCK,
 
     // BUIP010 xthin block. An xthin block contains the first 8 bytes of all
     // tx hashes in a block + transactions node is missing to reconstruct the

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -373,6 +373,7 @@ I ReadVarInt(Stream& is)
 
 #define FLATDATA(obj) REF(CFlatData((char*)&(obj), (char*)&(obj) + sizeof(obj)))
 #define VARINT(obj) REF(WrapVarInt(REF(obj)))
+#define COMPACTSIZE(obj) REF(CCompactSize(REF(obj)))
 #define LIMITED_STRING(obj,n) REF(LimitedString< n >(REF(obj)))
 
 /** 
@@ -434,6 +435,28 @@ public:
     template<typename Stream>
     void Unserialize(Stream& s, int, int) {
         n = ReadVarInt<Stream,I>(s);
+    }
+};
+
+class CCompactSize
+{
+protected:
+    uint64_t &n;
+public:
+    CCompactSize(uint64_t& nIn) : n(nIn) { }
+
+    unsigned int GetSerializeSize(int, int) const {
+        return GetSizeOfCompactSize(n);
+    }
+
+    template<typename Stream>
+    void Serialize(Stream &s, int, int) const {
+        WriteCompactSize<Stream>(s, n);
+    }
+
+    template<typename Stream>
+    void Unserialize(Stream& s, int, int) {
+        n = ReadCompactSize<Stream>(s);
     }
 };
 

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -1,0 +1,315 @@
+// Copyright (c) 2011-2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "blockencodings.h"
+#include "consensus/merkle.h"
+#include "chainparams.h"
+#include "random.h"
+
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+struct RegtestingSetup : public TestingSetup {
+    RegtestingSetup() : TestingSetup(CBaseChainParams::REGTEST) {}
+};
+
+BOOST_FIXTURE_TEST_SUITE(blockencodings_tests, RegtestingSetup)
+
+static CBlock BuildBlockTestCase() {
+    CBlock block;
+    CMutableTransaction tx;
+    tx.vin.resize(1);
+    tx.vin[0].scriptSig.resize(10);
+    tx.vout.resize(1);
+    tx.vout[0].nValue = 42;
+
+    block.vtx.resize(3);
+    block.vtx[0] = tx;
+    block.nVersion = 42;
+    block.hashPrevBlock = GetRandHash();
+    block.nBits = 0x207fffff;
+
+    tx.vin[0].prevout.hash = GetRandHash();
+    tx.vin[0].prevout.n = 0;
+    block.vtx[1] = tx;
+
+    tx.vin.resize(10);
+    for (size_t i = 0; i < tx.vin.size(); i++) {
+        tx.vin[i].prevout.hash = GetRandHash();
+        tx.vin[i].prevout.n = 0;
+    }
+    block.vtx[2] = tx;
+
+    bool mutated;
+    block.hashMerkleRoot = BlockMerkleRoot(block, &mutated);
+    assert(!mutated);
+    while (!CheckProofOfWork(block.GetHash(), block.nBits, Params().GetConsensus())) ++block.nNonce;
+    return block;
+}
+
+// Number of shared use_counts we expect for a tx we havent touched
+// == 2 (mempool + our copy from the GetSharedTx call)
+#define SHARED_TX_OFFSET 2
+
+BOOST_AUTO_TEST_CASE(SimpleRoundTripTest)
+{
+    CTxMemPool pool(CFeeRate(0));
+    TestMemPoolEntryHelper entry;
+    CBlock block(BuildBlockTestCase());
+
+    pool.addUnchecked(block.vtx[2].GetHash(), entry.FromTx(block.vtx[2]));
+    BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 0);
+
+    // Do a simple ShortTxIDs RT
+    {
+        CBlockHeaderAndShortTxIDs shortIDs(block);
+
+        CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+        stream << shortIDs;
+
+        CBlockHeaderAndShortTxIDs shortIDs2;
+        stream >> shortIDs2;
+
+        PartiallyDownloadedBlock partialBlock(&pool);
+        BOOST_CHECK(partialBlock.InitData(shortIDs2) == READ_STATUS_OK);
+        BOOST_CHECK( partialBlock.IsTxAvailable(0));
+        BOOST_CHECK(!partialBlock.IsTxAvailable(1));
+        BOOST_CHECK( partialBlock.IsTxAvailable(2));
+
+        BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 1);
+
+        std::list<CTransaction> removed;
+        pool.removeRecursive(block.vtx[2], removed);
+        BOOST_CHECK_EQUAL(removed.size(), 1);
+
+        CBlock block2;
+        std::vector<CTransaction> vtx_missing;
+        BOOST_CHECK(partialBlock.FillBlock(block2, vtx_missing) == READ_STATUS_INVALID); // No transactions
+
+        vtx_missing.push_back(block.vtx[2]); // Wrong transaction
+        partialBlock.FillBlock(block2, vtx_missing); // Current implementation doesn't check txn here, but don't require that
+        bool mutated;
+        BOOST_CHECK(block.hashMerkleRoot != BlockMerkleRoot(block2, &mutated));
+
+        vtx_missing[0] = block.vtx[1];
+        CBlock block3;
+        BOOST_CHECK(partialBlock.FillBlock(block3, vtx_missing) == READ_STATUS_OK);
+        BOOST_CHECK_EQUAL(block.GetHash().ToString(), block3.GetHash().ToString());
+        BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block3, &mutated).ToString());
+        BOOST_CHECK(!mutated);
+    }
+}
+
+class TestHeaderAndShortIDs {
+    // Utility to encode custom CBlockHeaderAndShortTxIDs
+public:
+    CBlockHeader header;
+    uint64_t nonce;
+    std::vector<uint64_t> shorttxids;
+    std::vector<PrefilledTransaction> prefilledtxn;
+
+    TestHeaderAndShortIDs(const CBlockHeaderAndShortTxIDs& orig) {
+        CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+        stream << orig;
+        stream >> *this;
+    }
+    TestHeaderAndShortIDs(const CBlock& block) :
+        TestHeaderAndShortIDs(CBlockHeaderAndShortTxIDs(block)) {}
+
+    uint64_t GetShortID(const uint256& txhash) const {
+        CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+        stream << *this;
+        CBlockHeaderAndShortTxIDs base;
+        stream >> base;
+        return base.GetShortID(txhash);
+    }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(header);
+        READWRITE(nonce);
+        size_t shorttxids_size = shorttxids.size();
+        READWRITE(VARINT(shorttxids_size));
+        shorttxids.resize(shorttxids_size);
+        for (size_t i = 0; i < shorttxids.size(); i++) {
+            uint32_t lsb = shorttxids[i] & 0xffffffff;
+            uint16_t msb = (shorttxids[i] >> 32) & 0xffff;
+            READWRITE(lsb);
+            READWRITE(msb);
+            shorttxids[i] = (uint64_t(msb) << 32) | uint64_t(lsb);
+        }
+        READWRITE(prefilledtxn);
+    }
+};
+
+BOOST_AUTO_TEST_CASE(NonCoinbasePreforwardRTTest)
+{
+    CTxMemPool pool(CFeeRate(0));
+    TestMemPoolEntryHelper entry;
+    CBlock block(BuildBlockTestCase());
+
+    pool.addUnchecked(block.vtx[2].GetHash(), entry.FromTx(block.vtx[2]));
+    BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 0);
+
+    // Test with pre-forwarding tx 1, but not coinbase
+    {
+        TestHeaderAndShortIDs shortIDs(block);
+        shortIDs.prefilledtxn.resize(1);
+        shortIDs.prefilledtxn[0] = {1, block.vtx[1]};
+        shortIDs.shorttxids.resize(2);
+        shortIDs.shorttxids[0] = shortIDs.GetShortID(block.vtx[0].GetHash());
+        shortIDs.shorttxids[1] = shortIDs.GetShortID(block.vtx[2].GetHash());
+
+        CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+        stream << shortIDs;
+
+        CBlockHeaderAndShortTxIDs shortIDs2;
+        stream >> shortIDs2;
+
+        PartiallyDownloadedBlock partialBlock(&pool);
+        BOOST_CHECK(partialBlock.InitData(shortIDs2) == READ_STATUS_OK);
+        BOOST_CHECK(!partialBlock.IsTxAvailable(0));
+        BOOST_CHECK( partialBlock.IsTxAvailable(1));
+        BOOST_CHECK( partialBlock.IsTxAvailable(2));
+
+        BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 1);
+
+        CBlock block2;
+        std::vector<CTransaction> vtx_missing;
+        BOOST_CHECK(partialBlock.FillBlock(block2, vtx_missing) == READ_STATUS_INVALID); // No transactions
+
+        vtx_missing.push_back(block.vtx[1]); // Wrong transaction
+        partialBlock.FillBlock(block2, vtx_missing); // Current implementation doesn't check txn here, but don't require that
+        bool mutated;
+        BOOST_CHECK(block.hashMerkleRoot != BlockMerkleRoot(block2, &mutated));
+
+        vtx_missing[0] = block.vtx[0];
+        CBlock block3;
+        BOOST_CHECK(partialBlock.FillBlock(block3, vtx_missing) == READ_STATUS_OK);
+        BOOST_CHECK_EQUAL(block.GetHash().ToString(), block3.GetHash().ToString());
+        BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block3, &mutated).ToString());
+        BOOST_CHECK(!mutated);
+
+        BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 1);
+    }
+    BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 0);
+}
+
+BOOST_AUTO_TEST_CASE(SufficientPreforwardRTTest)
+{
+    CTxMemPool pool(CFeeRate(0));
+    TestMemPoolEntryHelper entry;
+    CBlock block(BuildBlockTestCase());
+
+    pool.addUnchecked(block.vtx[1].GetHash(), entry.FromTx(block.vtx[1]));
+    BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[1].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 0);
+
+    // Test with pre-forwarding coinbase + tx 2 with tx 1 in mempool
+    {
+        TestHeaderAndShortIDs shortIDs(block);
+        shortIDs.prefilledtxn.resize(2);
+        shortIDs.prefilledtxn[0] = {0, block.vtx[0]};
+        shortIDs.prefilledtxn[1] = {1, block.vtx[2]}; // id == 1 as it is 1 after index 1
+        shortIDs.shorttxids.resize(1);
+        shortIDs.shorttxids[0] = shortIDs.GetShortID(block.vtx[1].GetHash());
+
+        CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+        stream << shortIDs;
+
+        CBlockHeaderAndShortTxIDs shortIDs2;
+        stream >> shortIDs2;
+
+        PartiallyDownloadedBlock partialBlock(&pool);
+        BOOST_CHECK(partialBlock.InitData(shortIDs2) == READ_STATUS_OK);
+        BOOST_CHECK( partialBlock.IsTxAvailable(0));
+        BOOST_CHECK( partialBlock.IsTxAvailable(1));
+        BOOST_CHECK( partialBlock.IsTxAvailable(2));
+
+        BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[1].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 1);
+
+        CBlock block2;
+        std::vector<CTransaction> vtx_missing;
+        BOOST_CHECK(partialBlock.FillBlock(block2, vtx_missing) == READ_STATUS_OK);
+        BOOST_CHECK_EQUAL(block.GetHash().ToString(), block2.GetHash().ToString());
+        bool mutated;
+        BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block2, &mutated).ToString());
+        BOOST_CHECK(!mutated);
+
+        BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[1].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 1);
+    }
+    BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[1].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 0);
+}
+
+BOOST_AUTO_TEST_CASE(EmptyBlockRoundTripTest)
+{
+    CTxMemPool pool(CFeeRate(0));
+    CMutableTransaction coinbase;
+    coinbase.vin.resize(1);
+    coinbase.vin[0].scriptSig.resize(10);
+    coinbase.vout.resize(1);
+    coinbase.vout[0].nValue = 42;
+
+    CBlock block;
+    block.vtx.resize(1);
+    block.vtx[0] = coinbase;
+    block.nVersion = 42;
+    block.hashPrevBlock = GetRandHash();
+    block.nBits = 0x207fffff;
+
+    bool mutated;
+    block.hashMerkleRoot = BlockMerkleRoot(block, &mutated);
+    assert(!mutated);
+    while (!CheckProofOfWork(block.GetHash(), block.nBits, Params().GetConsensus())) ++block.nNonce;
+
+    // Test simple header round-trip with only coinbase
+    {
+        CBlockHeaderAndShortTxIDs shortIDs(block);
+
+        CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+        stream << shortIDs;
+
+        CBlockHeaderAndShortTxIDs shortIDs2;
+        stream >> shortIDs2;
+
+        PartiallyDownloadedBlock partialBlock(&pool);
+        BOOST_CHECK(partialBlock.InitData(shortIDs2) == READ_STATUS_OK);
+        BOOST_CHECK(partialBlock.IsTxAvailable(0));
+
+        CBlock block2;
+        std::vector<CTransaction> vtx_missing;
+        BOOST_CHECK(partialBlock.FillBlock(block2, vtx_missing) == READ_STATUS_OK);
+        BOOST_CHECK_EQUAL(block.GetHash().ToString(), block2.GetHash().ToString());
+        bool mutated;
+        BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block2, &mutated).ToString());
+        BOOST_CHECK(!mutated);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(TransactionsRequestSerializationTest) {
+    BlockTransactionsRequest req1;
+    req1.blockhash = GetRandHash();
+    req1.indexes.resize(4);
+    req1.indexes[0] = 0;
+    req1.indexes[1] = 1;
+    req1.indexes[2] = 3;
+    req1.indexes[3] = 4;
+
+    CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+    stream << req1;
+
+    BlockTransactionsRequest req2;
+    stream >> req2;
+
+    BOOST_CHECK_EQUAL(req1.blockhash.ToString(), req2.blockhash.ToString());
+    BOOST_CHECK_EQUAL(req1.indexes.size(), req2.indexes.size());
+    BOOST_CHECK_EQUAL(req1.indexes[0], req2.indexes[0]);
+    BOOST_CHECK_EQUAL(req1.indexes[1], req2.indexes[1]);
+    BOOST_CHECK_EQUAL(req1.indexes[2], req2.indexes[2]);
+    BOOST_CHECK_EQUAL(req1.indexes[3], req2.indexes[3]);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -1,296 +1,24 @@
 // Copyright (c) 2011-2015 The Bitcoin Core developers
+// Copyright (c) 2016 The Bitcoin XT developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "blockencodings.h"
-#include "consensus/merkle.h"
 #include "chainparams.h"
 #include "random.h"
+#include "pow.h"
 
 #include "test/test_bitcoin.h"
+#include "test/thinblockutil.h"
 
 #include <boost/test/unit_test.hpp>
+#include <stdexcept>
+#include <limits>
 
-struct RegtestingSetup : public TestingSetup {
-    RegtestingSetup() : TestingSetup(CBaseChainParams::REGTEST) {}
-};
-
-BOOST_FIXTURE_TEST_SUITE(blockencodings_tests, RegtestingSetup)
-
-static CBlock BuildBlockTestCase() {
-    CBlock block;
-    CMutableTransaction tx;
-    tx.vin.resize(1);
-    tx.vin[0].scriptSig.resize(10);
-    tx.vout.resize(1);
-    tx.vout[0].nValue = 42;
-
-    block.vtx.resize(3);
-    block.vtx[0] = tx;
-    block.nVersion = 42;
-    block.hashPrevBlock = GetRandHash();
-    block.nBits = 0x207fffff;
-
-    tx.vin[0].prevout.hash = GetRandHash();
-    tx.vin[0].prevout.n = 0;
-    block.vtx[1] = tx;
-
-    tx.vin.resize(10);
-    for (size_t i = 0; i < tx.vin.size(); i++) {
-        tx.vin[i].prevout.hash = GetRandHash();
-        tx.vin[i].prevout.n = 0;
-    }
-    block.vtx[2] = tx;
-
-    bool mutated;
-    block.hashMerkleRoot = BlockMerkleRoot(block, &mutated);
-    assert(!mutated);
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, Params().GetConsensus())) ++block.nNonce;
-    return block;
-}
-
-// Number of shared use_counts we expect for a tx we havent touched
-// == 2 (mempool + our copy from the GetSharedTx call)
-#define SHARED_TX_OFFSET 2
-
-BOOST_AUTO_TEST_CASE(SimpleRoundTripTest)
-{
-    CTxMemPool pool(CFeeRate(0));
-    TestMemPoolEntryHelper entry;
-    CBlock block(BuildBlockTestCase());
-
-    pool.addUnchecked(block.vtx[2].GetHash(), entry.FromTx(block.vtx[2]));
-    BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 0);
-
-    // Do a simple ShortTxIDs RT
-    {
-        CBlockHeaderAndShortTxIDs shortIDs(block);
-
-        CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
-        stream << shortIDs;
-
-        CBlockHeaderAndShortTxIDs shortIDs2;
-        stream >> shortIDs2;
-
-        PartiallyDownloadedBlock partialBlock(&pool);
-        BOOST_CHECK(partialBlock.InitData(shortIDs2) == READ_STATUS_OK);
-        BOOST_CHECK( partialBlock.IsTxAvailable(0));
-        BOOST_CHECK(!partialBlock.IsTxAvailable(1));
-        BOOST_CHECK( partialBlock.IsTxAvailable(2));
-
-        BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 1);
-
-        std::list<CTransaction> removed;
-        pool.removeRecursive(block.vtx[2], removed);
-        BOOST_CHECK_EQUAL(removed.size(), 1);
-
-        CBlock block2;
-        std::vector<CTransaction> vtx_missing;
-        BOOST_CHECK(partialBlock.FillBlock(block2, vtx_missing) == READ_STATUS_INVALID); // No transactions
-
-        vtx_missing.push_back(block.vtx[2]); // Wrong transaction
-        partialBlock.FillBlock(block2, vtx_missing); // Current implementation doesn't check txn here, but don't require that
-        bool mutated;
-        BOOST_CHECK(block.hashMerkleRoot != BlockMerkleRoot(block2, &mutated));
-
-        vtx_missing[0] = block.vtx[1];
-        CBlock block3;
-        BOOST_CHECK(partialBlock.FillBlock(block3, vtx_missing) == READ_STATUS_OK);
-        BOOST_CHECK_EQUAL(block.GetHash().ToString(), block3.GetHash().ToString());
-        BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block3, &mutated).ToString());
-        BOOST_CHECK(!mutated);
-    }
-}
-
-class TestHeaderAndShortIDs {
-    // Utility to encode custom CBlockHeaderAndShortTxIDs
-public:
-    CBlockHeader header;
-    uint64_t nonce;
-    std::vector<uint64_t> shorttxids;
-    std::vector<PrefilledTransaction> prefilledtxn;
-
-    TestHeaderAndShortIDs(const CBlockHeaderAndShortTxIDs& orig) {
-        CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
-        stream << orig;
-        stream >> *this;
-    }
-    TestHeaderAndShortIDs(const CBlock& block) :
-        TestHeaderAndShortIDs(CBlockHeaderAndShortTxIDs(block)) {}
-
-    uint64_t GetShortID(const uint256& txhash) const {
-        CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
-        stream << *this;
-        CBlockHeaderAndShortTxIDs base;
-        stream >> base;
-        return base.GetShortID(txhash);
-    }
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        READWRITE(header);
-        READWRITE(nonce);
-        size_t shorttxids_size = shorttxids.size();
-        READWRITE(VARINT(shorttxids_size));
-        shorttxids.resize(shorttxids_size);
-        for (size_t i = 0; i < shorttxids.size(); i++) {
-            uint32_t lsb = shorttxids[i] & 0xffffffff;
-            uint16_t msb = (shorttxids[i] >> 32) & 0xffff;
-            READWRITE(lsb);
-            READWRITE(msb);
-            shorttxids[i] = (uint64_t(msb) << 32) | uint64_t(lsb);
-        }
-        READWRITE(prefilledtxn);
-    }
-};
-
-BOOST_AUTO_TEST_CASE(NonCoinbasePreforwardRTTest)
-{
-    CTxMemPool pool(CFeeRate(0));
-    TestMemPoolEntryHelper entry;
-    CBlock block(BuildBlockTestCase());
-
-    pool.addUnchecked(block.vtx[2].GetHash(), entry.FromTx(block.vtx[2]));
-    BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 0);
-
-    // Test with pre-forwarding tx 1, but not coinbase
-    {
-        TestHeaderAndShortIDs shortIDs(block);
-        shortIDs.prefilledtxn.resize(1);
-        shortIDs.prefilledtxn[0] = {1, block.vtx[1]};
-        shortIDs.shorttxids.resize(2);
-        shortIDs.shorttxids[0] = shortIDs.GetShortID(block.vtx[0].GetHash());
-        shortIDs.shorttxids[1] = shortIDs.GetShortID(block.vtx[2].GetHash());
-
-        CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
-        stream << shortIDs;
-
-        CBlockHeaderAndShortTxIDs shortIDs2;
-        stream >> shortIDs2;
-
-        PartiallyDownloadedBlock partialBlock(&pool);
-        BOOST_CHECK(partialBlock.InitData(shortIDs2) == READ_STATUS_OK);
-        BOOST_CHECK(!partialBlock.IsTxAvailable(0));
-        BOOST_CHECK( partialBlock.IsTxAvailable(1));
-        BOOST_CHECK( partialBlock.IsTxAvailable(2));
-
-        BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 1);
-
-        CBlock block2;
-        std::vector<CTransaction> vtx_missing;
-        BOOST_CHECK(partialBlock.FillBlock(block2, vtx_missing) == READ_STATUS_INVALID); // No transactions
-
-        vtx_missing.push_back(block.vtx[1]); // Wrong transaction
-        partialBlock.FillBlock(block2, vtx_missing); // Current implementation doesn't check txn here, but don't require that
-        bool mutated;
-        BOOST_CHECK(block.hashMerkleRoot != BlockMerkleRoot(block2, &mutated));
-
-        vtx_missing[0] = block.vtx[0];
-        CBlock block3;
-        BOOST_CHECK(partialBlock.FillBlock(block3, vtx_missing) == READ_STATUS_OK);
-        BOOST_CHECK_EQUAL(block.GetHash().ToString(), block3.GetHash().ToString());
-        BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block3, &mutated).ToString());
-        BOOST_CHECK(!mutated);
-
-        BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 1);
-    }
-    BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 0);
-}
-
-BOOST_AUTO_TEST_CASE(SufficientPreforwardRTTest)
-{
-    CTxMemPool pool(CFeeRate(0));
-    TestMemPoolEntryHelper entry;
-    CBlock block(BuildBlockTestCase());
-
-    pool.addUnchecked(block.vtx[1].GetHash(), entry.FromTx(block.vtx[1]));
-    BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[1].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 0);
-
-    // Test with pre-forwarding coinbase + tx 2 with tx 1 in mempool
-    {
-        TestHeaderAndShortIDs shortIDs(block);
-        shortIDs.prefilledtxn.resize(2);
-        shortIDs.prefilledtxn[0] = {0, block.vtx[0]};
-        shortIDs.prefilledtxn[1] = {1, block.vtx[2]}; // id == 1 as it is 1 after index 1
-        shortIDs.shorttxids.resize(1);
-        shortIDs.shorttxids[0] = shortIDs.GetShortID(block.vtx[1].GetHash());
-
-        CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
-        stream << shortIDs;
-
-        CBlockHeaderAndShortTxIDs shortIDs2;
-        stream >> shortIDs2;
-
-        PartiallyDownloadedBlock partialBlock(&pool);
-        BOOST_CHECK(partialBlock.InitData(shortIDs2) == READ_STATUS_OK);
-        BOOST_CHECK( partialBlock.IsTxAvailable(0));
-        BOOST_CHECK( partialBlock.IsTxAvailable(1));
-        BOOST_CHECK( partialBlock.IsTxAvailable(2));
-
-        BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[1].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 1);
-
-        CBlock block2;
-        std::vector<CTransaction> vtx_missing;
-        BOOST_CHECK(partialBlock.FillBlock(block2, vtx_missing) == READ_STATUS_OK);
-        BOOST_CHECK_EQUAL(block.GetHash().ToString(), block2.GetHash().ToString());
-        bool mutated;
-        BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block2, &mutated).ToString());
-        BOOST_CHECK(!mutated);
-
-        BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[1].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 1);
-    }
-    BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[1].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 0);
-}
-
-BOOST_AUTO_TEST_CASE(EmptyBlockRoundTripTest)
-{
-    CTxMemPool pool(CFeeRate(0));
-    CMutableTransaction coinbase;
-    coinbase.vin.resize(1);
-    coinbase.vin[0].scriptSig.resize(10);
-    coinbase.vout.resize(1);
-    coinbase.vout[0].nValue = 42;
-
-    CBlock block;
-    block.vtx.resize(1);
-    block.vtx[0] = coinbase;
-    block.nVersion = 42;
-    block.hashPrevBlock = GetRandHash();
-    block.nBits = 0x207fffff;
-
-    bool mutated;
-    block.hashMerkleRoot = BlockMerkleRoot(block, &mutated);
-    assert(!mutated);
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, Params().GetConsensus())) ++block.nNonce;
-
-    // Test simple header round-trip with only coinbase
-    {
-        CBlockHeaderAndShortTxIDs shortIDs(block);
-
-        CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
-        stream << shortIDs;
-
-        CBlockHeaderAndShortTxIDs shortIDs2;
-        stream >> shortIDs2;
-
-        PartiallyDownloadedBlock partialBlock(&pool);
-        BOOST_CHECK(partialBlock.InitData(shortIDs2) == READ_STATUS_OK);
-        BOOST_CHECK(partialBlock.IsTxAvailable(0));
-
-        CBlock block2;
-        std::vector<CTransaction> vtx_missing;
-        BOOST_CHECK(partialBlock.FillBlock(block2, vtx_missing) == READ_STATUS_OK);
-        BOOST_CHECK_EQUAL(block.GetHash().ToString(), block2.GetHash().ToString());
-        bool mutated;
-        BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block2, &mutated).ToString());
-        BOOST_CHECK(!mutated);
-    }
-}
+BOOST_AUTO_TEST_SUITE(blockencodings_tests);
 
 BOOST_AUTO_TEST_CASE(TransactionsRequestSerializationTest) {
-    BlockTransactionsRequest req1;
+    CompactReRequest req1;
     req1.blockhash = GetRandHash();
     req1.indexes.resize(4);
     req1.indexes[0] = 0;
@@ -301,7 +29,7 @@ BOOST_AUTO_TEST_CASE(TransactionsRequestSerializationTest) {
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
     stream << req1;
 
-    BlockTransactionsRequest req2;
+    CompactReRequest req2;
     stream >> req2;
 
     BOOST_CHECK_EQUAL(req1.blockhash.ToString(), req2.blockhash.ToString());
@@ -310,6 +38,76 @@ BOOST_AUTO_TEST_CASE(TransactionsRequestSerializationTest) {
     BOOST_CHECK_EQUAL(req1.indexes[1], req2.indexes[1]);
     BOOST_CHECK_EQUAL(req1.indexes[2], req2.indexes[2]);
     BOOST_CHECK_EQUAL(req1.indexes[3], req2.indexes[3]);
+}
+
+BOOST_AUTO_TEST_CASE(validate_compact_block) {
+    CBlock block = TestBlock1(); // valid block
+    CompactBlock a(block);
+    BOOST_CHECK_NO_THROW(validateCompactBlock(a));
+
+    // Invalid header
+    CompactBlock b = a;
+    b.header.SetNull();
+    BOOST_ASSERT(b.header.IsNull());
+    BOOST_CHECK_THROW(validateCompactBlock(b), std::invalid_argument);
+
+    // null tx in prefilled
+    CompactBlock c = a;
+    c.prefilledtxn.at(0).tx = CTransaction();
+    BOOST_CHECK_THROW(validateCompactBlock(c), std::invalid_argument);
+
+    // overflowing index
+    CompactBlock d = a;
+    d.prefilledtxn.at(0).index = std::numeric_limits<uint16_t>::max();
+    BOOST_CHECK_THROW(validateCompactBlock(d), std::invalid_argument);
+
+    // too high index
+    CompactBlock e = a;
+    e.prefilledtxn.at(0).index = std::numeric_limits<uint16_t>::max() / 2;
+    BOOST_CHECK_THROW(validateCompactBlock(e), std::invalid_argument);
+
+    // no transactions
+    CompactBlock f = a;
+    f.shorttxids.clear();
+    f.prefilledtxn.clear();
+    BOOST_CHECK_THROW(validateCompactBlock(f), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(prefill_transactions) {
+
+    CBlock block = TestBlock1();
+
+    // Transactions that we know that peer knows about.
+    uint256 known1 = block.vtx[2].GetHash();
+    uint256 known2 = block.vtx[3].GetHash();
+    uint256 known3 = block.vtx[5].GetHash();
+
+    CRollingBloomFilter inventoryKnown(100, 0.000001);
+
+    inventoryKnown.insert(known1);
+    inventoryKnown.insert(known2);
+    inventoryKnown.insert(known3);
+
+    CompactBlock thin(block, &inventoryKnown);
+
+    // Should have 3 prefilled, coinbase + known1 + known2
+    BOOST_CHECK_EQUAL(block.vtx.size() - 3, thin.prefilledtxn.size());
+
+    // inventoryKnown should not be included
+    auto findFunc = [&known1, &known2, &known3](const PrefilledTransaction& tx) {
+        return tx.tx.GetHash() == known1
+            || tx.tx.GetHash() == known2
+            || tx.tx.GetHash() == known3;
+    };
+    auto res = std::find_if(
+            begin(thin.prefilledtxn), end(thin.prefilledtxn), findFunc);
+    BOOST_CHECK(res == end(thin.prefilledtxn));
+
+    // indexes should be "differentially encoded"
+    BOOST_CHECK_EQUAL(thin.prefilledtxn.at(0).index, 0);
+    BOOST_CHECK_EQUAL(thin.prefilledtxn.at(1).index, 1);
+    BOOST_CHECK_EQUAL(thin.prefilledtxn.at(2).index, 3);
+    BOOST_CHECK_EQUAL(thin.prefilledtxn.at(3).index, 2);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/blocksender_tests.cpp
+++ b/src/test/blocksender_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include <boost/test/unit_test.hpp>
 #include "test/thinblockutil.h"
+#include "blockencodings.h"
 #include "blocksender.h"
 #include "net.h"
 #include "uint256.h"
@@ -21,6 +22,7 @@ BOOST_AUTO_TEST_CASE(inv_type_check) {
     BOOST_CHECK(b.isBlockType(MSG_FILTERED_BLOCK));
     BOOST_CHECK(b.isBlockType(MSG_THINBLOCK));
     BOOST_CHECK(b.isBlockType(MSG_XTHINBLOCK));
+    BOOST_CHECK(b.isBlockType(MSG_CMPCT_BLOCK));
     BOOST_CHECK(!b.isBlockType(MSG_TX));
 }
 
@@ -115,6 +117,7 @@ BOOST_AUTO_TEST_CASE(send_msg_thinblock) {
     CBlockIndex index;
     BlockSenderDummy bs;
     DummyNode node;
+    NodeStatePtr(node.id)->supportsCompactBlocks = false;
 
     bs.sendBlock(node, index, MSG_THINBLOCK);
     BOOST_CHECK_EQUAL("block", node.messages.at(0));
@@ -165,7 +168,32 @@ BOOST_AUTO_TEST_CASE(send_msg_xblocktx) {
     req.txRequesting = requesting;
     bs.sendReReqReponse(node, index, req);
     BOOST_CHECK_EQUAL("xblocktx", node.messages.at(0));
-
 }
+
+BOOST_AUTO_TEST_CASE(send_msg_cmpct_block) {
+    CBlockIndex index;
+    BlockSenderDummy bs;
+
+    DummyNode node;
+    NodeStatePtr(node.id)->supportsCompactBlocks = true;
+    bs.readBlock = TestBlock2();
+    bs.sendBlock(node, index, MSG_CMPCT_BLOCK);
+    BOOST_CHECK_EQUAL("cmpctblock", node.messages.at(0));
+};
+
+BOOST_AUTO_TEST_CASE(send_msg_blocktxn) {
+    CBlockIndex index;
+    BlockSenderDummy bs;
+    DummyNode node;
+    CBlock block = TestBlock1();
+
+    CompactReRequest req;
+    req.indexes.push_back(1);
+    req.indexes.push_back(4);
+    req.blockhash = block.GetHash();
+    bs.sendReReqReponse(node, index, req);
+    BOOST_CHECK_EQUAL("blocktxn", node.messages.at(0));
+}
+
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/test/compactprefiller_tests.cpp
+++ b/src/test/compactprefiller_tests.cpp
@@ -1,0 +1,110 @@
+// Copyright (c) 2016 The Bitcoin XT developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <boost/test/unit_test_suite.hpp>
+#include <boost/test/test_tools.hpp>
+#include "compactprefiller.h"
+#include "test/thinblockutil.h"
+
+BOOST_AUTO_TEST_SUITE(comapactprefiller_tests)
+
+BOOST_AUTO_TEST_CASE(coinbase_only_test) {
+    CoinbaseOnlyPrefiller filler;
+    CBlock block = TestBlock2();
+
+    std::vector<PrefilledTransaction> prefilled = filler.fillFrom(block);
+    BOOST_CHECK_EQUAL(1, prefilled.size());
+    BOOST_CHECK_EQUAL(
+            block.vtx.at(0).GetHash().ToString(),
+            prefilled.at(0).tx.GetHash().ToString());
+}
+
+BOOST_AUTO_TEST_CASE(inventory_known_test) {
+
+    CBlock block = TestBlock1();
+
+    // Transactions that we know that peer knows about.
+    uint256 known1 = block.vtx[2].GetHash();
+    uint256 known2 = block.vtx[3].GetHash();
+    uint256 known3 = block.vtx[5].GetHash();
+
+    std::unique_ptr<CRollingBloomFilter> inventoryKnown(new CRollingBloomFilter(100, 0.000001));
+
+    inventoryKnown->insert(known1);
+    inventoryKnown->insert(known2);
+    inventoryKnown->insert(known3);
+
+    InventoryKnownPrefiller filler(std::move(inventoryKnown));
+    std::vector<PrefilledTransaction> prefilled = filler.fillFrom(block);
+
+    // Should have prefilled all except known1, known2 and known3
+    BOOST_CHECK_EQUAL(block.vtx.size() - 3, prefilled.size());
+
+    // inventoryKnown should not be included
+    auto findFunc = [&known1, &known2, &known3](const PrefilledTransaction& tx) {
+        return tx.tx.GetHash() == known1
+            || tx.tx.GetHash() == known2
+            || tx.tx.GetHash() == known3;
+    };
+    auto res = std::find_if(
+            begin(prefilled), end(prefilled), findFunc);
+    BOOST_CHECK(res == end(prefilled));
+
+    // indexes should be "differentially encoded"
+    BOOST_CHECK_EQUAL(prefilled.at(0).index, 0);
+    BOOST_CHECK_EQUAL(prefilled.at(1).index, 0);
+    BOOST_CHECK_EQUAL(prefilled.at(2).index, 2);
+    BOOST_CHECK_EQUAL(prefilled.at(3).index, 1);
+}
+
+unsigned int sumTx(std::vector<CTransaction>& txs) {
+    unsigned int sum = 0;
+    for (auto& t : txs)
+        sum += ::GetSerializeSize(t, SER_NETWORK, PROTOCOL_VERSION);
+    return sum;
+}
+
+unsigned int sumTx(std::vector<PrefilledTransaction>& txs) {
+    unsigned int sum = 0;
+    for (auto& t : txs)
+        sum += ::GetSerializeSize(t.tx, SER_NETWORK, PROTOCOL_VERSION);
+    return sum;
+}
+
+BOOST_AUTO_TEST_CASE(prefill_dont_exceed_10kb) {
+    // From BIP152
+    // Nodes sending cmpctblock messages SHOULD limit prefilledtxn to 10KB of transactions
+
+    CBlock block = TestBlock1();
+
+    // Block with ~20KB tx
+    while (sumTx(block.vtx) < 20 * 1000 /* 20 KB */) {
+        CMutableTransaction newTx(block.vtx.back());
+        newTx.vin[0].prevout.hash = GetRandHash();
+        block.vtx.push_back(CTransaction(newTx));
+    }
+
+    // Filter matches nothing, should prefill as much as possible.
+    std::unique_ptr<CRollingBloomFilter> inventoryKnown(new CRollingBloomFilter(100, 0.000001));
+    InventoryKnownPrefiller filler(std::move(inventoryKnown));
+
+    std::vector<PrefilledTransaction> prefilled = filler.fillFrom(block);
+
+    BOOST_CHECK(sumTx(prefilled) < 10 * 1000 /* 10KB */);
+    BOOST_CHECK(sumTx(prefilled) > 9 * 1000); // Want close to the limit
+}
+
+BOOST_AUTO_TEST_CASE(test_choose_prefiller) {
+
+    DummyNode node;
+    node.fRelayTxes = false;
+
+    std::unique_ptr<CompactPrefiller> prefiller = choosePrefiller(node);
+    BOOST_CHECK(dynamic_cast<CoinbaseOnlyPrefiller*>(prefiller.get()) != nullptr);
+
+    node.fRelayTxes = true;
+    prefiller = choosePrefiller(node);
+    BOOST_CHECK(dynamic_cast<InventoryKnownPrefiller*>(prefiller.get()) != nullptr);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/compactthin_tests.cpp
+++ b/src/test/compactthin_tests.cpp
@@ -1,0 +1,86 @@
+// Copyright (c) 2016- The Bitcoin XT developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <boost/test/unit_test.hpp>
+
+#include "test/thinblockutil.h"
+//#include "bloom.h"
+//#include "uint256.h"
+#include "compactthin.h"
+#include "chainparams.h"
+#include "blockencodings.h"
+#include "compactthin.h"
+
+
+// Workaround for segfaulting
+struct Workaround {
+    Workaround() {
+        SelectParams(CBaseChainParams::MAIN);
+    }
+};
+
+BOOST_FIXTURE_TEST_SUITE(compactthin_tests, Workaround);
+
+BOOST_AUTO_TEST_CASE(stub_tx_hashtypes) {
+    CBlock block = TestBlock1();
+    CompactBlock cmpctblock(block);
+
+    // CompactBlock is initialized with coinbase prefilled.
+    // Prefilled transactions have full hash.
+    CompactStub stub(block);
+    std::vector<ThinTx> all = stub.allTransactions();
+    for (auto& t : all)
+        BOOST_CHECK(!t.isNull());
+
+    // Coinbase should have full hash.
+    BOOST_CHECK(all.at(0).hasFull());
+    BOOST_CHECK_EQUAL(
+            block.vtx.at(0).GetHash().ToString(),
+            all.at(0).full().ToString());
+
+    // All others should only have an obfuscated "short id" (we
+    // don't know full nor cheap hash)
+    for (size_t i = 1; i < all.size(); ++i) {
+        BOOST_CHECK(!all.at(i).hasFull());
+        if (all.at(i).hasFull())
+            std::cerr << all.at(i).full().ToString() << std::endl;
+        BOOST_CHECK(!all.at(i).hasCheap());
+        BOOST_CHECK(all.at(i).equals(block.vtx.at(i).GetHash()));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(ids_are_correct) {
+    CBlock testblock = TestBlock1();
+
+    CRollingBloomFilter inventoryKnown(100, 0.000001);
+    for (size_t i = 1; i < testblock.vtx.size(); ++i) {
+
+        if (i == 3 || i == 5)
+            continue;
+
+        inventoryKnown.insert(testblock.vtx[i].GetHash());
+    }
+
+    CompactBlock thin(testblock, &inventoryKnown);
+    CompactStub stub(thin);
+
+    auto all = stub.allTransactions();
+    BOOST_CHECK_EQUAL(testblock.vtx.size(), all.size());
+
+    // index 0, 3 and 5 should have full id, rest shortid.
+    for (size_t i = 0; i < all.size(); ++i) {
+        if (i == 0 || i == 3 || i == 5) {
+            BOOST_CHECK_EQUAL(
+                    testblock.vtx[i].GetHash().ToString(),
+                    all[i].full().ToString());
+            continue;
+        }
+        uint64_t shortID = GetShortID(
+                thin.shorttxidk0, thin.shorttxidk1,
+                testblock.vtx[i].GetHash());
+
+        BOOST_CHECK_EQUAL(shortID, all[i].obfuscated());
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/test/compacttxfinder_tests.cpp
+++ b/src/test/compacttxfinder_tests.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2016 The Bitcoin XT developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <boost/test/unit_test_suite.hpp>
+#include <boost/test/test_tools.hpp>
+#include "blockencodings.h"
+#include "compactprefiller.h"
+#include "compactthin.h"
+#include "compacttxfinder.h"
+#include "sync.h"
+#include "test/test_bitcoin.h"
+#include "test/thinblockutil.h"
+#include "txmempool.h"
+
+BOOST_AUTO_TEST_SUITE(comapacttxfinder_tests)
+
+BOOST_AUTO_TEST_CASE(compacttxfinder_test) {
+
+    CTxMemPool mpool(CFeeRate(0));
+    TestMemPoolEntryHelper entry;
+
+    CBlock block = TestBlock1();
+    mpool.addUnchecked(block.vtx[1].GetHash(), entry.FromTx(block.vtx[1]));
+    mpool.addUnchecked(block.vtx[2].GetHash(), entry.FromTx(block.vtx[2]));
+    mpool.addUnchecked(block.vtx[3].GetHash(), entry.FromTx(block.vtx[3]));
+
+    CompactBlock cmpct(block, CoinbaseOnlyPrefiller());
+    CompactStub stub(cmpct);
+
+    std::vector<ThinTx> all = stub.allTransactions();
+
+    CompactTxFinder finder(mpool, cmpct.shorttxidk0, cmpct.shorttxidk1);
+
+    // Should find the txs in mpool
+    BOOST_CHECK_EQUAL(
+            block.vtx[1].GetHash().ToString(),
+            finder(all[1]).GetHash().ToString());
+    BOOST_CHECK_EQUAL(
+            block.vtx[2].GetHash().ToString(),
+            finder(all[2]).GetHash().ToString());
+    BOOST_CHECK_EQUAL(
+            block.vtx[3].GetHash().ToString(),
+            finder(all[3]).GetHash().ToString());
+
+    // Should not find txs not in mempool
+    BOOST_CHECK(finder(all[4]).IsNull());
+
+    // If tx is erased from mempool, it should not be found
+    LOCK(mpool.cs);
+    auto i = mpool.mapTx.find(block.vtx[1].GetHash());
+    mpool.mapTx.erase(i);
+    BOOST_CHECK(finder(all[1]).IsNull());
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/hash_tests.cpp
+++ b/src/test/hash_tests.cpp
@@ -47,4 +47,24 @@ BOOST_AUTO_TEST_CASE(murmurhash3)
 #undef T
 }
 
+BOOST_AUTO_TEST_CASE(siphash)
+{
+    CSipHasher hasher(0x0706050403020100ULL, 0x0F0E0D0C0B0A0908ULL);
+    BOOST_CHECK_EQUAL(hasher.Finalize(),  0x726fdb47dd0e0e31ull);
+    hasher.Write(0x0706050403020100ULL);
+    BOOST_CHECK_EQUAL(hasher.Finalize(),  0x93f5f5799a932462ull);
+    hasher.Write(0x0F0E0D0C0B0A0908ULL);
+    BOOST_CHECK_EQUAL(hasher.Finalize(),  0x3f2acc7f57c29bdbull);
+    hasher.Write(0x1716151413121110ULL);
+    BOOST_CHECK_EQUAL(hasher.Finalize(),  0xb8ad50c6f649af94ull);
+    hasher.Write(0x1F1E1D1C1B1A1918ULL);
+    BOOST_CHECK_EQUAL(hasher.Finalize(),  0x7127512f72f27cceull);
+    hasher.Write(0x2726252423222120ULL);
+    BOOST_CHECK_EQUAL(hasher.Finalize(),  0x0e3ea96b5304a7d0ull);
+    hasher.Write(0x2F2E2D2C2B2A2928ULL);
+    BOOST_CHECK_EQUAL(hasher.Finalize(),  0xe612a3cb9ecba951ull);
+
+    BOOST_CHECK_EQUAL(SipHashUint256(0x0706050403020100ULL, 0x0F0E0D0C0B0A0908ULL, uint256S("1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100")), 0x7127512f72f27cceull);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/hash_tests.cpp
+++ b/src/test/hash_tests.cpp
@@ -122,6 +122,10 @@ BOOST_AUTO_TEST_CASE(siphash)
         hasher3.Write(uint64_t(x)|(uint64_t(x+1)<<8)|(uint64_t(x+2)<<16)|(uint64_t(x+3)<<24)|
                      (uint64_t(x+4)<<32)|(uint64_t(x+5)<<40)|(uint64_t(x+6)<<48)|(uint64_t(x+7)<<56));
     }
+
+    CHashWriter ss(SER_DISK, CLIENT_VERSION);
+    ss << CTransaction();
+    BOOST_CHECK_EQUAL(SipHashUint256(1, 2, ss.GetHash()), 0x79751e980c2a0a35ULL);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/hash_tests.cpp
+++ b/src/test/hash_tests.cpp
@@ -51,13 +51,22 @@ BOOST_AUTO_TEST_CASE(siphash)
 {
     CSipHasher hasher(0x0706050403020100ULL, 0x0F0E0D0C0B0A0908ULL);
     BOOST_CHECK_EQUAL(hasher.Finalize(),  0x726fdb47dd0e0e31ull);
-    hasher.Write(0x0706050403020100ULL);
+    static const unsigned char t0[1] = {0};
+    hasher.Write(t0, 1);
+    BOOST_CHECK_EQUAL(hasher.Finalize(),  0x74f839c593dc67fdull);
+    static const unsigned char t1[7] = {1,2,3,4,5,6,7};
+    hasher.Write(t1, 7);
     BOOST_CHECK_EQUAL(hasher.Finalize(),  0x93f5f5799a932462ull);
     hasher.Write(0x0F0E0D0C0B0A0908ULL);
     BOOST_CHECK_EQUAL(hasher.Finalize(),  0x3f2acc7f57c29bdbull);
-    hasher.Write(0x1716151413121110ULL);
-    BOOST_CHECK_EQUAL(hasher.Finalize(),  0xb8ad50c6f649af94ull);
-    hasher.Write(0x1F1E1D1C1B1A1918ULL);
+    static const unsigned char t2[2] = {16,17};
+    hasher.Write(t2, 2);
+    BOOST_CHECK_EQUAL(hasher.Finalize(),  0x4bc1b3f0968dd39cull);
+    static const unsigned char t3[9] = {18,19,20,21,22,23,24,25,26};
+    hasher.Write(t3, 9);
+    BOOST_CHECK_EQUAL(hasher.Finalize(),  0x2f2e6163076bcfadull);
+    static const unsigned char t4[5] = {27,28,29,30,31};
+    hasher.Write(t4, 5);
     BOOST_CHECK_EQUAL(hasher.Finalize(),  0x7127512f72f27cceull);
     hasher.Write(0x2726252423222120ULL);
     BOOST_CHECK_EQUAL(hasher.Finalize(),  0x0e3ea96b5304a7d0ull);

--- a/src/test/hash_tests.cpp
+++ b/src/test/hash_tests.cpp
@@ -47,6 +47,38 @@ BOOST_AUTO_TEST_CASE(murmurhash3)
 #undef T
 }
 
+/*
+   SipHash-2-4 output with
+   k = 00 01 02 ...
+   and
+   in = (empty string)
+   in = 00 (1 byte)
+   in = 00 01 (2 bytes)
+   in = 00 01 02 (3 bytes)
+   ...
+   in = 00 01 02 ... 3e (63 bytes)
+
+   from: https://131002.net/siphash/siphash24.c
+*/
+uint64_t siphash_4_2_testvec[] = {
+    0x726fdb47dd0e0e31, 0x74f839c593dc67fd, 0x0d6c8009d9a94f5a, 0x85676696d7fb7e2d,
+    0xcf2794e0277187b7, 0x18765564cd99a68d, 0xcbc9466e58fee3ce, 0xab0200f58b01d137,
+    0x93f5f5799a932462, 0x9e0082df0ba9e4b0, 0x7a5dbbc594ddb9f3, 0xf4b32f46226bada7,
+    0x751e8fbc860ee5fb, 0x14ea5627c0843d90, 0xf723ca908e7af2ee, 0xa129ca6149be45e5,
+    0x3f2acc7f57c29bdb, 0x699ae9f52cbe4794, 0x4bc1b3f0968dd39c, 0xbb6dc91da77961bd,
+    0xbed65cf21aa2ee98, 0xd0f2cbb02e3b67c7, 0x93536795e3a33e88, 0xa80c038ccd5ccec8,
+    0xb8ad50c6f649af94, 0xbce192de8a85b8ea, 0x17d835b85bbb15f3, 0x2f2e6163076bcfad,
+    0xde4daaaca71dc9a5, 0xa6a2506687956571, 0xad87a3535c49ef28, 0x32d892fad841c342,
+    0x7127512f72f27cce, 0xa7f32346f95978e3, 0x12e0b01abb051238, 0x15e034d40fa197ae,
+    0x314dffbe0815a3b4, 0x027990f029623981, 0xcadcd4e59ef40c4d, 0x9abfd8766a33735c,
+    0x0e3ea96b5304a7d0, 0xad0c42d6fc585992, 0x187306c89bc215a9, 0xd4a60abcf3792b95,
+    0xf935451de4f21df2, 0xa9538f0419755787, 0xdb9acddff56ca510, 0xd06c98cd5c0975eb,
+    0xe612a3cb9ecba951, 0xc766e62cfcadaf96, 0xee64435a9752fe72, 0xa192d576b245165a,
+    0x0a8787bf8ecb74b2, 0x81b3e73d20b49b6f, 0x7fa8220ba3b2ecea, 0x245731c13ca42499,
+    0xb78dbfaf3a8d83bd, 0xea1ad565322a1a0b, 0x60e61c23a3795013, 0x6606d7e446282b93,
+    0x6ca4ecb15c5f91e1, 0x9f626da15c9625f3, 0xe51b38608ef25f57, 0x958a324ceb064572
+};
+
 BOOST_AUTO_TEST_CASE(siphash)
 {
     CSipHasher hasher(0x0706050403020100ULL, 0x0F0E0D0C0B0A0908ULL);
@@ -74,6 +106,22 @@ BOOST_AUTO_TEST_CASE(siphash)
     BOOST_CHECK_EQUAL(hasher.Finalize(),  0xe612a3cb9ecba951ull);
 
     BOOST_CHECK_EQUAL(SipHashUint256(0x0706050403020100ULL, 0x0F0E0D0C0B0A0908ULL, uint256S("1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100")), 0x7127512f72f27cceull);
+
+    // Check test vectors from spec, one byte at a time
+    CSipHasher hasher2(0x0706050403020100ULL, 0x0F0E0D0C0B0A0908ULL);
+    for (uint8_t x=0; x<ARRAYLEN(siphash_4_2_testvec); ++x)
+    {
+        BOOST_CHECK_EQUAL(hasher2.Finalize(), siphash_4_2_testvec[x]);
+        hasher2.Write(&x, 1);
+    }
+    // Check test vectors from spec, eight bytes at a time
+    CSipHasher hasher3(0x0706050403020100ULL, 0x0F0E0D0C0B0A0908ULL);
+    for (uint8_t x=0; x<ARRAYLEN(siphash_4_2_testvec); x+=8)
+    {
+        BOOST_CHECK_EQUAL(hasher3.Finalize(), siphash_4_2_testvec[x]);
+        hasher3.Write(uint64_t(x)|(uint64_t(x+1)<<8)|(uint64_t(x+2)<<16)|(uint64_t(x+3)<<24)|
+                     (uint64_t(x+4)<<32)|(uint64_t(x+5)<<40)|(uint64_t(x+6)<<48)|(uint64_t(x+7)<<56));
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -92,7 +92,13 @@ TestingSetup::~TestingSetup()
 
 CTxMemPoolEntry TestMemPoolEntryHelper::FromTx(CMutableTransaction &tx, CTxMemPool *pool) {
     CTransaction txn(tx);
-    bool hasNoDependencies = pool ? pool->HasNoInputsOf(tx) : hadNoDependencies;
+    return FromTx(txn, pool);
+}
+
+CTxMemPoolEntry TestMemPoolEntryHelper::FromTx(CTransaction &txn, CTxMemPool *pool) {
+    bool hasNoDependencies = pool ? pool->HasNoInputsOf(txn) : hadNoDependencies;
+    // Hack to assume either its completely dependent on other mempool txs or not at all
+    CAmount inChainValue = hasNoDependencies ? txn.GetValueOut() : 0;
 
     return CTxMemPoolEntry(txn, nFee, nTime, dPriority, nHeight,
                            hasNoDependencies, spendsCoinbase, lp);

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -52,6 +52,7 @@ struct TestMemPoolEntryHelper
         hadNoDependencies(false), spendsCoinbase(false) { }
 
     CTxMemPoolEntry FromTx(CMutableTransaction &tx, CTxMemPool *pool = NULL);
+    CTxMemPoolEntry FromTx(CTransaction &tx, CTxMemPool *pool = NULL);
 
     // Change the default value
     TestMemPoolEntryHelper &Fee(CAmount _fee) { nFee = _fee; return *this; }

--- a/src/test/thinblock_tests.cpp
+++ b/src/test/thinblock_tests.cpp
@@ -1,0 +1,84 @@
+// todo: Test merge
+#include <boost/test/unit_test_suite.hpp>
+#include <boost/test/test_tools.hpp>
+#include "blockencodings.h"
+#include "thinblock.h"
+#include "uint256.h"
+
+BOOST_AUTO_TEST_SUITE(thinblock_tests)
+
+BOOST_AUTO_TEST_CASE(thintx_init) {
+    ThinTx a = ThinTx::Null();
+    BOOST_CHECK(!a.hasFull());
+    BOOST_CHECK(!a.hasCheap());
+    BOOST_CHECK(a.isNull());
+
+    ThinTx b = ThinTx(uint256S("0xCBA"));
+    BOOST_CHECK(b.hasFull());
+    BOOST_CHECK(b.full() == uint256S("0xCBA"));
+    BOOST_CHECK(b.hasCheap());
+    BOOST_CHECK(b.cheap() == uint256S("0xCBA").GetCheapHash());
+    BOOST_CHECK(!b.isNull());
+
+    ThinTx c = ThinTx(GetShortID(0xabc, 0xbbc, uint256S("0xCBA")), 0xabc, 0xbcc);
+    BOOST_CHECK(!c.hasFull());
+    BOOST_CHECK(!c.hasCheap());
+    BOOST_CHECK(!c.isNull());
+}
+
+BOOST_AUTO_TEST_CASE(thintx_equal) {
+
+    ThinTx a = ThinTx::Null();
+    ThinTx b = ThinTx::Null();
+    ThinTx c = ThinTx(uint256S("0xCBA"));
+
+    const uint64_t idk0_a = 0xf00;
+    const uint64_t idk1_a = 0xbaa;
+
+    // null
+    BOOST_CHECK(a.equals(b));
+    BOOST_CHECK(!a.equals(c));
+
+    // same type vs same type
+    a = b = ThinTx(uint256S("0xABC"));
+    BOOST_CHECK(a.equals(b));
+    BOOST_CHECK(!a.equals(c));
+
+    a = b = ThinTx(uint256S("0xABC").GetCheapHash());
+    BOOST_CHECK(a.equals(b));
+    BOOST_CHECK(!a.equals(ThinTx(c.cheap())));
+
+    a = b = ThinTx(GetShortID(
+        idk0_a, idk1_a, uint256S("0xABC")),
+        idk0_a, idk1_a);
+
+    BOOST_CHECK(a.equals(b));
+    c = ThinTx(GetShortID(
+        0xfefe, 0xbaba, uint256S("0xABC")),
+        0xfefe, 0xbaba);
+    BOOST_CHECK(!a.equals(c));
+    BOOST_CHECK(!c.equals(a));
+    c = ThinTx(GetShortID(
+        idk0_a, idk1_a, uint256S("0xCBA")),
+        idk0_a, idk1_a);
+    BOOST_CHECK(!c.equals(a));
+
+
+    // full vs cheap
+    a = ThinTx(uint256S("0xABC"));
+    b = ThinTx(uint256S("0xABC").GetCheapHash());
+    BOOST_CHECK(a.equals(b));
+    BOOST_CHECK(b.equals(a));
+    b = ThinTx(uint256S("0xCBA").GetCheapHash());
+    BOOST_CHECK(!a.equals(b));
+    BOOST_CHECK(!b.equals(a));
+
+    // full vs obfuscated
+    a = ThinTx(GetShortID(
+        0xfefe, 0xbaba, uint256S("0xABC")),
+        0xfefe, 0xbaba);
+    b = ThinTx(uint256S("0xABC"));
+    BOOST_CHECK(a.equals(b));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/thinblockconcluder_tests.cpp
+++ b/src/test/thinblockconcluder_tests.cpp
@@ -1,8 +1,10 @@
 #include <boost/test/unit_test_suite.hpp>
 #include <boost/test/test_tools.hpp>
 #include "test/thinblockutil.h"
+#include "blockencodings.h"
 #include "bloomthin.h"
 #include "chainparams.h"
+#include "compactthin.h"
 #include "merkleblock.h"
 #include "streams.h"
 #include "thinblockconcluder.h"
@@ -220,7 +222,7 @@ BOOST_AUTO_TEST_CASE(xthin_concluder) {
         DummyWorker(ThinBlockManager& mg, NodeId id) :
             XThinWorker(mg, id), addTxCalled(false) { }
 
-        virtual bool addTx(const CTransaction& tx) {
+        bool addTx(const CTransaction& tx) override {
             addTxCalled = true;
             return true;
         }
@@ -246,5 +248,42 @@ BOOST_AUTO_TEST_CASE(xthin_concluder) {
     worker.setToWork(resp.block);
     conclude(resp, pfrom, worker);
 }
+
+BOOST_AUTO_TEST_CASE(compact_concluder) {
+
+    CompactReReqResponse resp;
+    resp.blockhash = uint256S("0xBADBAD");
+    resp.txn.push_back(CTransaction());
+
+    struct DummyWorker : public CompactWorker {
+        DummyWorker(ThinBlockManager& mg, NodeId id) :
+            CompactWorker(mg, id), addTxCalled(false) { }
+
+        bool addTx(const CTransaction& tx) override {
+            addTxCalled = true;
+            return true;
+        }
+
+        bool addTxCalled;
+    };
+
+    DummyWorker worker(tmgr, 42);
+    CompactBlockConcluder conclude;
+    // Should ignore since worker is not working
+    // on anything.
+    worker.setAvailable();
+    conclude(resp, pfrom, worker);
+    BOOST_CHECK(!worker.addTxCalled);
+
+    // Should ignore since worker is assigned to a
+    // different block.
+    worker.setToWork(uint256S("0xf00d"));
+    conclude(resp, pfrom, worker);
+    BOOST_CHECK(!worker.addTxCalled);
+
+    // Should add tx.
+    worker.setToWork(resp.blockhash);
+    conclude(resp, pfrom, worker);
+};
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -4,6 +4,121 @@
 #include "thinblock.h"
 #include "thinblockmanager.h"
 #include "primitives/block.h"
+#include "blockencodings.h" // GetShortID
+#include "util.h"
+#include <sstream>
+
+
+ThinTx::ThinTx(const uint256& h) : full_(h), cheap_(h.GetCheapHash())
+{
+    obfuscated_.id = 0;
+}
+
+ThinTx::ThinTx(const uint64_t& h) : cheap_(h)
+{
+    obfuscated_.id = 0;
+}
+
+ThinTx::ThinTx(const uint64_t& id,
+        const uint64_t& idk0, const uint64_t& idk1) : cheap_(0) {
+    obfuscated_.id = id;
+    obfuscated_.idk0 = idk0;
+    obfuscated_.idk1 = idk1;
+}
+
+void ThinTx::merge(const ThinTx& tx) {
+    if (hasFull())
+        return;
+
+    if (tx.hasFull()) {
+        full_ = tx.full();
+        cheap_ = tx.cheap();
+        return;
+    }
+
+    if (!hasCheap() && tx.hasCheap())
+        cheap_ = tx.cheap();
+
+    if (hasObfuscated())
+        return;
+
+    if (!tx.hasObfuscated())
+        return;
+
+    obfuscated_ = tx.obfuscated_;
+}
+
+bool ThinTx::hasFull() const {
+    return !full_.IsNull();
+}
+
+const uint256& ThinTx::full() const {
+    if (!hasFull())
+        throw std::runtime_error("full hash not available");
+    return full_;
+}
+
+const uint64_t& ThinTx::cheap() const {
+    if (cheap_ == 0)
+        throw std::runtime_error("cheap hash not available");
+
+    return cheap_;
+}
+
+uint64_t ThinTx::obfuscated() const {
+    if (obfuscated_.id == 0)
+        throw std::runtime_error("obfuscated hash not available");
+    return obfuscated_.id;
+}
+
+bool ThinTx::hasObfuscated() const {
+    return obfuscated_.id != 0;
+}
+
+bool ThinTx::equals(const ThinTx& b) const {
+
+    const bool indeterminate = false; //< can't know if txs equal or not
+
+    if (isNull() && b.isNull())
+        return true;
+
+    if (isNull() || b.isNull())
+        return false;
+
+    if (hasFull() && b.hasFull())
+        return full() == b.full();
+
+    if (hasCheap() && b.hasCheap())
+        return cheap() == b.cheap();
+
+    if (hasObfuscated() && b.hasFull())
+        return obfuscated_.id == GetShortID(
+                obfuscated_.idk0, obfuscated_.idk1, b.full());
+
+    if (hasFull() && b.hasObfuscated())
+        return b.obfuscated_.id == GetShortID(
+                b.obfuscated_.idk0, b.obfuscated_.idk1, full());
+
+    if (hasObfuscated() && b.hasObfuscated()) {
+
+        if (obfuscated_.idk0 != b.obfuscated_.idk0)
+            return indeterminate;
+
+        if (obfuscated_.idk1 != b.obfuscated_.idk1)
+            return indeterminate;
+
+        return obfuscated_.id == b.obfuscated_.id;
+    }
+
+    if (hasObfuscated() || b.hasObfuscated())
+        return indeterminate;
+
+    assert(!"ThinTx::equals");
+}
+
+bool ThinTx::equals(const uint256& b) const {
+    return equals(ThinTx(b));
+}
 
 ThinBlockWorker::ThinBlockWorker(ThinBlockManager& m, NodeId n) :
     mg(m), rerequesting(false), node(n)

--- a/src/thinblockconcluder.cpp
+++ b/src/thinblockconcluder.cpp
@@ -1,3 +1,4 @@
+#include "blockencodings.h"
 #include "net.h"
 #include "thinblockbuilder.h"
 #include "thinblockconcluder.h"
@@ -8,6 +9,7 @@
 #include "xthin.h"
 #include "utilprocessmsg.h"
 #include <vector>
+#include "compactthin.h"
 
 
 void BloomBlockConcluder::operator()(CNode* pfrom,
@@ -101,12 +103,12 @@ void XThinBlockConcluder::operator()(const XThinReReqResponse& resp,
 
     if (worker.isAvailable())
     {
-        LogPrint("thin", "worker peer=%d should not be working on a thin block,"
+        LogPrint("thin", "worker peer=%d should not be working on a xthin block,"
                 "ignoring re-req response\n", pfrom.id);
         return;
     }
     if (worker.blockHash() != resp.block) {
-        LogPrint("thin", "working on block %s, got re-req response from peer=%d for %s\n",
+        LogPrint("thin", "working on block %s, got xthin re-req response from peer=%d for %s\n",
                 worker.blockStr(), pfrom.id, resp.block.ToString());
         return;
     }
@@ -124,6 +126,38 @@ void XThinBlockConcluder::operator()(const XThinReReqResponse& resp,
     LogPrint("thin", "peer=%d responded to re-request for block %s, "
         "but still did not provide all transctions missing\n",
         pfrom.id, resp.block.ToString());
+
+    worker.setAvailable();
+    Misbehaving(pfrom.id, 10);
+}
+
+void CompactBlockConcluder::operator()(const CompactReReqResponse& resp,
+        CNode& pfrom, ThinBlockWorker& worker) {
+
+    if (worker.isAvailable())
+    {
+        LogPrint("thin", "worker peer=%d should not be working on a compact thin block,"
+                "ignoring re-req response\n", pfrom.id);
+        return;
+    }
+    if (worker.blockHash() != resp.blockhash) {
+        LogPrint("thin", "working on block %s, got compact re-req response from peer=%d for %s\n",
+                worker.blockStr(), pfrom.id, resp.blockhash.ToString());
+        return;
+    }
+
+    for (auto& t : resp.txn)
+        worker.addTx(t);
+
+    // Block finished?
+    if (worker.isAvailable())
+        return;
+
+    // There is no reason for remote peer not to have provided all
+    // transactions at this point.
+    LogPrint("thin", "peer=%d responded to compact re-request for block %s, "
+        "but still did not provide all transctions missing\n",
+        pfrom.id, resp.blockhash.ToString());
 
     worker.setAvailable();
     Misbehaving(pfrom.id, 10);

--- a/src/thinblockconcluder.h
+++ b/src/thinblockconcluder.h
@@ -11,6 +11,7 @@ typedef int NodeId;
 class CBlockIndex;
 class uint256;
 struct XThinReReqResponse;
+class CompactReReqResponse;
 
 namespace Consensus { struct Params; }
 
@@ -46,6 +47,12 @@ struct BloomBlockConcluder {
 // Finishes a block using response from a transaction re-request.
 struct XThinBlockConcluder {
     void operator()(const XThinReReqResponse& resp,
+        CNode& pfrom, ThinBlockWorker& worker);
+};
+
+// Finishes a block using response from a transaction re-request.
+struct CompactBlockConcluder {
+    void operator()(const CompactReReqResponse& resp,
         CNode& pfrom, ThinBlockWorker& worker);
 };
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -736,7 +736,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
     assert(innerUsage == cachedInnerUsage);
 }
 
-void CTxMemPool::queryHashes(vector<uint256>& vtxid)
+void CTxMemPool::queryHashes(vector<uint256>& vtxid) const
 {
     vtxid.clear();
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -457,7 +457,7 @@ public:
                         std::list<CTransaction>& conflicts, bool fCurrentEstimate = true);
     void clear();
     void _clear(); //lock free
-    void queryHashes(std::vector<uint256>& vtxid);
+    void queryHashes(std::vector<uint256>& vtxid) const;
     void pruneSpent(const uint256& hash, CCoins &coins);
     unsigned int GetTransactionsUpdated() const;
     void AddTransactionsUpdated(unsigned int n);

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -124,7 +124,7 @@ public:
  */
 class uint256 : public base_blob<256> {
 public:
-    uint256() {}
+    uint256() : base_blob<256>() {}
     uint256(const base_blob<256>& b) : base_blob<256>(b) {}
     explicit uint256(const std::vector<unsigned char>& vch) : base_blob<256>(vch) {}
 

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -80,6 +80,19 @@ public:
         return sizeof(data);
     }
 
+    uint64_t GetUint64(int pos) const
+    {
+        const uint8_t* ptr = data + pos * 8;
+        return ((uint64_t)ptr[0]) | \
+               ((uint64_t)ptr[1]) << 8 | \
+               ((uint64_t)ptr[2]) << 16 | \
+               ((uint64_t)ptr[3]) << 24 | \
+               ((uint64_t)ptr[4]) << 32 | \
+               ((uint64_t)ptr[5]) << 40 | \
+               ((uint64_t)ptr[6]) << 48 | \
+               ((uint64_t)ptr[7]) << 56;
+    }
+
     template<typename Stream>
     void Serialize(Stream& s, int nType, int nVersion) const
     {

--- a/src/version.h
+++ b/src/version.h
@@ -9,7 +9,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70012;
+static const int PROTOCOL_VERSION = 70014;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -39,5 +39,8 @@ static const int NO_BLOOM_VERSION = 70011;
 
 //! "sendheaders" command and announcing blocks with headers starts with this version
 static const int SENDHEADERS_VERSION = 70012;
+
+//! Core added "compact blocks".
+static const int SHORT_IDS_BLOCKS_VERSION = 70014;
 
 #endif // BITCOIN_VERSION_H

--- a/src/xthin.h
+++ b/src/xthin.h
@@ -7,6 +7,7 @@
 #include "thinblock.h"
 #include "serialize.h"
 #include "primitives/block.h"
+#include "util.h"
 #include <memory>
 #include <stdexcept>
 
@@ -58,8 +59,8 @@ class XThinWorker : public ThinBlockWorker {
         // only for unit testing
         XThinWorker(ThinBlockManager&, NodeId);
 
-        virtual void requestBlock(const uint256& block,
-                std::vector<CInv>& getDataReq, CNode& node);
+        void requestBlock(const uint256& block,
+                std::vector<CInv>& getDataReq, CNode& node) override;
 
     private:
         std::unique_ptr<struct TxHashProvider> HashProvider;
@@ -82,6 +83,9 @@ struct XThinStub : public StubData {
         catch (const std::exception& e) {
             throw thinblock_error(e.what());
         }
+
+        LogPrint("thin", "Created xthin stub for %s, %d transactions.\n",
+                header().GetHash().ToString(), allTransactions().size());
     }
 
     virtual CBlockHeader header() const {


### PR DESCRIPTION
So Core went ahead and created yet another thin block protocol. This is the third thin block implementation I add to XT. It’s getting kind of repetitive. But this is a good step in the direction of on-chain scaling so I’m happy too. This PR is created on top of PR #159.

This PR has limited testing: It’s been running on my node since yesterday without issues, sharing compact blocks with Core nodes and xthin blocks with others.  I have also successfully tested all rpc-tests (except pruning.py which i skipped) with compact block transfers.

**The missing:**
- I have cherry-picked p2p-compactblocks.py by @sdaftuar, but I have not been able to get the test to run yet. There are likely issues with regtest differences because of BIP109. Help would be appreciated.
- I have not implemented _high bandwidth mode_. It is optional per BIP152. I may implement it later together with XThin Xpedited.

**The bonus:**
- Uses inventoryKnown add transactions the remote node is missing to the compact blocks sent - reducing latency. This is in contrast to the Core implementation that only sends the coinbase tx.
- Supports parallel download of the same block -- meaning no stalled downloads. XT continues to be the only full node supporting parallel download of the chain tip.
- Can parallel download xthin and bloom thins for the same block.

Compact blocks are very similar to xthin. Thus this implementation fits well within existing architecture.
