### PR TITLE
BIP100: Dynamic maximum block size by miner vote

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,7 +105,8 @@ linux-build
 win32-build
 qa/pull-tester/run-bitcoind-for-test.sh
 qa/pull-tester/tests-config.sh
-qa/pull-tester/cache/*
+qa/pull-tester/cache
+qa/pull-tester/cache_bigblock
 qa/pull-tester/test.*/*
 
 !src/leveldb*/Makefile

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -96,6 +96,7 @@ testScripts = [
     'sendheaders.py'
 ]
 testScriptsExt = [
+    'bip100-sizelimit.py',
     'bip9-softforks.py',
     'bipdersig-p2p.py',
     'bip65-cltv-p2p.py',

--- a/qa/rpc-tests/.gitignore
+++ b/qa/rpc-tests/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 cache
+cache_bigblock

--- a/qa/rpc-tests/bip100-sizelimit.py
+++ b/qa/rpc-tests/bip100-sizelimit.py
@@ -30,10 +30,10 @@ class BigBlockTest(BitcoinTestFramework):
             # Node 3 creates empty blocks that do not vote for increase
             self.nodes = []
             # Use node0 to mine blocks for input splitting
-            self.nodes.append(start_node(0, CACHE_DIR, ["-blockmaxsize=8000000", "-maxblocksizevote=8"]))
-            self.nodes.append(start_node(1, CACHE_DIR, ["-blockmaxsize=1000", "-maxblocksizevote=8"]))
-            self.nodes.append(start_node(2, CACHE_DIR, ["-blockmaxsize=1000", "-maxblocksizevote=2"]))
-            self.nodes.append(start_node(3, CACHE_DIR, ["-blockmaxsize=1000", "-maxblocksizevote=1"]))
+            self.nodes.append(start_node(0, CACHE_DIR, ["-blockmaxsize=8000000", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"]))
+            self.nodes.append(start_node(1, CACHE_DIR, ["-blockmaxsize=1000", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"]))
+            self.nodes.append(start_node(2, CACHE_DIR, ["-blockmaxsize=1000", "-maxblocksizevote=1", "-limitancestorsize=2000", "-limitdescendantsize=2000"]))
+            self.nodes.append(start_node(3, CACHE_DIR, ["-blockmaxsize=1000", "-maxblocksizevote=2", "-limitancestorsize=2000", "-limitdescendantsize=2000"]))
 
             connect_nodes_bi(self.nodes, 0, 1)
             connect_nodes_bi(self.nodes, 1, 2)
@@ -47,39 +47,45 @@ class BigBlockTest(BitcoinTestFramework):
             blocks = []
             blocks.append(self.nodes[1].generate(503))
             assert(self.sync_blocks(self.nodes[1:3]))
-            blocks.append(self.nodes[2].generate(503))
+            blocks.append(self.nodes[2].generate(502)) # <--- genesis is 503rd vote for 1MB
             assert(self.sync_blocks(self.nodes[2:4]))
-            blocks.append(self.nodes[3].generate(502)) # <--- genesis is 503rd vote for 1MB
+            blocks.append(self.nodes[3].generate(503))
             assert(self.sync_blocks(self.nodes[1:4]))
             blocks.append(self.nodes[1].generate(503))
             assert(self.sync_blocks(self.nodes))
 
-            # Generate 1200 addresses
-            addresses = [ self.nodes[3].getnewaddress() for i in range(0,1200) ]
-
-            amount = Decimal("0.00125")
-
-            send_to = { }
-            for address in addresses:
-                send_to[address] = amount
-
             tx_file = open(os.path.join(CACHE_DIR, "txdata"), "w")
 
-            # Create four megabytes worth of transactions ready to be
-            # mined:
-            print("Creating 100 40K transactions (4MB)")
-            for node in range(1,3):
-                for i in range(0,50):
-                    txid = self.nodes[node].sendmany("", send_to, 1)
-                    txdata = self.nodes[node].getrawtransaction(txid)
-                    tx_file.write(txdata+"\n")
+            # Create a lot of tansaction data ready to be mined
+            fee = Decimal('.00005')
+            used = set()
+            print("Creating transaction data")
+            for i in range(0,25):
+                inputs = []
+                outputs = {}
+                limit = 0
+                utxos = self.nodes[3].listunspent(0)
+                for utxo in utxos:
+                    if not utxo["txid"]+str(utxo["vout"]) in used:
+                        raw_input = {}
+                        raw_input["txid"] = utxo["txid"]
+                        raw_input["vout"] = utxo["vout"]
+                        inputs.append(raw_input)
+                        outputs[self.nodes[3].getnewaddress()] = utxo["amount"] - fee
+                        used.add(utxo["txid"]+str(utxo["vout"]))
+                        limit = limit + 1
+                        if (limit >= 250):
+                            break
+                rawtx = self.nodes[3].createrawtransaction(inputs, outputs)
+                txdata = self.nodes[3].signrawtransaction(rawtx)["hex"]
+                self.nodes[3].sendrawtransaction(txdata)
+                tx_file.write(txdata+"\n")
             tx_file.close()
 
             stop_nodes(self.nodes)
             wait_bitcoinds()
             self.nodes = []
             for i in range(4):
-                os.remove(log_filename(CACHE_DIR, i, "debug.log"))
                 os.remove(log_filename(CACHE_DIR, i, "db.log"))
                 os.remove(log_filename(CACHE_DIR, i, "peers.dat"))
                 os.remove(log_filename(CACHE_DIR, i, "fee_estimates.dat"))
@@ -90,7 +96,7 @@ class BigBlockTest(BitcoinTestFramework):
             shutil.copytree(from_dir, to_dir)
             initialize_datadir(self.options.tmpdir, i) # Overwrite port/rpcport in bitcoin.conf
 
-    def sync_blocks(self, rpc_connections, wait=1, max_wait=30):
+    def sync_blocks(self, rpc_connections, wait=1, max_wait=60):
         """
         Wait until everybody has the same block count
         """
@@ -104,31 +110,26 @@ class BigBlockTest(BitcoinTestFramework):
     def setup_network(self):
         self.nodes = []
 
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-blockmaxsize=8000000", "-maxblocksizevote=8"]))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-blockmaxsize=1000", "-maxblocksizevote=8"]))
-        self.nodes.append(start_node(2, self.options.tmpdir, ["-blockmaxsize=1000", "-maxblocksizevote=2"]))
-        self.nodes.append(start_node(3, self.options.tmpdir, ["-blockmaxsize=1000", "-maxblocksizevote=1"]))
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-blockmaxsize=8000000", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"], timewait=60))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-blockmaxsize=1000", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"], timewait=60))
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-blockmaxsize=1000", "-maxblocksizevote=1", "-limitancestorsize=2000", "-limitdescendantsize=2000"], timewait=60))
+        # (We don't restart the node with the huge wallet
         connect_nodes_bi(self.nodes, 0, 1)
         connect_nodes_bi(self.nodes, 1, 2)
-        connect_nodes_bi(self.nodes, 2, 3)
-        connect_nodes_bi(self.nodes, 3, 0)
+        connect_nodes_bi(self.nodes, 2, 0)
 
-        # Populate node0's mempool with cached pre-created transactions:
+        self.load_mempool(self.nodes[0])
+
+    def load_mempool(self, node):
         with open(os.path.join(CACHE_DIR, "txdata"), "r") as f:
             for line in f:
-                self.nodes[0].sendrawtransaction(line.rstrip())
-
-    def copy_mempool(self, from_node, to_node):
-        txids = from_node.getrawmempool()
-        for txid in txids:
-            txdata = from_node.getrawtransaction(txid)
-            to_node.sendrawtransaction(txdata)
+                node.sendrawtransaction(line.rstrip())
 
     def TestMineBig(self, expect_big):
         # Test if node0 will mine a block bigger than legacy MAX_BLOCK_SIZE
         b1hash = self.nodes[0].generate(1)[0]
         b1 = self.nodes[0].getblock(b1hash, True)
-        assert(self.sync_blocks(self.nodes))
+        assert(self.sync_blocks(self.nodes[0:3]))
 
         if expect_big:
             assert(b1['size'] > 1000*1000)
@@ -138,22 +139,18 @@ class BigBlockTest(BitcoinTestFramework):
             b2hash = self.nodes[1].generate(1)[0]
             b2 = self.nodes[1].getblock(b2hash, True)
             assert(b2['previousblockhash'] == b1hash)
-            assert(self.sync_blocks(self.nodes))
+            assert(self.sync_blocks(self.nodes[0:3]))
 
         else:
             assert(b1['size'] < 1000*1000)
 
         # Reset chain to before b1hash:
-        for node in self.nodes:
+        for node in self.nodes[0:3]:
             node.invalidateblock(b1hash)
-        assert(self.sync_blocks(self.nodes))
+        assert(self.sync_blocks(self.nodes[0:3]))
 
 
     def run_test(self):
-        # nodes 0 and 1 have mature 50-BTC coinbase transactions.
-        # Spend them with 50 transactions, each that has
-        # 1,200 outputs (so they're about 41K big).
-
         print("Testing consensus blocksize increase conditions")
 
         assert_equal(self.nodes[0].getblockcount(), 2011) # This is a 0-based height
@@ -163,8 +160,8 @@ class BigBlockTest(BitcoinTestFramework):
         self.TestMineBig(False)
 
         # Create a situation where the 1512th-highest vote is for 2MB
-        self.nodes[3].generate(1)
-        assert(self.sync_blocks(self.nodes[1:4]))
+        self.nodes[2].generate(1)
+        assert(self.sync_blocks(self.nodes[1:3]))
         ahash = self.nodes[1].generate(3)[2]
         assert_equal(self.nodes[1].getblocktemplate()["sizelimit"], int(1000000 * 1.05))
         assert(self.sync_blocks(self.nodes[0:2]))
@@ -172,34 +169,34 @@ class BigBlockTest(BitcoinTestFramework):
 
         # Shutdown then restart node[0], it should produce a big block.
         stop_node(self.nodes[0], 0)
-        self.nodes[0] = start_node(0, self.options.tmpdir, ["-blockmaxsize=8000000", "-maxblocksizevote=8"])
-        self.copy_mempool(self.nodes[1], self.nodes[0])
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-blockmaxsize=8000000", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"], timewait=60)
+        self.load_mempool(self.nodes[0])
         connect_nodes_bi(self.nodes, 0, 1)
