### PR TITLE
Make net debugging more granular

### DIFF
--- a/src/blockannounce.cpp
+++ b/src/blockannounce.cpp
@@ -100,7 +100,7 @@ BlockAnnounceReceiver::DownloadStrategy BlockAnnounceReceiver::pickDownloadStrat
 void requestHeaders(CNode& from, const uint256& block) {
 
     from.PushMessage("getheaders", chainActive.GetLocator(pindexBestHeader), block);
-    LogPrint("net", "getheaders (%d) %s to peer=%d\n",
+    LogPrint("block", "getheaders (%d) %s to peer=%d\n",
             pindexBestHeader->nHeight, block.ToString(), from.id);
 }
 
@@ -266,7 +266,7 @@ bool BlockAnnounceSender::announceWithHeaders() {
     if (headers.empty())
         return true;
 
-    LogPrint("net", "%s: %u headers, range (%s, %s), to peer=%d\n", __func__,
+    LogPrint("block", "%s: %u headers, range (%s, %s), to peer=%d\n", __func__,
             headers.size(),
             headers.front().GetHash().ToString(),
             headers.back().GetHash().ToString(), to.id);
@@ -315,7 +315,7 @@ void BlockAnnounceSender::announceWithInv() {
     // setInventoryKnown to track this.)
     if (!peerHasHeader(pindex)) {
         to.PushInventory(CInv(MSG_BLOCK, hashToAnnounce));
-        LogPrint("net", "%s: sending inv peer=%d hash=%s\n", __func__,
+        LogPrint("block", "%s: sending inv peer=%d hash=%s\n", __func__,
                 to.id, hashToAnnounce.ToString());
     }
 }

--- a/src/blockheaderprocessor.cpp
+++ b/src/blockheaderprocessor.cpp
@@ -66,7 +66,7 @@ bool DefaultHeaderProcessor::operator()(const std::vector<CBlockHeader>& headers
         // Headers message had its maximum size; the peer may have more headers.
         // TODO: optimize: if pindexLast is an ancestor of chainActive.Tip or pindexBestHeader, continue
         // from there instead.
-        LogPrint("net", "more getheaders (%d) to end to peer=%d (startheight:%d)\n", pindexLast->nHeight, pfrom->id, pfrom->nStartingHeight);
+        LogPrint("block", "more getheaders (%d) to end to peer=%d (startheight:%d)\n", pindexLast->nHeight, pfrom->id, pfrom->nStartingHeight);
         pfrom->PushMessage("getheaders", chainActive.GetLocator(pindexLast), uint256());
     }
 
@@ -160,7 +160,7 @@ void DefaultHeaderProcessor::suggestDownload(const std::vector<CBlockIndex*>& to
     }
 
     if (!toGet.empty()) {
-        LogPrint("net", "Downloading blocks toward %s (%d) via headers direct fetch\n",
+        LogPrint("block", "Downloading blocks toward %s (%d) via headers direct fetch\n",
                 last->GetBlockHash().ToString(), last->nHeight);
         pfrom->PushMessage("getdata", toGet);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4424,7 +4424,7 @@ bool static SanityCheckMessage(CNode* peer, const CNetMessage& msg)
     const std::string& strCommand = msg.hdr.GetCommand();
     if (msg.hdr.nMessageSize > MAX_PROTOCOL_MESSAGE_LENGTH ||
         (maxMessageSizes.count(strCommand) && msg.hdr.nMessageSize > maxMessageSizes[strCommand])) {
-        LogPrint("net", "Oversized %s message from peer=%i (%d bytes)\n",
+        LogPrint("neterr", "Oversized %s message from peer=%i (%d bytes)\n",
                  SanitizeString(strCommand), peer->GetId(), msg.hdr.nMessageSize);
         Misbehaving(peer->GetId(), 20);
         return msg.hdr.nMessageSize <= MAX_PROTOCOL_MESSAGE_LENGTH;
@@ -4713,7 +4713,7 @@ struct MempoolHashProvider : public TxHashProvider {
 bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t nTimeReceived)
 {
     RandAddSeedPerfmon();
-    LogPrint("net", "received: %s (%u bytes) peer=%d\n", SanitizeString(strCommand), vRecv.size(), pfrom->id);
+    LogPrint("netrecv", "received: %s (%u bytes) peer=%d\n", SanitizeString(strCommand), vRecv.size(), pfrom->id);
     if (mapArgs.count("-dropmessagestest") && GetRand(atoi(mapArgs["-dropmessagestest"])) == 0)
     {
         LogPrintf("dropmessagestest DROPPING RECV MESSAGE\n");
@@ -5088,10 +5088,10 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
         }
 
         if (fDebug || (vInv.size() != 1))
-            LogPrint("net", "received getdata (%u invsz) peer=%d\n", vInv.size(), pfrom->id);
+            LogPrint("netrecv", "received getdata (%u invsz) peer=%d\n", vInv.size(), pfrom->id);
 
         if ((fDebug && vInv.size() > 0) || (vInv.size() == 1))
-            LogPrint("net", "received getdata for: %s peer=%d\n", vInv[0].ToString(), pfrom->id);
+            LogPrint("netrecv", "received getdata for: %s peer=%d\n", vInv[0].ToString(), pfrom->id);
 
         pfrom->vRecvGetData.insert(pfrom->vRecvGetData.end(), vInv.begin(), vInv.end());
         ProcessGetData(pfrom);
@@ -5113,12 +5113,12 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
         if (pindex)
             pindex = chainActive.Next(pindex);
         int nLimit = 500;
-        LogPrint("net", "getblocks %d to %s limit %d from peer=%d\n", (pindex ? pindex->nHeight : -1), hashStop.IsNull() ? "end" : hashStop.ToString(), nLimit, pfrom->id);
+        LogPrint("blocksend", "getblocks %d to %s limit %d from peer=%d\n", (pindex ? pindex->nHeight : -1), hashStop.IsNull() ? "end" : hashStop.ToString(), nLimit, pfrom->id);
         for (; pindex; pindex = chainActive.Next(pindex))
         {
             if (pindex->GetBlockHash() == hashStop)
             {
-                LogPrint("net", "  getblocks stopping at %d %s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
+                LogPrint("blocksend", "  getblocks stopping at %d %s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
                 break;
             }
             // If pruning, don't inv blocks unless we have on disk and are likely to still have
@@ -5126,7 +5126,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
             const int nPrunedBlocksLikelyToHave = MIN_BLOCKS_TO_KEEP - 3600 / Params().GetConsensus().nPowTargetSpacing;
             if (fPruneMode && (!(pindex->nStatus & BLOCK_HAVE_DATA) || pindex->nHeight <= chainActive.Tip()->nHeight - nPrunedBlocksLikelyToHave))
             {
-                LogPrint("net", " getblocks stopping, pruned or too old block at %d %s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
+                LogPrint("blocksend", " getblocks stopping, pruned or too old block at %d %s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
                 break;
             }
             pfrom->PushInventory(CInv(MSG_BLOCK, pindex->GetBlockHash()));
@@ -5134,7 +5134,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
             {
                 // When this block is requested, we'll send an inv that'll
                 // trigger the peer to getblocks the next batch of inventory.
-                LogPrint("net", "  getblocks stopping at limit %d %s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
+                LogPrint("blocksend", "  getblocks stopping at limit %d %s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
                 pfrom->hashContinue = pindex->GetBlockHash();
                 break;
             }
@@ -5173,7 +5173,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
         // we must use CBlocks, as CBlockHeaders won't include the 0x00 nTx count at the end
         vector<CBlock> vHeaders;
         int nLimit = MAX_HEADERS_RESULTS;
-        LogPrint("net", "getheaders %d to %s from peer=%d\n", (pindex ? pindex->nHeight : -1), hashStop.ToString(), pfrom->id);
+        LogPrint("blocksend", "getheaders %d to %s from peer=%d\n", (pindex ? pindex->nHeight : -1), hashStop.ToString(), pfrom->id);
         for (; pindex; pindex = chainActive.Next(pindex))
         {
             vHeaders.push_back(pindex->GetBlockHeader());
@@ -5851,7 +5851,7 @@ bool ProcessMessages(CNode* pfrom)
         }
 
         if (!fRet)
-            LogPrint("net", "%s(%s, %u bytes) FAILED peer=%d\n", __func__, SanitizeString(strCommand), nMessageSize, pfrom->id);
+            LogPrint("neterr", "%s(%s, %u bytes) FAILED peer=%d\n", __func__, SanitizeString(strCommand), nMessageSize, pfrom->id);
 
         break;
     }
@@ -6008,7 +6008,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
                 statePtr->fSyncStarted = true;
                 nSyncStarted++;
                 CBlockIndex *pindexStart = pindexBestHeader->pprev ? pindexBestHeader->pprev : pindexBestHeader;
-                LogPrint("net", "initial getheaders (%d) to peer=%d (startheight:%d)\n", pindexStart->nHeight, pto->id, pto->nStartingHeight);
+                LogPrint("block", "initial getheaders (%d) to peer=%d (startheight:%d)\n", pindexStart->nHeight, pto->id, pto->nStartingHeight);
                 pto->PushMessage("getheaders", chainActive.GetLocator(pindexStart), uint256());
             }
         }
@@ -6118,13 +6118,13 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
                 if (ThinBlocksActive(pto) && worker.isAvailable()) {
                     worker.requestBlock(pindex->GetBlockHash(), vGetData, *pto);
                     worker.setToWork(pindex->GetBlockHash());
-                    LogPrint("net", "Requesting thin block %s (%d) peer=%d\n",
+                    LogPrint("block", "Requesting thin block %s (%d) peer=%d\n",
                             pindex->GetBlockHash().ToString(), pindex->nHeight, pto->id);
                 }
                 else
                 {
                     vGetData.push_back(CInv(MSG_BLOCK, pindex->GetBlockHash()));
-                    LogPrint("net", "Requesting full block %s (%d) peer=%d\n", pindex->GetBlockHash().ToString(),
+                    LogPrint("block", "Requesting full block %s (%d) peer=%d\n", pindex->GetBlockHash().ToString(),
                             pindex->nHeight, pto->id);
 
                 }
@@ -6135,7 +6135,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
                 for (auto_ n = stallers.begin(); n != stallers.end(); ++n) {
                     if (NodeStatePtr(*n)->nStallingSince == 0) {
                         NodeStatePtr(*n)->nStallingSince = nNow;
-                        LogPrint("net", "Stall started peer=%d\n", *n);
+                        LogPrint("block", "Stall started peer=%d\n", *n);
                     }
                 }
             }
@@ -6150,7 +6150,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
             if (!AlreadyHave(inv))
             {
                 if (fDebug)
-                    LogPrint("net", "Requesting %s peer=%d\n", inv.ToString(), pto->id);
+                    LogPrint("tx", "Requesting %s peer=%d\n", inv.ToString(), pto->id);
                 vGetData.push_back(inv);
                 if (vGetData.size() >= 1000)
                 {

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -464,7 +464,7 @@ bool static ConnectSocketDirectly(const CService &addrConnect, SOCKET& hSocketRe
             int nRet = select(hSocket + 1, NULL, &fdset, NULL, &timeout);
             if (nRet == 0)
             {
-                LogPrint("net", "connection to %s timeout\n", addrConnect.ToString());
+                LogPrint("conn", "connection to %s timeout\n", addrConnect.ToString());
                 CloseSocket(hSocket);
                 return false;
             }


### PR DESCRIPTION
debug=net tends to produce too much output and it can often be desired to debug just certain parts of what is provided by net debug. I have split it down into the following:-

This wll help with when developing just certain areas, e.g. block propagation, and therefore we're not needing visibility of tx send/get logic.

As yet the command line help is not updated - can add this if it is wanted (or a maintainer can).

"block" debugs block download progress
"blocksend" debugs block upload progress
"netrecv" debugs every message received
"netsend" debugs every message sent
"conn" debugs the making and breaking of connections to other peers
"neterr" debugs network errors
"net" everything else