### PR TITLE
Don't ignore nodes advertising SEGWIT

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2203,9 +2203,5 @@ bool CNode::SupportsXThinBlocks() const {
 }
 
 bool CNode::SupportsCompactBlocks() const {
-
-    // If a Core node activates segwit, it also
-    // disables support for compact blocks v1
-    return nVersion >= SHORT_IDS_BLOCKS_VERSION
-        && !(nServices & NODE_WITNESS);
+    return nVersion >= SHORT_IDS_BLOCKS_VERSION;
 }


### PR DESCRIPTION
Core continues to support compact blocks v1 after segwit activation (this was not the case when this check was added).

(Original commit: https://github.com/rebroad/bitcoinxt/commit/81d7d605f88dadfbe995149c0689ce67b4127531)