-        connect_nodes_bi(self.nodes, 0, 3)
+        connect_nodes_bi(self.nodes, 0, 2)
         assert_equal(self.nodes[0].getblocktemplate()["sizelimit"], int(1000000 * 1.05))
         self.TestMineBig(True)
 
         # Test re-orgs past the sizechange block
         stop_node(self.nodes[0], 0)
-        self.nodes[3].invalidateblock(ahash)
-        assert_equal(self.nodes[3].getblocktemplate()["sizelimit"], 1000000)
-        self.nodes[3].generate(2)
-        assert_equal(self.nodes[3].getblocktemplate()["sizelimit"], 1000000)
-        assert(self.sync_blocks(self.nodes[1:]))
+        self.nodes[2].invalidateblock(ahash)
+        assert_equal(self.nodes[2].getblocktemplate()["sizelimit"], 1000000)
+        self.nodes[2].generate(2)
+        assert_equal(self.nodes[2].getblocktemplate()["sizelimit"], 1000000)
+        assert(self.sync_blocks(self.nodes[1:3]))
 
         # Restart node0, it should re-org onto longer chain,
         # and refuse to mine a big block:
-        self.nodes[0] = start_node(0, self.options.tmpdir, ["-blockmaxsize=8000000", "-maxblocksizevote=8"])
-        self.copy_mempool(self.nodes[1], self.nodes[0])
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-blockmaxsize=8000000", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"], timewait=60)
+        self.load_mempool(self.nodes[0])
         connect_nodes_bi(self.nodes, 0, 1)
-        connect_nodes_bi(self.nodes, 0, 3)
-        assert(self.sync_blocks(self.nodes))
+        connect_nodes_bi(self.nodes, 0, 2)
+        assert(self.sync_blocks(self.nodes[0:3]))
         assert_equal(self.nodes[0].getblocktemplate()["sizelimit"], 1000000)
         self.TestMineBig(False)
 
-        # Mine 4 blocks voting for 2MB. Bigger block NOT ok, we are in the next voting period
-        self.nodes[2].generate(4)
-        assert_equal(self.nodes[2].getblocktemplate()["sizelimit"], 1000000)
+        # Mine 4 blocks voting for 8MB. Bigger block NOT ok, we are in the next voting period
+        self.nodes[1].generate(4)
+        assert_equal(self.nodes[1].getblocktemplate()["sizelimit"], 1000000)
         assert(self.sync_blocks(self.nodes[0:3]))
         self.TestMineBig(False)
 

--- a/qa/rpc-tests/bip100-sizelimit.py
+++ b/qa/rpc-tests/bip100-sizelimit.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python2
+# Copyright (c) 2017 The Bitcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test mining and broadcast of larger-than-1MB-blocks
+#
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+from decimal import Decimal
+
+CACHE_DIR = "cache_bigblock"
+
+class BigBlockTest(BitcoinTestFramework):
+
+    def setup_chain(self):
+        print("Initializing test directory "+self.options.tmpdir)
+
+        if not os.path.isdir(os.path.join(CACHE_DIR, "node0")):
+            print("Creating initial chain. This will be cached for future runs.")
+
+            for i in range(4):
+                initialize_datadir(CACHE_DIR, i) # Overwrite port/rpcport in bitcoin.conf
+
+            # Node 0 creates 8MB blocks that vote for increase to 8MB
+            # Node 1 creates empty blocks that vote for 8MB
+            # Node 2 creates empty blocks that vote for 2MB
+            # Node 3 creates empty blocks that do not vote for increase
+            self.nodes = []
+            # Use node0 to mine blocks for input splitting
+            self.nodes.append(start_node(0, CACHE_DIR, ["-blockmaxsize=8000000", "-maxblocksizevote=8"]))
+            self.nodes.append(start_node(1, CACHE_DIR, ["-blockmaxsize=1000", "-maxblocksizevote=8"]))
+            self.nodes.append(start_node(2, CACHE_DIR, ["-blockmaxsize=1000", "-maxblocksizevote=2"]))
+            self.nodes.append(start_node(3, CACHE_DIR, ["-blockmaxsize=1000", "-maxblocksizevote=1"]))
+
+            connect_nodes_bi(self.nodes, 0, 1)
+            connect_nodes_bi(self.nodes, 1, 2)
+            connect_nodes_bi(self.nodes, 2, 3)
+            connect_nodes_bi(self.nodes, 3, 0)
+
+            self.is_network_split = False
+
+            # Create a 2012-block chain in a 75% ratio for increase (genesis block votes for 1MB)
+            # Make sure they are not already sorted correctly
+            blocks = []
+            blocks.append(self.nodes[1].generate(503))
+            assert(self.sync_blocks(self.nodes[1:3]))
+            blocks.append(self.nodes[2].generate(503))
+            assert(self.sync_blocks(self.nodes[2:4]))
+            blocks.append(self.nodes[3].generate(502)) # <--- genesis is 503rd vote for 1MB
+            assert(self.sync_blocks(self.nodes[1:4]))
+            blocks.append(self.nodes[1].generate(503))
+            assert(self.sync_blocks(self.nodes))
+
+            # Generate 1200 addresses
+            addresses = [ self.nodes[3].getnewaddress() for i in range(0,1200) ]
+
+            amount = Decimal("0.00125")
+
+            send_to = { }
+            for address in addresses:
+                send_to[address] = amount
+
+            tx_file = open(os.path.join(CACHE_DIR, "txdata"), "w")
+
+            # Create four megabytes worth of transactions ready to be
+            # mined:
+            print("Creating 100 40K transactions (4MB)")
+            for node in range(1,3):
+                for i in range(0,50):
+                    txid = self.nodes[node].sendmany("", send_to, 1)
+                    txdata = self.nodes[node].getrawtransaction(txid)
+                    tx_file.write(txdata+"\n")
+            tx_file.close()
+
+            stop_nodes(self.nodes)
+            wait_bitcoinds()
+            self.nodes = []
+            for i in range(4):
+                os.remove(log_filename(CACHE_DIR, i, "debug.log"))
+                os.remove(log_filename(CACHE_DIR, i, "db.log"))
+                os.remove(log_filename(CACHE_DIR, i, "peers.dat"))
+                os.remove(log_filename(CACHE_DIR, i, "fee_estimates.dat"))
+
+        for i in range(4):
+            from_dir = os.path.join(CACHE_DIR, "node"+str(i))
+            to_dir = os.path.join(self.options.tmpdir,  "node"+str(i))
+            shutil.copytree(from_dir, to_dir)
+            initialize_datadir(self.options.tmpdir, i) # Overwrite port/rpcport in bitcoin.conf
+
+    def sync_blocks(self, rpc_connections, wait=1, max_wait=30):
+        """
+        Wait until everybody has the same block count
+        """
+        for i in range(0,max_wait):
+            if i > 0: time.sleep(wait)
+            counts = [ x.getblockcount() for x in rpc_connections ]
+            if counts == [ counts[0] ]*len(counts):
+                return True
+        return False
+
+    def setup_network(self):
+        self.nodes = []
+
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-blockmaxsize=8000000", "-maxblocksizevote=8"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-blockmaxsize=1000", "-maxblocksizevote=8"]))
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-blockmaxsize=1000", "-maxblocksizevote=2"]))
+        self.nodes.append(start_node(3, self.options.tmpdir, ["-blockmaxsize=1000", "-maxblocksizevote=1"]))
+        connect_nodes_bi(self.nodes, 0, 1)
+        connect_nodes_bi(self.nodes, 1, 2)
+        connect_nodes_bi(self.nodes, 2, 3)
+        connect_nodes_bi(self.nodes, 3, 0)
+
+        # Populate node0's mempool with cached pre-created transactions:
+        with open(os.path.join(CACHE_DIR, "txdata"), "r") as f:
+            for line in f:
+                self.nodes[0].sendrawtransaction(line.rstrip())
+
+    def copy_mempool(self, from_node, to_node):
+        txids = from_node.getrawmempool()
+        for txid in txids:
+            txdata = from_node.getrawtransaction(txid)
+            to_node.sendrawtransaction(txdata)
+
+    def TestMineBig(self, expect_big):
+        # Test if node0 will mine a block bigger than legacy MAX_BLOCK_SIZE
+        b1hash = self.nodes[0].generate(1)[0]
+        b1 = self.nodes[0].getblock(b1hash, True)
+        assert(self.sync_blocks(self.nodes))
+
+        if expect_big:
+            assert(b1['size'] > 1000*1000)
+
+            # Have node1 mine on top of the block,
+            # to make sure it goes along with the fork
+            b2hash = self.nodes[1].generate(1)[0]
+            b2 = self.nodes[1].getblock(b2hash, True)
+            assert(b2['previousblockhash'] == b1hash)
+            assert(self.sync_blocks(self.nodes))
+
+        else:
+            assert(b1['size'] < 1000*1000)
+
+        # Reset chain to before b1hash:
+        for node in self.nodes:
+            node.invalidateblock(b1hash)
+        assert(self.sync_blocks(self.nodes))
+
+
+    def run_test(self):
+        # nodes 0 and 1 have mature 50-BTC coinbase transactions.
+        # Spend them with 50 transactions, each that has
+        # 1,200 outputs (so they're about 41K big).
+
+        print("Testing consensus blocksize increase conditions")
+
+        assert_equal(self.nodes[0].getblockcount(), 2011) # This is a 0-based height
+
+        # Current nMaxBlockSize is still 1MB
+        assert_equal(self.nodes[0].getblocktemplate()["sizelimit"], 1000000)
+        self.TestMineBig(False)
+
+        # Create a situation where the 1512th-highest vote is for 2MB
+        self.nodes[3].generate(1)
+        assert(self.sync_blocks(self.nodes[1:4]))
+        ahash = self.nodes[1].generate(3)[2]
+        assert_equal(self.nodes[1].getblocktemplate()["sizelimit"], int(1000000 * 1.05))
+        assert(self.sync_blocks(self.nodes[0:2]))
+        self.TestMineBig(True)
+
+        # Shutdown then restart node[0], it should produce a big block.
+        stop_node(self.nodes[0], 0)
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-blockmaxsize=8000000", "-maxblocksizevote=8"])
+        self.copy_mempool(self.nodes[1], self.nodes[0])
+        connect_nodes_bi(self.nodes, 0, 1)
+        connect_nodes_bi(self.nodes, 0, 3)
+        assert_equal(self.nodes[0].getblocktemplate()["sizelimit"], int(1000000 * 1.05))
+        self.TestMineBig(True)
+
+        # Test re-orgs past the sizechange block
+        stop_node(self.nodes[0], 0)
+        self.nodes[3].invalidateblock(ahash)
+        assert_equal(self.nodes[3].getblocktemplate()["sizelimit"], 1000000)
+        self.nodes[3].generate(2)
+        assert_equal(self.nodes[3].getblocktemplate()["sizelimit"], 1000000)
+        assert(self.sync_blocks(self.nodes[1:]))
+
+        # Restart node0, it should re-org onto longer chain,
+        # and refuse to mine a big block:
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-blockmaxsize=8000000", "-maxblocksizevote=8"])
+        self.copy_mempool(self.nodes[1], self.nodes[0])
+        connect_nodes_bi(self.nodes, 0, 1)
+        connect_nodes_bi(self.nodes, 0, 3)
+        assert(self.sync_blocks(self.nodes))
+        assert_equal(self.nodes[0].getblocktemplate()["sizelimit"], 1000000)
+        self.TestMineBig(False)
+
+        # Mine 4 blocks voting for 2MB. Bigger block NOT ok, we are in the next voting period
+        self.nodes[2].generate(4)
+        assert_equal(self.nodes[2].getblocktemplate()["sizelimit"], 1000000)
+        assert(self.sync_blocks(self.nodes[0:3]))
+        self.TestMineBig(False)
+
+
+        print("Cached test chain and transactions left in %s"%(CACHE_DIR))
+
+if __name__ == '__main__':
+    BigBlockTest().main()

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -118,6 +118,7 @@ BITCOIN_CORE_H = \
   leveldbwrapper.h \
   limitedmap.h \
   main.h \
