### PR TITLE
[depends] Boost 1.61.0

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,8 +1,8 @@
 package=boost
-$(package)_version=1_59_0
-$(package)_download_path=http://sourceforge.net/projects/boost/files/boost/1.59.0
+$(package)_version=1_61_0
+$(package)_download_path=https://sourceforge.net/projects/boost/files/boost/1.61.0
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
-$(package)_sha256_hash=727a932322d94287b62abb1bd2d41723eec4356a7728909e38adb65ca25241ca
+$(package)_sha256_hash=a547bd06c2fd9a71ba1d169d9cf0339da7ebf4753849a8f7d6fdb8feee99b640
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release


### PR DESCRIPTION
Release G will include several dependency version bumps.  This fixes a known bug with one of them.