+  maxblocksize.h \
   memusage.h \
   merkleblock.h \
   miner.h \
@@ -211,6 +212,7 @@ libbitcoin_server_a_SOURCES = \
   leakybucket.cpp \
   leveldbwrapper.cpp \
   main.cpp \
+  maxblocksize.cpp \
   merkleblock.cpp \
   miner.cpp \
   net.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -61,6 +61,7 @@ BITCOIN_TESTS =\
   test/ipgroups_tests.cpp \
   test/key_tests.cpp \
   test/main_tests.cpp \
+  test/maxblocksize_tests.cpp \
   test/mempool_tests.cpp \
   test/miner_tests.cpp \
   test/multisig_tests.cpp \

--- a/src/blockencodings.h
+++ b/src/blockencodings.h
@@ -163,6 +163,7 @@ public:
     }
 };
 
-void validateCompactBlock(const CompactBlock& cmpctblock);
+unsigned int minTxSize();
+void validateCompactBlock(const CompactBlock& cmpctblock, uint64_t currMaxBlockSize);
 
 #endif

--- a/src/chain.h
+++ b/src/chain.h
@@ -14,6 +14,9 @@
 
 #include <vector>
 
+static const int BIP100_DBI_VERSION = 0x08000000;
+static const int DISK_BLOCK_INDEX_VERSION = BIP100_DBI_VERSION;
+
 struct CDiskBlockPos
 {
     int nFile;
@@ -67,8 +70,8 @@ enum BlockStatus {
 
     /**
      * Only first tx is coinbase, 2 <= coinbase input script length <= 100, transactions valid, no duplicate txids,
-     * sigops, size, merkle root. Implies all parents are at least TREE but not necessarily TRANSACTIONS. When all
-     * parent blocks also have TRANSACTIONS, CBlockIndex::nChainTx will be set.
+     * merkle root. Implies all parents are at least TREE but not necessarily TRANSACTIONS. When all
+     * parent blocks also have TRANSACTIONS, CBlockIndex::nChainTx and maxblocksize will be set.
      */
     BLOCK_VALID_TRANSACTIONS =    3,
 
@@ -146,6 +149,15 @@ public:
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
     uint32_t nSequenceId;
 
+    //! Index entry serial format version
+    int nSerialVersion;
+
+    //! Maximum serialized block size at nHeight
+    uint64_t nMaxBlockSize;
+
+    //! This block's vote for future maximum serialized block size
+    uint64_t nMaxBlockSizeVote;
+
     void SetNull()
     {
         phashBlock = NULL;
@@ -160,6 +172,9 @@ public:
         nChainTx = 0;
         nStatus = 0;
         nSequenceId = 0;
+        nSerialVersion = 0;
+        nMaxBlockSize = 0;
+        nMaxBlockSizeVote = 0;
 
         nVersion       = 0;
         hashMerkleRoot = uint256();
@@ -292,6 +307,7 @@ public:
 
     explicit CDiskBlockIndex(const CBlockIndex* pindex) : CBlockIndex(*pindex) {
         hashPrev = (pprev ? pprev->GetBlockHash() : uint256());
+        nSerialVersion = DISK_BLOCK_INDEX_VERSION;
     }
 
     ADD_SERIALIZE_METHODS;
@@ -299,7 +315,7 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         if (!(nType & SER_GETHASH))
-            READWRITE(VARINT(nVersion));
+            READWRITE(VARINT(nSerialVersion));
 
         READWRITE(VARINT(nHeight));
         READWRITE(VARINT(nStatus));
@@ -318,6 +334,11 @@ public:
         READWRITE(nTime);
         READWRITE(nBits);
         READWRITE(nNonce);
+
+        if (nSerialVersion >= BIP100_DBI_VERSION) {
+            READWRITE(VARINT(nMaxBlockSize));
+            READWRITE(VARINT(nMaxBlockSizeVote));
+        }
     }
 
     uint256 GetBlockHash() const

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -91,6 +91,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1462060800; // May 1st, 2016
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1493596800; // May 1st, 2017
 
+        // BIP100 defined start height and max block size change critical vote position
+        consensus.bip100ActivationHeight = 449568;
+        consensus.nMaxBlockSizeChangePosition = 1512;
+
         /**
          * The message start string is designed to be unlikely to occur in normal data.
          * The characters are rarely used upper ASCII, not valid as UTF-8, and produce
@@ -183,6 +187,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1456790400; // March 1st, 2016
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1493596800; // May 1st, 2017
 
+        // BIP100 defined start height and max block size change critical vote position
+        consensus.bip100ActivationHeight = 798336;
+        consensus.nMaxBlockSizeChangePosition = 1512;
+
         pchMessageStart[0] = 0x0b;
         pchMessageStart[1] = 0x11;
         pchMessageStart[2] = 0x09;
@@ -254,6 +262,9 @@ public:
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
+
+        consensus.bip100ActivationHeight = 0;
+        consensus.nMaxBlockSizeChangePosition = 1512;
 
         pchMessageStart[0] = 0xfa;
         pchMessageStart[1] = 0xbf;

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -9,6 +9,8 @@
 
 #include <string>
 #include <boost/version.hpp>
+#include <iomanip>
+#include <cmath>
 
 #if BOOST_VERSION >= 105500 // Boost 1.55 or newer
 #include <boost/predef.h>
@@ -150,7 +152,7 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const 
 /**
  * The default Bitcoin XT subversion field according to BIP 14 spec
  */
-std::string XTSubVersion()
+std::string XTSubVersion(uint64_t nMaxBlockSize)
 {
     std::vector<std::string> comments = Opt().UAComment();
 
@@ -161,6 +163,12 @@ std::string XTSubVersion()
         std::vector<std::string> p = GetPlatformDetails();
         comments.insert(comments.end(), p.begin(), p.end());
     }
+
+    // Announce our excessive block acceptence.
+    std::stringstream ss;
+    double dMaxBlockSize = double(nMaxBlockSize)/1000000;
+    ss << "EB" << std::setprecision(int(log10(dMaxBlockSize))+7) << dMaxBlockSize;
+    comments.insert(end(comments), ss.str());
 
     return FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, comments, CLIENT_VERSION_XT_SUBVER);
 }

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -65,7 +65,7 @@ extern const std::string CLIENT_DATE;
 std::string FormatFullVersion();
 std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments, const char *releaseCharacter = "");
 
-std::string XTSubVersion();
+std::string XTSubVersion(uint64_t nMaxBlockSize);
 
 #endif // WINDRES_PREPROC
 

--- a/src/compactblockprocessor.cpp
+++ b/src/compactblockprocessor.cpp
@@ -9,7 +9,8 @@
 #include "consensus/validation.h"
 #include "compacttxfinder.h"
 
-void CompactBlockProcessor::operator()(CDataStream& vRecv, const CTxMemPool& mempool)
+void CompactBlockProcessor::operator()(CDataStream& vRecv, const CTxMemPool& mempool,
+        uint64_t currMaxBlockSize)
 {
     CompactBlock block;
     vRecv >> block;
@@ -20,7 +21,7 @@ void CompactBlockProcessor::operator()(CDataStream& vRecv, const CTxMemPool& mem
             hash.ToString(), worker.nodeID());
 
     try {
-        validateCompactBlock(block);
+        validateCompactBlock(block, currMaxBlockSize);
     }
     catch (const std::exception& e) {
         LogPrint("thin", "Invalid compact block %s\n", e.what());

--- a/src/compactblockprocessor.h
+++ b/src/compactblockprocessor.h
@@ -14,7 +14,8 @@ class CompactBlockProcessor : public BlockProcessor {
         {
         }
 
-        void operator()(CDataStream& vRecv, const CTxMemPool& mempool);
+        void operator()(CDataStream& vRecv, const CTxMemPool& mempool,
+                uint64_t currMaxBlockSize);
 };
 
 #endif

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -6,10 +6,16 @@
 #ifndef BITCOIN_CONSENSUS_CONSENSUS_H
 #define BITCOIN_CONSENSUS_CONSENSUS_H
 
-/** The maximum allowed size for a serialized block, in bytes (network rule) */
+#include <stdint.h>
+
+/** Legacy maximum block size */
 static const unsigned int MAX_BLOCK_SIZE = 1000000;
+/** The maximum allowed size for a serialized transaction, in bytes */
+static const unsigned int MAX_TRANSACTION_SIZE = 1000*1000;
 /** The maximum allowed number of signature check operations in a block (network rule) */
-static const unsigned int MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE/50;
+inline uint64_t MaxBlockSigops(uint64_t nMaxBlockSize) {
+    return ((nMaxBlockSize - 1) / 1000000 + 1) * 1000000 / 50;
+}
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
 static const int COINBASE_MATURITY = 100;
 

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -13,8 +13,8 @@ static const unsigned int MAX_BLOCK_SIZE = 1000000;
 /** The maximum allowed size for a serialized transaction, in bytes */
 static const unsigned int MAX_TRANSACTION_SIZE = 1000*1000;
 /** The maximum allowed number of signature check operations in a block (network rule) */
-inline uint64_t MaxBlockSigops(uint64_t nMaxBlockSize) {
-    return ((nMaxBlockSize - 1) / 1000000 + 1) * 1000000 / 50;
+inline uint64_t MaxBlockSigops(uint64_t nBlockSize) {
+    return ((nBlockSize - 1) / 1000000 + 1) * 1000000 / 50;
 }
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
 static const int COINBASE_MATURITY = 100;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -52,6 +52,13 @@ struct Params {
     uint32_t nRuleChangeActivationThreshold;
     uint32_t nMinerConfirmationWindow;
     BIP9Deployment vDeployments[MAX_VERSION_BITS_DEPLOYMENTS];
+    /**
+     * BIP100: One-based position from beginning (end) of the ascending sorted list of max block size
+     * votes in a retarget interval, at which the possible new lower (higher) max block size is read.
+     * 1512 = 75th percentile of 2016
+     */
+    int bip100ActivationHeight;
+    uint32_t nMaxBlockSizeChangePosition;
     /** Proof of work parameters */
     uint256 powLimit;
     bool fPowAllowMinDifficultyBlocks;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1001,11 +1001,12 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         return InitError(e.what());
     }
 
-    if (XTSubVersion().size() > MAX_SUBVERSION_LENGTH)
+    uint64_t hugeBlock = 1000 * MAX_BLOCK_SIZE;
+    if (XTSubVersion(hugeBlock).size() > MAX_SUBVERSION_LENGTH)
         return InitError(strprintf(
             "Total length of network version string %i exceeds maximum of %i characters. "
             "Reduce size of uacomment or hide platform details.",
-            XTSubVersion().size(), MAX_SUBVERSION_LENGTH));
+            XTSubVersion(hugeBlock).size(), MAX_SUBVERSION_LENGTH));
 
     if (mapArgs.count("-onlynet")) {
         std::set<enum Network> nets;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5435,7 +5435,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
             DefaultHeaderProcessor headerp(pfrom, blocksInFlight, thinblockmg,
                     inFlight, CheckBlockIndex);
             CompactBlockProcessor blockp(*pfrom, *(nodestate->thinblock), headerp);
-            blockp(vRecv, mempool);
+            blockp(vRecv, mempool, chainActive.Tip()->nMaxBlockSize);
         }
         catch (...) {
             LogPrintf("Unexpected error receiving cmpctblock from %d\n", pfrom->id);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@
 #include "consensus/validation.h"
 #include "inflightindex.h"
 #include "init.h"
+#include "maxblocksize.h"
 #include "merkleblock.h"
 #include "net.h"
 #include "nodestate.h"
@@ -1105,7 +1106,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state)
         return state.DoS(10, error("CheckTransaction(): vout empty"),
                          REJECT_INVALID, "bad-txns-vout-empty");
     // Size limits
-    if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION) > MAX_BLOCK_SIZE)
+    if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION) > MAX_TRANSACTION_SIZE)
         return state.DoS(100, error("CheckTransaction(): size limits failed"),
                          REJECT_INVALID, "bad-txns-oversize");
 
@@ -1344,7 +1345,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         // Check that the transaction doesn't have an excessive number of
         // sigops, making it impossible to mine. Since the coinbase transaction
         // itself can contain sigops MAX_STANDARD_TX_SIGOPS is less than
-        // MAX_BLOCK_SIGOPS; we still consider this an invalid rather than
+        // MaxBlockSigops(), we still consider this an invalid rather than
         // merely non-standard transaction.
         unsigned int nSigOps = GetLegacySigOpCount(tx);
         nSigOps += GetP2SHSigOpCount(tx, view);
@@ -2289,6 +2290,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         return true;
     }
 
+    // Block size limit (BIP100)
+    if (block.vtx.size() > pindex->nMaxBlockSize || ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION) > pindex->nMaxBlockSize)
+        return state.DoS(100, error("%s: size limits failed", __func__), REJECT_INVALID, "bad-blk-length");
+
     const int64_t timeBarrier = GetTime() - 24 * 3600 * Opt().CheckpointDays();
     // Blocks that have varius days of POW behind them makes them secure in
     // that actually online nodes checked the scripts, so during initial sync we
@@ -2376,7 +2381,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
         nInputs += tx.vin.size();
         nSigOps += GetLegacySigOpCount(tx);
-        if (nSigOps > MAX_BLOCK_SIGOPS)
+        if (nSigOps > MaxBlockSigops(pindex->nMaxBlockSize))
             return state.DoS(100, error("ConnectBlock(): too many sigops"),
                              REJECT_INVALID, "bad-blk-sigops");
 
@@ -2405,7 +2410,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 // this is to prevent a "rogue miner" from creating
                 // an incredibly-expensive-to-validate block.
                 nSigOps += GetP2SHSigOpCount(tx, view);
-                if (nSigOps > MAX_BLOCK_SIGOPS)
+                if (nSigOps > MaxBlockSigops(pindex->nMaxBlockSize))
                     return state.DoS(100, error("ConnectBlock(): too many sigops"),
                                      REJECT_INVALID, "bad-blk-sigops");
             }
@@ -3109,6 +3114,7 @@ bool ReceivedBlockTransactions(const CBlock &block, CValidationState& state, CBl
     pindexNew->nFile = pos.nFile;
     pindexNew->nDataPos = pos.nPos;
     pindexNew->nUndoPos = 0;
+    pindexNew->nMaxBlockSizeVote = GetMaxBlockSizeVote(block.vtx[0].vin[0].scriptSig, pindexNew->nHeight);
     pindexNew->nStatus |= BLOCK_HAVE_DATA;
     pindexNew->RaiseValidity(BLOCK_VALID_TRANSACTIONS);
     setDirtyBlockIndex.insert(pindexNew);
@@ -3127,6 +3133,7 @@ bool ReceivedBlockTransactions(const CBlock &block, CValidationState& state, CBl
                 LOCK(cs_nBlockSequenceId);
                 pindex->nSequenceId = nBlockSequenceId++;
             }
+            pindex->nMaxBlockSize = GetNextMaxBlockSize(pindex->pprev, Params().GetConsensus());
             if (chainActive.Tip() == NULL || !setBlockIndexCandidates.value_comp()(pindex, chainActive.Tip())) {
                 setBlockIndexCandidates.insert(pindex);
             }
@@ -3157,7 +3164,7 @@ bool FindBlockPos(CValidationState &state, CDiskBlockPos &pos, unsigned int nAdd
     }
 
     if (!fKnown) {
-        while (vinfoBlockFile[nFile].nSize + nAddSize >= MAX_BLOCKFILE_SIZE) {
+        while (vinfoBlockFile[nFile].nSize + nAddSize >= GetNextMaxBlockSize(chainActive.Tip(), Params().GetConsensus()) * MIN_BLOCKFILE_BLOCKS) {
             LogPrintf("Leaving block file %i: %s\n", nFile, vinfoBlockFile[nFile].ToString());
             FlushBlockFile(true);
             nFile++;
@@ -3275,9 +3282,8 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
     // because we receive the wrong transactions for it.
 
     // Size limits
-    if (block.vtx.empty() || block.vtx.size() > MAX_BLOCK_SIZE || ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION) > MAX_BLOCK_SIZE)
-        return state.DoS(100, error("CheckBlock(): size limits failed"),
-                         REJECT_INVALID, "bad-blk-length");
+    if (block.vtx.empty())
+        return state.DoS(100, error("CheckBlock(): no transactions"), REJECT_INVALID, "bad-blk-length");
 
     // First transaction must be coinbase, the rest must not be
     if (block.vtx.empty() || !block.vtx[0].IsCoinBase())
@@ -3292,15 +3298,6 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
     BOOST_FOREACH(const CTransaction& tx, block.vtx)
         if (!CheckTransaction(tx, state))
             return error("CheckBlock(): CheckTransaction failed");
-
-    unsigned int nSigOps = 0;
-    BOOST_FOREACH(const CTransaction& tx, block.vtx)
-    {
-        nSigOps += GetLegacySigOpCount(tx);
-    }
-    if (nSigOps > MAX_BLOCK_SIGOPS)
-        return state.DoS(100, error("CheckBlock(): out-of-bounds SigOpCount"),
-                         REJECT_INVALID, "bad-blk-sigops", true);
 
     return true;
 }
@@ -3548,6 +3545,7 @@ bool TestBlockValidity(CValidationState &state, const CBlock& block, CBlockIndex
     CBlockIndex indexDummy(block);
     indexDummy.pprev = pindexPrev;
     indexDummy.nHeight = pindexPrev->nHeight + 1;
+    indexDummy.nMaxBlockSize = GetNextMaxBlockSize(pindexPrev, Params().GetConsensus());
 
     // NOTE: CheckBlockHeader is called by CheckBlock
     if (!ContextualCheckBlockHeader(block, state, pindexPrev))
@@ -3735,7 +3733,7 @@ CBlockIndex * InsertBlockIndex(uint256 hash)
     return pindexNew;
 }
 
-bool static LoadBlockIndexDB()
+bool static LoadBlockIndexDB(bool* fRebuildRequired)
 {
     const CChainParams& chainparams = Params();
     if (!pblocktree->LoadBlockIndexGuts())
@@ -3752,8 +3750,10 @@ bool static LoadBlockIndexDB()
         vSortedByHeight.push_back(make_pair(pindex->nHeight, pindex));
     }
     sort(vSortedByHeight.begin(), vSortedByHeight.end());
-    BOOST_FOREACH(const PAIRTYPE(int, CBlockIndex*)& item, vSortedByHeight)
+    vector<pair<int, CBlockIndex*>>::iterator firstBIP100Entry = vSortedByHeight.end();
+    for (vector<pair<int, CBlockIndex*>>::iterator iter = vSortedByHeight.begin(); iter != vSortedByHeight.end(); iter++)
     {
+        const PAIRTYPE(int, CBlockIndex*)& item = *iter;
         CBlockIndex* pindex = item.second;
         pindex->nChainWork = (pindex->pprev ? pindex->pprev->nChainWork : 0) + GetBlockProof(*pindex);
         // We can link the chain of blocks for which we've received transactions at some point.
@@ -3778,6 +3778,11 @@ bool static LoadBlockIndexDB()
             pindex->BuildSkip();
         if (pindex->IsValid(BLOCK_VALID_TREE) && (pindexBestHeader == NULL || CBlockIndexWorkComparator()(pindexBestHeader, pindex)))
             pindexBestHeader = pindex;
+        if (item.first < chainparams.GetConsensus().bip100ActivationHeight) {
+            pindex->nMaxBlockSize = MAX_BLOCK_SIZE;
+        } else if (firstBIP100Entry == vSortedByHeight.end()) {
+            firstBIP100Entry = iter;
+        }
     }
 
     // Load block file info
@@ -3824,6 +3829,35 @@ bool static LoadBlockIndexDB()
     bool fReindexing = false;
     pblocktree->ReadReindexing(fReindexing);
     fReindex |= fReindexing;
+
+    // Set max block size variables in any remaining pre-BIP100 index entries
+    bool fUpdatedEntries = false;
+    for (vector<pair<int, CBlockIndex*>>::iterator iter = firstBIP100Entry; iter != vSortedByHeight.end(); iter++) {
+        const PAIRTYPE(int, CBlockIndex*)& item = *iter;
+        CBlockIndex* pindex = item.second;
+        if (pindex->nSerialVersion < BIP100_DBI_VERSION) {
+            if (!fUpdatedEntries) {
+                uiInterface.InitMessage(_("Updating block index for BIP100..."));
+                fUpdatedEntries = true;
+            }
+            pindex->nSerialVersion = DISK_BLOCK_INDEX_VERSION;
+            if (pindex->nChainTx) {
+                CBlock block;
+                if (ReadBlockFromDisk(block, pindex)) {
+                    pindex->nMaxBlockSizeVote = GetMaxBlockSizeVote(block.vtx[0].vin[0].scriptSig, pindex->nHeight);
+                    pindex->nMaxBlockSize = GetNextMaxBlockSize(pindex->pprev, chainparams.GetConsensus());
+                } else {
+                    // Error: Can't reconstruct vote. Rebuild required.
+                    // This can happen if the blocks were pruned after BIP100
+                    // activation with pre-BIP100 software.
+                    *fRebuildRequired = true;
+                    return false;
+                }
+            }
+            LogPrint("reindex", "%s: Updating block index entry at height %d for BIP100\n", __func__, pindex->nHeight);
+            setDirtyBlockIndex.insert(pindex);
+        }
+    }
 
     // Check whether we have a transaction index
     pblocktree->ReadFlag("txindex", fTxIndex);
@@ -3968,10 +4002,11 @@ void UnloadBlockIndex()
     fHavePruned = false;
 }
 
-bool LoadBlockIndex()
+bool LoadBlockIndex(bool* fRebuildRequired)
 {
+    assert(fRebuildRequired != NULL);
     // Load block index from databases
-    if (!fReindex && !LoadBlockIndexDB())
+    if (!fReindex && !LoadBlockIndexDB(fRebuildRequired))
         return false;
     return true;
 }
@@ -4051,7 +4086,7 @@ bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos *dbp)
                     continue;
                 // read size
                 blkdat >> nSize;
-                if (nSize < 80 || nSize > MAX_BLOCK_SIZE)
+                if (nSize < 80)
                     continue;
             } catch (const std::exception&) {
                 // no valid block header found; don't complain
@@ -4374,12 +4409,13 @@ static std::map<std::string, size_t> maxMessageSizes = boost::assign::map_list_o
 bool static SanityCheckMessage(CNode* peer, const CNetMessage& msg)
 {
     const std::string& strCommand = msg.hdr.GetCommand();
-    if (msg.hdr.nMessageSize > MAX_PROTOCOL_MESSAGE_LENGTH ||
+    uint64_t nMaxMessageSize = GetMaxBlockSize() * 105 / 100;
+    if (msg.hdr.nMessageSize > nMaxMessageSize ||
         (maxMessageSizes.count(strCommand) && msg.hdr.nMessageSize > maxMessageSizes[strCommand])) {
         LogPrint("net", "Oversized %s message from peer=%i (%d bytes)\n",
                  SanitizeString(strCommand), peer->GetId(), msg.hdr.nMessageSize);
         Misbehaving(peer->GetId(), 20);
-        return msg.hdr.nMessageSize <= MAX_PROTOCOL_MESSAGE_LENGTH;
+        return msg.hdr.nMessageSize <= nMaxMessageSize;
     }
     // This would be a good place for more sophisticated DoS detection/prevention.
     // (e.g. disconnect a peer that is flooding us with excessive messages)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1630,8 +1630,12 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
     return nSubsidy;
 }
 
+bool fForceInitialBlockDownload = false;
 bool IsInitialBlockDownload()
 {
+    if (fForceInitialBlockDownload)
+        return false;
+
     const CChainParams& chainParams = Params();
     LOCK(cs_main);
     if (fImporting || fReindex)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -256,6 +256,12 @@ int GetHeight()
     return chainActive.Height();
 }
 
+int GetMaxBlockSize()
+{
+    LOCK(cs_main);
+    return chainActive.Tip()->nMaxBlockSize;
+}
+
 void UpdatePreferredDownload(CNode* node, NodeStatePtr& state)
 {
     nPreferredDownload -= state->fPreferredDownload;
@@ -590,6 +596,7 @@ void RegisterNodeSignals(CNodeSignals& nodeSignals)
     nodeSignals.SendMessages.connect(&SendMessages);
     nodeSignals.InitializeNode.connect(&InitializeNode);
     nodeSignals.FinalizeNode.connect(&FinalizeNode);
+    nodeSignals.GetMaxBlockSize.connect(&GetMaxBlockSize);
 }
 
 void UnregisterNodeSignals(CNodeSignals& nodeSignals)
@@ -600,6 +607,7 @@ void UnregisterNodeSignals(CNodeSignals& nodeSignals)
     nodeSignals.SendMessages.disconnect(&SendMessages);
     nodeSignals.InitializeNode.disconnect(&InitializeNode);
     nodeSignals.FinalizeNode.disconnect(&FinalizeNode);
+    nodeSignals.GetMaxBlockSize.disconnect(&GetMaxBlockSize);
 }
 
 CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& locator)

--- a/src/main.h
+++ b/src/main.h
@@ -49,8 +49,6 @@ class CValidationState;
 struct CNodeStateStats;
 struct LockPoints;
 
-/** Default for -blockmaxsize, which controls the range of sizes the mining code will create **/
-static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
 /** Used only for relay rule that guesses at network miner policies **/
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000;
 /** The maximum size for transactions we're willing to relay/mine */
@@ -58,7 +56,7 @@ static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */
 static const unsigned int MAX_P2SH_SIGOPS = 15;
 /** The maximum number of sigops we're willing to relay/mine in a single tx */
-static const unsigned int MAX_STANDARD_TX_SIGOPS = MAX_BLOCK_SIGOPS/5;
+static const unsigned int MAX_STANDARD_TX_SIGOPS = 4000;
 /** Default for -maxorphantx, maximum number of orphan transactions kept in memory */
 static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 100;
 /** Default for -limitancestorcount, max number of in-mempool ancestors */
@@ -73,8 +71,8 @@ static const unsigned int DEFAULT_DESCENDANT_SIZE_LIMIT = 101;
 static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
 /** Default for -mempoolexpiry, expiration time for mempool transactions in hours */
 static const unsigned int DEFAULT_MEMPOOL_EXPIRY = 72;
-/** The maximum size of a blk?????.dat file (since 0.8) */
-static const unsigned int MAX_BLOCKFILE_SIZE = 0x8000000; // 128 MiB
+/** Minimum number of max-sized blocks in blk?????.dat files */
+static const unsigned int MIN_BLOCKFILE_BLOCKS = 128;
 /** The pre-allocation chunk size for blk?????.dat files (since 0.8) */
 static const unsigned int BLOCKFILE_CHUNK_SIZE = 0x1000000; // 16 MiB
 /** The pre-allocation chunk size for rev?????.dat files (since 0.8) */
@@ -97,8 +95,6 @@ static const unsigned int DATABASE_WRITE_INTERVAL = 60 * 60;
 static const unsigned int DATABASE_FLUSH_INTERVAL = 24 * 60 * 60;
 /** Maximum length of reject messages. */
 static const unsigned int MAX_REJECT_MESSAGE_LENGTH = 111;
-/** Maximum length of incoming protocol messages (no message over 2 MiB is currently acceptable). */
-static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 2 * 1024 * 1024;
 
 struct BlockHasher
 {
@@ -187,7 +183,7 @@ bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos *dbp = NULL);
 /** Initialize a new block tree database + block data on disk */
 bool InitBlockIndex();
 /** Load the block tree and coins database from disk */
-bool LoadBlockIndex();
+bool LoadBlockIndex(bool* fRebuildRequired);
 /** Unload database information */
 void UnloadBlockIndex();
 /** Process protocol messages received from a given node */

--- a/src/main.h
+++ b/src/main.h
@@ -202,6 +202,7 @@ void ThreadScriptCheck();
 /** Try to detect Partition (network isolation) attacks against us */
 int PartitionCheck(bool (*initialDownloadCheck)(), CCriticalSection& cs, const CBlockIndex *const &bestHeader, int64_t nPowTargetSpacing);
 /** Check whether we are doing an initial block download (synchronizing from disk or network) */
+extern bool fForceInitialBlockDownload;
 bool IsInitialBlockDownload();
 /** Format a string that describes several potential problems detected by the core */
 std::string GetWarnings(std::string strFor);

--- a/src/maxblocksize.cpp
+++ b/src/maxblocksize.cpp
@@ -61,7 +61,8 @@ uint64_t GetNextMaxBlockSize(const CBlockIndex* pindexLast, const Consensus::Par
 
 static uint32_t FindVote(const std::string& coinbase) {
 
-    uint32_t eb_vote = 0;
+    bool eb_vote = false;
+    uint32_t ebVoteMB = 0;
     std::vector<char> curr;
     bool bip100vote = false;
     bool started = false;
@@ -98,8 +99,9 @@ static uint32_t FindVote(const std::string& coinbase) {
             // Look for a EB vote. Keep it, but continue to look for a BIP100/B vote.
             if (!eb_vote && curr[0] == 'E' && curr[1] == 'B') {
                 try {
-                    eb_vote = boost::lexical_cast<uint32_t>(std::string(
+                    ebVoteMB = boost::lexical_cast<uint32_t>(std::string(
                                 begin(curr) + 2, end(curr)));
+                    eb_vote = true;
                 }
                 catch (const std::exception& e) {
                     LogPrintf("Invalid coinbase EB-vote: %s\n", e.what());
@@ -115,7 +117,7 @@ static uint32_t FindVote(const std::string& coinbase) {
         else
             curr.push_back(s);
     }
-    return eb_vote;
+    return ebVoteMB;
 }
 
 uint64_t GetMaxBlockSizeVote(const CScript &coinbase, int32_t nHeight)

--- a/src/maxblocksize.cpp
+++ b/src/maxblocksize.cpp
@@ -1,0 +1,137 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2017 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "maxblocksize.h"
+
+#include "chain.h"
+#include "util.h"
+#include <string>
+#include <boost/lexical_cast.hpp>
+
+uint64_t GetNextMaxBlockSize(const CBlockIndex* pindexLast, const Consensus::Params& params)
+{
+    // BIP100 not active, return legacy max size
+    if (pindexLast == NULL || pindexLast->nHeight < params.bip100ActivationHeight)
+        return MAX_BLOCK_SIZE;
+
+    uint64_t nMaxBlockSize = pindexLast->nMaxBlockSize;
+
+    // Only change once per difficulty adjustment interval
+    if ((pindexLast->nHeight+1) % params.DifficultyAdjustmentInterval() != 0) {
+        return nMaxBlockSize;
+    }
+
+    std::vector<uint64_t> votes;
+    const CBlockIndex *pindexWalk = pindexLast;
+    for (int64_t i = 0; i < params.DifficultyAdjustmentInterval(); i++) {
+        assert(pindexWalk);
+        assert(pindexWalk->nMaxBlockSize == nMaxBlockSize);
+        votes.push_back(pindexWalk->nMaxBlockSizeVote ? pindexWalk->nMaxBlockSizeVote : pindexWalk->nMaxBlockSize);
+        pindexWalk = pindexWalk->pprev;
+    }
+
+    std::sort(votes.begin(),votes.end());
+    uint64_t lowerValue = votes.at(params.nMaxBlockSizeChangePosition - 1);
+    uint64_t raiseValue = votes.at(params.DifficultyAdjustmentInterval() - params.nMaxBlockSizeChangePosition);
+
+    assert(lowerValue >= 1000000); // minimal vote supported is 1MB
+    assert(lowerValue >= raiseValue); // lowerValue comes from a higher sorted position
+
+    uint64_t raiseCap = nMaxBlockSize * 105 / 100;
+    raiseValue = (raiseValue > raiseCap ? raiseCap : raiseValue);
+    if (raiseValue > nMaxBlockSize) {
+        nMaxBlockSize = raiseValue;
+    } else {
+        uint64_t lowerFloor = nMaxBlockSize * 100 / 105;
+        lowerValue = (lowerValue < lowerFloor ? lowerFloor : lowerValue);
+        if (lowerValue < nMaxBlockSize)
+            nMaxBlockSize = lowerValue;
+    }
+
+    if (nMaxBlockSize != pindexLast->nMaxBlockSize) {
+        LogPrintf("GetNextMaxBlockSize RETARGET\n");
+        LogPrintf("Before: %d\n", pindexLast->nMaxBlockSize);
+        LogPrintf("After:  %d\n", nMaxBlockSize);
+    }
+
+    return nMaxBlockSize;
+}
+
+static uint32_t FindVote(const std::string& coinbase) {
+
+    uint32_t eb_vote = 0;
+    std::vector<char> curr;
+    bool bip100vote = false;
+    bool started = false;
+
+    for (char s : coinbase) {
+        if (s == '/') {
+            started = true;
+            // End (or beginning) of a potential vote string.
+
+            if (curr.size() < 2) // Minimum vote string length is 2
+            {
+                bip100vote = false;
+                curr.clear();
+                continue;
+            }
+
+            if (std::string(begin(curr), end(curr)) == "BIP100") {
+                bip100vote = true;
+                curr.clear();
+                continue;
+            }
+
+            // Look for a B vote.
+            if (bip100vote && curr[0] == 'B') {
+                try {
+                    return boost::lexical_cast<uint32_t>(std::string(
+                                begin(curr) + 1, end(curr)));
+                }
+                catch (const std::exception& e) {
+                    LogPrintf("Invalid coinbase B-vote: %s\n", e.what());
+                }
+            }
+
+            // Look for a EB vote. Keep it, but continue to look for a BIP100/B vote.
+            if (!eb_vote && curr[0] == 'E' && curr[1] == 'B') {
+                try {
+                    eb_vote = boost::lexical_cast<uint32_t>(std::string(
+                                begin(curr) + 2, end(curr)));
+                }
+                catch (const std::exception& e) {
+                    LogPrintf("Invalid coinbase EB-vote: %s\n", e.what());
+                }
+            }
+
+            bip100vote = false;
+            curr.clear();
+            continue;
+        }
+        else if (!started)
+            continue;
+        else
+            curr.push_back(s);
+    }
+    return eb_vote;
+}
+
+uint64_t GetMaxBlockSizeVote(const CScript &coinbase, int32_t nHeight)
+{
+    // Skip encoded height if found at start of coinbase
+    CScript expect = CScript() << nHeight;
+    int searchStart = coinbase.size() >= expect.size() &&
+                      std::equal(expect.begin(), expect.end(), coinbase.begin())
+                      ? expect.size()
+                      :0;
+
+    std::string s(coinbase.begin() + searchStart, coinbase.end());
+
+    if (s.length() < 5) // shortest vote is /EB1/
+        return 0;
+
+
+    return static_cast<uint64_t>(FindVote(s)) * 1000000;
+}

--- a/src/maxblocksize.h
+++ b/src/maxblocksize.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2017 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_MAXBLOCKSIZE_H
+#define BITCOIN_MAXBLOCKSIZE_H
+
+#include "consensus/consensus.h"
+#include "consensus/params.h"
+#include "script/script.h"
+
+#include <stdint.h>
+
+class CBlockHeader;
+class CBlockIndex;
+
+uint64_t GetNextMaxBlockSize(const CBlockIndex* pindexLast, const Consensus::Params&);
+
+uint64_t GetMaxBlockSizeVote(const CScript &coinbase, int32_t nHeight);
+
+#endif // BITCOIN_MAXBLOCKSIZE_H

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -57,7 +57,7 @@ void UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, 
 // BIP100 string:
 // - Adds our block size vote (B) if configured.
 // - Adds Excessive Block (EB) string. This announces how big blocks we currently accept.
-static std::vector<unsigned char> BIP100Str(uint64_t hardLimit) {
+std::vector<unsigned char> BIP100Str(uint64_t hardLimit) {
     uint64_t blockVote = Opt().MaxBlockSizeVote();
 
     std::stringstream ss;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -198,9 +198,11 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
             if (!IsFinalTx(tx, nHeight, nLockTimeCutoff))
                 continue;
 
+            // TODO: with more complexity we could make the block bigger when
+            // sigop-constrained and sigop density in later megabytes is low
             unsigned int nTxSigOps = iter->GetSigOpCount();
-            if (nBlockSigOps + nTxSigOps >= MaxBlockSigops(hardLimit)) {
-                if (nBlockSigOps > MaxBlockSigops(hardLimit) - 2) {
+            if (nBlockSigOps + nTxSigOps >= MaxBlockSigops(nBlockSize)) {
+                if (nBlockSigOps > MaxBlockSigops(nBlockSize) - 2) {
                     break;
                 }
                 continue;

--- a/src/miner.h
+++ b/src/miner.h
@@ -29,7 +29,7 @@ void GenerateBitcoins(bool fGenerate, CWallet* pwallet, int nThreads);
 CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn);
 CBlockTemplate* CreateNewBlockWithKey(CReserveKey& reservekey);
 /** Modify the extranonce in a block */
-void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce);
+void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce, uint64_t nMaxBlockSize);
 void UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);
 
 #endif // BITCOIN_MINER_H

--- a/src/miner.h
+++ b/src/miner.h
@@ -31,5 +31,5 @@ CBlockTemplate* CreateNewBlockWithKey(CReserveKey& reservekey);
 /** Modify the extranonce in a block */
 void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce, uint64_t nMaxBlockSize);
 void UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);
-
+std::vector<unsigned char> BIP100Str(uint64_t hardlimit);
 #endif // BITCOIN_MINER_H

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -440,10 +440,11 @@ void CNode::PushVersion()
             services = NODE_NETWORK;
 
         PushMessage("version", 70002, services, nTime, addrYou, addrMe,
-                nLocalHostNonce, XTSubVersion(), nBestHeight, true);
+                nLocalHostNonce, XTSubVersion(0), nBestHeight, true);
     } else {
+        int nMaxBlockSize = g_signals.GetMaxBlockSize().get_value_or(0);
         PushMessage("version", PROTOCOL_VERSION, nLocalServices, nTime, addrYou, addrMe,
-                nLocalHostNonce, XTSubVersion(), nBestHeight, true);
+                nLocalHostNonce, XTSubVersion(nMaxBlockSize), nBestHeight, true);
     }
 }
 

--- a/src/net.h
+++ b/src/net.h
@@ -113,6 +113,7 @@ struct CNodeSignals
     boost::signals2::signal<bool (CNode*, bool), CombinerAll> SendMessages;
     boost::signals2::signal<void (NodeId, const CNode*)> InitializeNode;
     boost::signals2::signal<void (NodeId)> FinalizeNode;
+    boost::signals2::signal<int ()> GetMaxBlockSize;
 };
 
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -69,6 +69,10 @@ int64_t Opt::CheckpointDays() {
     return std::max(int64_t(1), Args->GetArg("-checkpoint-days", def));
 }
 
+uint64_t Opt::MaxBlockSizeVote() {
+    return Args->GetArg("-maxblocksizevote", 0);
+}
+
 bool Opt::UsingThinBlocks() {
     if (IsStealthMode())
         return false;

--- a/src/options.h
+++ b/src/options.h
@@ -14,6 +14,7 @@ struct Opt {
     std::vector<std::string> UAComment(bool validate = false);
     int ScriptCheckThreads();
     int64_t CheckpointDays();
+    uint64_t MaxBlockSizeVote();
 
     // Thin block options
     bool UsingThinBlocks();

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -69,6 +69,8 @@ UniValue blockheaderToJSON(const CBlockIndex* blockindex)
     result.push_back(Pair("bits", strprintf("%08x", blockindex->nBits)));
     result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
     result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));
+    result.push_back(Pair("sizelimit", blockindex->nMaxBlockSize));
+    result.push_back(Pair("sizelimitvote", blockindex->nMaxBlockSizeVote));
 
     if (blockindex->pprev)
         result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));
@@ -111,6 +113,8 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     result.push_back(Pair("bits", strprintf("%08x", block.nBits)));
     result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
     result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));
+    result.push_back(Pair("sizelimit", blockindex->nMaxBlockSize));
+    result.push_back(Pair("sizelimitvote", blockindex->nMaxBlockSizeVote));
 
     if (blockindex->pprev)
         result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));
@@ -310,6 +314,9 @@ UniValue getblockheader(const UniValue& params, bool fHelp)
             "  \"nonce\" : n,           (numeric) The nonce\n"
             "  \"bits\" : \"1d00ffff\", (string) The bits\n"
             "  \"difficulty\" : x.xxx,  (numeric) The difficulty\n"
+            "  \"chainwork\" : \"0000...1f3\"     (string) Expected number of hashes required to produce the current chain (in hex)\n"
+            "  \"sizelimit\" : n,       (numeric) The block size limit as of this block\n"
+            "  \"sizelimitvote\" : n,   (numeric) This block's size limit vote\n"
             "  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n"
             "  \"nextblockhash\" : \"hash\"       (string) The hash of the next block\n"
             "}\n"
@@ -372,6 +379,9 @@ UniValue getblock(const UniValue& params, bool fHelp)
             "  \"nonce\" : n,           (numeric) The nonce\n"
             "  \"bits\" : \"1d00ffff\", (string) The bits\n"
             "  \"difficulty\" : x.xxx,  (numeric) The difficulty\n"
+            "  \"chainwork\" : \"0000...1f3\"     (string) Expected number of hashes required to produce the current chain (in hex)\n"
+            "  \"sizelimit\" : n,       (numeric) The block size limit as of this block\n"
+            "  \"sizelimitvote\" : n,   (numeric) This block's sizelimit vote\n"
             "  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n"
             "  \"nextblockhash\" : \"hash\"       (string) The hash of the next block\n"
             "}\n"
@@ -623,6 +633,8 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp)
             "  \"mediantime\": xxxxxx,     (numeric) median time for the current best block\n"
             "  \"verificationprogress\": xxxx, (numeric) estimate of verification progress [0..1]\n"
             "  \"chainwork\": \"xxxx\"     (string) total amount of work in active chain, in hexadecimal\n"
+            "  \"pruned\": xx,             (boolean) if the blocks are subject to pruning\n"
+            "  \"sizelimit\" : n,          (numeric) The block size limit as of the last block\n"
             "  \"softforks\": [            (array) status of softforks in progress\n"
             "     {\n"
             "        \"id\": \"xxxx\",        (string) name of softfork\n"
@@ -660,6 +672,7 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("verificationprogress",  Checkpoints::GuessVerificationProgress(Params().Checkpoints(), chainActive.Tip())));
     obj.push_back(Pair("chainwork",             chainActive.Tip()->nChainWork.GetHex()));
     obj.push_back(Pair("pruned",                fPruneMode));
+    obj.push_back(Pair("sizelimit",             chainActive.Tip()->nMaxBlockSize));
 
     const Consensus::Params& consensusParams = Params().GetConsensus();
     CBlockIndex* tip = chainActive.Tip();

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -240,6 +240,7 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
             "  \"pooledtx\": n              (numeric) The size of the mem pool\n"
             "  \"testnet\": true|false      (boolean) If using testnet or not\n"
             "  \"chain\": \"xxxx\",         (string) current network name as defined in BIP70 (main, test, regtest)\n"
+            "  \"sizelimit\" : n,           (numeric) The block size limit as of the last block\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("getmininginfo", "")
@@ -260,6 +261,7 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("pooledtx",         (uint64_t)mempool.size()));
     obj.push_back(Pair("testnet",          Params().TestnetToBeDeprecatedFieldRPC()));
     obj.push_back(Pair("chain",            Params().NetworkIDString()));
+    obj.push_back(Pair("sizelimit",        chainActive.Tip()->nMaxBlockSize));
 #ifdef ENABLE_WALLET
     obj.push_back(Pair("generate",         getgenerate(params, false)));
 #endif

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -553,12 +553,14 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
         int index_in_template = i - 1;
         entry.push_back(Pair("fee", pblocktemplate->vTxFees[index_in_template]));
         entry.push_back(Pair("sigops", pblocktemplate->vTxSigOps[index_in_template]));
-
         transactions.push_back(entry);
     }
 
+    uint64_t nMaxBlockSize = GetNextMaxBlockSize(chainActive.Tip(), Params().GetConsensus());
+    CScript flags = CScript() << BIP100Str(nMaxBlockSize);
+    flags +=  COINBASE_FLAGS;
     UniValue aux(UniValue::VOBJ);
-    aux.push_back(Pair("flags", HexStr(COINBASE_FLAGS.begin(), COINBASE_FLAGS.end())));
+    aux.push_back(Pair("flags", HexStr(flags.begin(), flags.end())));
 
     arith_uint256 hashTarget = arith_uint256().SetCompact(pblock->nBits);
 
@@ -570,7 +572,6 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
         aMutable.push_back("prevblock");
     }
 
-    uint64_t nMaxBlockSize = GetNextMaxBlockSize(chainActive.Tip(), Params().GetConsensus());
     UniValue result(UniValue::VOBJ);
     result.push_back(Pair("capabilities", aCaps));
     result.push_back(Pair("version", pblock->nVersion));

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -61,6 +61,7 @@ UniValue getinfo(const UniValue& params, bool fHelp)
             "  \"unlocked_until\": ttt,      (numeric) the timestamp in seconds since epoch (midnight Jan 1 1970 GMT) that the wallet is unlocked for transfers, or 0 if the wallet is locked\n"
             "  \"paytxfee\": x.xxxx,         (numeric) the transaction fee set in btc/kb\n"
             "  \"relayfee\": x.xxxx,         (numeric) minimum relay fee for non-free transactions in btc/kb\n"
+            "  \"sizelimit\" : n,            (numeric) The block size limit as of the last block\n"
             "  \"errors\": \"...\"           (string) any error messages\n"
             "}\n"
             "\nExamples:\n"
@@ -102,6 +103,7 @@ UniValue getinfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("paytxfee",      ValueFromAmount(payTxFee.GetFeePerK())));
 #endif
     obj.push_back(Pair("relayfee",      ValueFromAmount(::minRelayTxFee.GetFeePerK())));
+    obj.push_back(Pair("sizelimit",     chainActive.Tip()->nMaxBlockSize));
     obj.push_back(Pair("errors",        GetWarnings("statusbar")));
     return obj;
 }

--- a/src/test/ReceiveMsgBytes_tests.cpp
+++ b/src/test/ReceiveMsgBytes_tests.cpp
@@ -12,6 +12,7 @@
 #include "pow.h"
 #include "serialize.h"
 #include "util.h"
+#include "maxblocksize.h"
 
 #include "test/test_bitcoin.h"
 
@@ -78,7 +79,8 @@ BOOST_AUTO_TEST_CASE(TooLargeBlock)
     s << block;
 
     // Test: too large
-    s.resize(MAX_PROTOCOL_MESSAGE_LENGTH+headerLen+1);
+    size_t nMaxMessageSize = chainActive.Tip()->nMaxBlockSize * 105 / 100;
+    s.resize(nMaxMessageSize + headerLen + 1);
     CNetMessage::FinalizeHeader(s);
 
     BOOST_CHECK(!testNode.ReceiveMsgBytes(&s[0], s.size()));
@@ -86,7 +88,7 @@ BOOST_AUTO_TEST_CASE(TooLargeBlock)
     testNode.vRecvMsg.clear();
 
     // Test: exactly at max:
-    s.resize(MAX_PROTOCOL_MESSAGE_LENGTH+headerLen);
+    s.resize(nMaxMessageSize + headerLen);
     CNetMessage::FinalizeHeader(s);
 
     BOOST_CHECK(testNode.ReceiveMsgBytes(&s[0], s.size()));

--- a/src/test/maxblocksize_tests.cpp
+++ b/src/test/maxblocksize_tests.cpp
@@ -182,8 +182,14 @@ BOOST_AUTO_TEST_CASE(get_max_blocksize_vote_no_vote) {
 
     // missing BIP100 prefix
     BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << to_uchar("/B2/"), height));
-
     BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << to_uchar("/BIP100/B/B8/"), height));
+
+    //Explicit zeros and garbage
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << to_uchar("/BIP100/B0/BIP100/B2"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << to_uchar("/EB0/EB2/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << to_uchar("/BIP100/Bgarbage/B2/"), height));
+    BOOST_CHECK_EQUAL(2000000, GetMaxBlockSizeVote(CScript() << to_uchar("/EBgarbage/EB2/"), height));
+
 
     // Test that height is not a part of the vote string.
     // Encoded height in this test ends with /.

--- a/src/test/maxblocksize_tests.cpp
+++ b/src/test/maxblocksize_tests.cpp
@@ -1,0 +1,198 @@
+// Copyright (c) 2017 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <boost/test/unit_test.hpp>
+#include "maxblocksize.h"
+#include "chain.h"
+#include "chainparams.h"
+#include <algorithm>
+
+BOOST_AUTO_TEST_SUITE(maxblocksize_tests);
+
+void fillBlockIndex(
+        Consensus::Params& params, std::vector<CBlockIndex>& blockIndexes,
+        bool addVotes, int64_t currMax) {
+
+    int height = params.bip100ActivationHeight;
+    CBlockIndex* prev = nullptr;
+    for (CBlockIndex& index : blockIndexes)
+    {
+        index.nHeight = height++;
+        index.nMaxBlockSize = currMax;
+
+        if (addVotes)
+            index.nMaxBlockSizeVote = std::max(
+                (index.nHeight - params.bip100ActivationHeight) * 1000000, 1000000);
+
+        index.pprev = prev;
+        prev = &index;
+    }
+};
+
+BOOST_AUTO_TEST_CASE(get_next_max_blocksize) {
+    auto params = Params(CBaseChainParams::MAIN).GetConsensus();
+    BOOST_CHECK_EQUAL(1512, params.nMaxBlockSizeChangePosition);
+
+    // Genesis block, legacy block size
+    BOOST_CHECK_EQUAL(MAX_BLOCK_SIZE, GetNextMaxBlockSize(nullptr, params));
+
+    const int64_t interval = params.DifficultyAdjustmentInterval();
+
+    // Not at a difficulty adjustment interval,
+    // should not change max block size.
+    {
+        uint64_t currMax = 42 * 1000000;
+        std::vector<CBlockIndex> blockInterval(interval);
+        fillBlockIndex(params, blockInterval, true, currMax);
+        CBlockIndex index;
+
+        for (auto& b : blockInterval) {
+            if ((b.nHeight + 1) % interval == 0)
+                continue;
+            BOOST_CHECK_EQUAL(currMax,
+                GetNextMaxBlockSize(&b, params));
+
+        }
+    }
+
+    // No block voted. Keep current size.
+    {
+        uint64_t currMax = 2000000;
+        std::vector<CBlockIndex> blockInterval(interval);
+        fillBlockIndex(params, blockInterval, false, currMax);
+
+        BOOST_CHECK_EQUAL(currMax,
+                GetNextMaxBlockSize(&blockInterval.back(), params));
+    }
+
+    // Everyone votes current size. Keep current size.
+    {
+        uint64_t currMax = 2000000;
+        std::vector<CBlockIndex> blockInterval(interval);
+        fillBlockIndex(params, blockInterval, false, currMax);
+
+        for (CBlockIndex& b : blockInterval)
+            b.nMaxBlockSizeVote = currMax;
+
+        BOOST_CHECK_EQUAL(currMax,
+                GetNextMaxBlockSize(&blockInterval.back(), params));
+    }
+
+    // Everyone votes.
+    // Blocks vote (vote# * 1MB)
+    {
+        // Test raise.
+        uint64_t currMax = 2000000;
+        std::vector<CBlockIndex> blockInterval(interval);
+        fillBlockIndex(params, blockInterval, true, currMax);
+        uint64_t newLimit = GetNextMaxBlockSize(&blockInterval.back(), params);
+        BOOST_CHECK_EQUAL(int(currMax * 1.05), newLimit);
+
+        // Test lower.
+        currMax = 1000 * 2000000;
+        fillBlockIndex(params, blockInterval, true, currMax);
+        newLimit = GetNextMaxBlockSize(&blockInterval.back(), params);
+        BOOST_CHECK_EQUAL(int(currMax / 1.05), newLimit);
+    }
+}
+
+std::vector<unsigned char> to_uchar(const std::string& coinbaseStr) {
+    return std::vector<unsigned char>(begin(coinbaseStr), end(coinbaseStr));
+}
+
+// If we have an explicit /B/ vote, we read it and ignore /EB/.
+BOOST_AUTO_TEST_CASE(get_max_blocksize_vote_b) {
+
+    std::vector<unsigned char> vote(to_uchar("/BIP100/B2/EB1/"));
+    int32_t height = 600000;
+
+    // Coinbase as in the internal miner
+    CScript coinbase = CScript() << height << vote << OP_0;
+    BOOST_CHECK_EQUAL(2000000, GetMaxBlockSizeVote(coinbase, height));
+
+    // Coinbase as created with IncrementExtraNonce
+    unsigned int nonce = 1;
+    CScript coinbase_flags;
+    coinbase = (CScript() << height << vote << CScriptNum(nonce)) + coinbase_flags;
+    BOOST_CHECK_EQUAL(2000000, GetMaxBlockSizeVote(coinbase, height));
+
+    // coinbase without height should also work
+    coinbase = (CScript() << vote << CScriptNum(nonce)) + coinbase_flags;
+    BOOST_CHECK_EQUAL(2000000, GetMaxBlockSizeVote(coinbase, height));
+
+    // can't vote twice, only first one counts.
+    coinbase = (CScript() << to_uchar("/BIP100/B4/EB6/BIP100/B8/"));
+    BOOST_CHECK_EQUAL(4000000, GetMaxBlockSizeVote(coinbase, height));
+
+    // B-votes override EB, even though EB is first.
+    coinbase = (CScript() << to_uchar("/EB6/BIP100/B8/"));
+    BOOST_CHECK_EQUAL(8000000, GetMaxBlockSizeVote(coinbase, height));
+}
+
+// If /B/ is not present, we count /EB/ as a vote.
+BOOST_AUTO_TEST_CASE(get_max_blocksize_vote_eb) {
+    std::vector<unsigned char> vote(to_uchar("/some data/EB1/"));
+    int32_t height = 600000;
+
+    CScript coinbase = CScript() << height << vote << OP_0;
+    BOOST_CHECK_EQUAL(1000000, GetMaxBlockSizeVote(coinbase, height));
+
+    unsigned int nonce = 1;
+    CScript coinbase_flags;
+    coinbase = (CScript() << height << vote << CScriptNum(nonce)) + coinbase_flags;
+    BOOST_CHECK_EQUAL(1000000, GetMaxBlockSizeVote(coinbase, height));
+
+    // Example of a Bitcoin Unlimited coinbase string
+    coinbase = CScript() << height << to_uchar("/EB16/AD12/a miner comment");
+    BOOST_CHECK_EQUAL(16000000, GetMaxBlockSizeVote(coinbase, height));
+
+    // can't vote twice, only first one counts.
+    coinbase = (CScript() << to_uchar("some data/EB6/EB8/"));
+    BOOST_CHECK_EQUAL(6000000, GetMaxBlockSizeVote(coinbase, height));
+}
+
+BOOST_AUTO_TEST_CASE(get_max_blocksize_vote_no_vote) {
+    int32_t height = 600000;
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << OP_0, height));
+
+    // votes must begin and end with /
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/EB2"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("EB2/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/BIP100/B2"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("BIP100/B2/"), height));
+
+    // whitespace is not allowed
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/ EB2/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/EB2 /"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/EB 2/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/BIP100/B2 /"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/BIP100/ B2/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/BIP100/B 2/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/BIP100 /B2/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/ BIP100/B2/"), height));
+
+    // decimals not supported
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/EB2.2/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/BIP100/B2.2/"), height));
+
+    // missing mb value
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << to_uchar("/BIP100/B/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << to_uchar("/EB/"), height));
+
+    // missing BIP100 prefix
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << to_uchar("/B2/"), height));
+
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << to_uchar("/BIP100/B/B8/"), height));
+
+    // Test that height is not a part of the vote string.
+    // Encoded height in this test ends with /.
+    // Should not be interpreted as /BIP100/B8/
+    CScript coinbase = CScript() << 47;
+    BOOST_CHECK_EQUAL('/', coinbase.back());
+    std::vector<unsigned char> vote = to_uchar("BIP100/B8/");
+    coinbase.insert(coinbase.end(), vote.begin(), vote.end()); // insert instead of << to avoid size being prepended
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(coinbase, 47));
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -249,6 +249,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         next->pprev = prev;
         next->nHeight = prev->nHeight + 1;
         next->BuildSkip();
+        next->nMaxBlockSize = prev->nMaxBlockSize;
         chainActive.SetTip(next);
     }
     BOOST_CHECK(pblocktemplate = CreateNewBlock(scriptPubKey));
@@ -262,6 +263,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         next->pprev = prev;
         next->nHeight = prev->nHeight + 1;
         next->BuildSkip();
+        next->nMaxBlockSize = prev->nMaxBlockSize;
         chainActive.SetTip(next);
     }
     BOOST_CHECK(pblocktemplate = CreateNewBlock(scriptPubKey));

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -9,6 +9,7 @@
 #include "pubkey.h"
 #include "uint256.h"
 #include "util.h"
+#include "options.h"
 
 #include "test/test_bitcoin.h"
 
@@ -379,6 +380,40 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         delete tx;
 
     fCheckpointsEnabled = true;
+}
+
+std::string DefaultCoinbaseStr() {
+    CScript scriptPubKey = CScript() << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f") << OP_CHECKSIG;
+    std::unique_ptr<CBlockTemplate> tpl(CreateNewBlock(scriptPubKey));
+    CScript coinbase = tpl->block.vtx.at(0).vin.at(0).scriptSig;
+    return std::string(coinbase.begin(), coinbase.end());
+}
+
+BOOST_AUTO_TEST_CASE(CreateNewBlock_bip100str)
+{
+    LOCK(cs_main);
+
+    // No vote defined. Should only contain EB.
+    std::string c = DefaultCoinbaseStr();
+    BOOST_CHECK(c.find("/BIP100/EB1/") != std::string::npos);
+    BOOST_CHECK(c.find("/B1/") == std::string::npos);
+
+    // Vote for 16MB blocks (using -maxblocksizevote)
+    struct Dummy : public ArgGetter {
+        int64_t GetArg(const std::string& arg, int64_t def) override {
+            return arg == "-maxblocksizevote" ? 16 : def;
+        }
+
+        bool GetBool(const std::string&, bool def) override
+        { return def; }
+
+        std::vector<std::string> GetMultiArgs(const std::string&) override
+        { return { }; }
+    };
+    auto reset = SetDummyArgGetter(std::unique_ptr<ArgGetter>(new Dummy));
+
+    c = DefaultCoinbaseStr();
+    BOOST_CHECK(c.find("/BIP100/B16/EB1/") != std::string::npos);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -224,6 +224,9 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
                 pindexNew->nNonce         = diskindex.nNonce;
                 pindexNew->nStatus        = diskindex.nStatus;
                 pindexNew->nTx            = diskindex.nTx;
+                pindexNew->nSerialVersion = diskindex.nSerialVersion;
+                pindexNew->nMaxBlockSize  = diskindex.nMaxBlockSize;
+                pindexNew->nMaxBlockSizeVote = diskindex.nMaxBlockSizeVote;
 
                 if (!CheckProofOfWork(pindexNew->GetBlockHash(), pindexNew->nBits, Params().GetConsensus()))
                     return error("LoadBlockIndex(): CheckProofOfWork failed: %s", pindexNew->ToString());


### PR DESCRIPTION
These changes are for Bitcoin XT. For the Bitcoin Core version, see bitcoinxt/bitcoin#1.

Implementation of the [BIP100 specification](https://github.com/jgarzik/bip100/blob/master/bip-0100.mediawiki) as published.

Full nodes need no configuration to follow the network sizelimit as determined by BIP100.  Miners may set their coinbase /B vote using 

``-maxblocksizevote=<n> Set vote for maximum block size in megabytes (default: network sizelimit)``

Most RPC's return the sizelimit as of the current tip, consistent with the other attributes.  ``getblocktemplate`` returns the sizelimit for a block built on the current tip, which may change by a factor of up to 1.05 at the start of a difficulty interval, per the specification.

On first run, block index entries starting at the activation height (449568, which was in January 2017) are updated to track miner size votes and sizelimit history.  Use ``-debug=reindex`` (NOT ``-reindex``) to see the progress of this update.

The current network sizelimit is published in the user agent string as EB.

This implementation does not lift the 32MB physical MAX_SIZE limit.  File buffer sizes, sanity checks in bitcoin-tx, verifytxoutproof, and merkle blocks also continue to reference MAX_BLOCK_SIZE as a general scale indicator.
