### PR TITLE
rpc: Accept strings in AmountFromValue

### DIFF
--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -26,12 +26,10 @@ The HTTP request and response are both handled entirely in-memory, thus making m
 With the /notxdetails/ option JSON response will only contain the transaction hash instead of the complete transaction details. The option only affects the JSON response.
 
 ####Blockheaders
-`GET /rest/headers/<COUNT>/<BLOCK-HASH>.<bin|hex>`
+`GET /rest/headers/<COUNT>/<BLOCK-HASH>.<bin|hex|json>`
 
 Given a block hash,
 Returns <COUNT> amount of blockheaders in upward direction.
-
-JSON is not supported.
 
 ####Chaininfos
 `GET /rest/chaininfo.json`

--- a/qa/rpc-tests/rest.py
+++ b/qa/rpc-tests/rest.py
@@ -14,6 +14,7 @@ from struct import *
 import binascii
 import json
 import StringIO
+import decimal
 
 try:
     import http.client as httplib
@@ -243,7 +244,7 @@ class RESTTest (BitcoinTestFramework):
         response_header_json = http_get_call(url.hostname, url.port, '/rest/headers/1/'+bb_hash+self.FORMAT_SEPARATOR+"json", "", True)
         assert_equal(response_header_json.status, 200)
         response_header_json_str = response_header_json.read()
-        json_obj = json.loads(response_header_json_str)
+        json_obj = json.loads(response_header_json_str, parse_float=decimal.Decimal)
         assert_equal(len(json_obj), 1) #ensure that there is one header in the json response
         assert_equal(json_obj[0]['hash'], bb_hash) #request/response hash should be the same
 

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -65,6 +65,7 @@ public:
 extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry);
 extern UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDetails = false);
 extern void ScriptPubKeyToJSON(const CScript& scriptPubKey, UniValue& out, bool fIncludeHex);
+extern UniValue blockheaderToJSON(const CBlockIndex* blockindex);
 
 static RestErr RESTERR(enum HTTPStatusCode status, string message)
 {
@@ -134,14 +135,14 @@ static bool rest_headers(AcceptedConnection* conn,
     if (!ParseHashStr(hashStr, hash))
         throw RESTERR(HTTP_BAD_REQUEST, "Invalid hash: " + hashStr);
 
-    std::vector<CBlockHeader> headers;
+    std::vector<const CBlockIndex *> headers;
     headers.reserve(count);
     {
         LOCK(cs_main);
         BlockMap::const_iterator it = mapBlockIndex.find(hash);
         const CBlockIndex *pindex = (it != mapBlockIndex.end()) ? it->second : NULL;
         while (pindex != NULL && chainActive.Contains(pindex)) {
-            headers.push_back(pindex->GetBlockHeader());
+            headers.push_back(pindex);
             if (headers.size() == (unsigned long)count)
                 break;
             pindex = chainActive.Next(pindex);
@@ -149,8 +150,8 @@ static bool rest_headers(AcceptedConnection* conn,
     }
 
     CDataStream ssHeader(SER_NETWORK, PROTOCOL_VERSION);
-    BOOST_FOREACH(const CBlockHeader &header, headers) {
-        ssHeader << header;
+    BOOST_FOREACH(const CBlockIndex *pindex, headers) {
+        ssHeader << pindex->GetBlockHeader();
     }
 
     switch (rf) {
@@ -163,6 +164,16 @@ static bool rest_headers(AcceptedConnection* conn,
     case RF_HEX: {
         string strHex = HexStr(ssHeader.begin(), ssHeader.end()) + "\n";
         conn->stream() << HTTPReply(HTTP_OK, strHex, fRun, false, "text/plain") << std::flush;
+        return true;
+    }
+
+    case RF_JSON: {
+        UniValue jsonHeaders(UniValue::VARR);
+        BOOST_FOREACH(const CBlockIndex *pindex, headers) {
+            jsonHeaders.push_back(blockheaderToJSON(pindex));
+        }
+        string strJSON = jsonHeaders.write() + "\n";
+        conn->stream() << HTTPReply(HTTP_OK, strJSON, fRun) << std::flush;
         return true;
     }
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -78,7 +78,6 @@ UniValue blockheaderToJSON(const CBlockIndex* blockindex)
     return result;
 }
 
-
 UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDetails = false)
 {
     UniValue result(UniValue::VOBJ);
@@ -119,7 +118,6 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
         result.push_back(Pair("nextblockhash", pnext->GetBlockHash().GetHex()));
     return result;
 }
-
 
 UniValue getblockcount(const UniValue& params, bool fHelp)
 {

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -251,12 +251,12 @@ UniValue settrafficshaping(const UniValue& params, bool fHelp)
     {
         int burst;
         int ave;
-        if (params[1].isReal())
+        if (params[1].isNum())
             burst = params[1].get_int();
         else
             burst = boost::lexical_cast<int>(params[1].getValStr());
 
-        if (params[2].isReal())
+        if (params[2].isNum())
             ave = params[2].get_int();
         else
             ave = boost::lexical_cast<int>(params[2].getValStr());

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -120,8 +120,8 @@ void RPCTypeCheckObj(const UniValue& o,
 
 CAmount AmountFromValue(const UniValue& value)
 {
-    if (!value.isNum())
-        throw JSONRPCError(RPC_TYPE_ERROR, "Amount is not a number");
+    if (!value.isNum() && !value.isStr())
+        throw JSONRPCError(RPC_TYPE_ERROR, "Amount is not a number or string");
     CAmount amount;
     if (!ParseFixedPoint(value.getValStr(), 8, &amount))
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -11,6 +11,7 @@
 #include "sync.h"
 #include "ui_interface.h"
 #include "util.h"
+#include "utilmoneystr.h"
 #include "utilstrencodings.h"
 #ifdef ENABLE_WALLET
 #include "wallet/wallet.h"
@@ -118,25 +119,21 @@ void RPCTypeCheckObj(const UniValue& o,
     }
 }
 
-static inline int64_t roundint64(double d)
-{
-    return (int64_t)(d > 0 ? d + 0.5 : d - 0.5);
-}
-
 CAmount AmountFromValue(const UniValue& value)
 {
-    double dAmount = value.get_real();
-    if (dAmount <= 0.0 || dAmount > 21000000.0)
+    if (!value.isReal() && !value.isNum())
+        throw JSONRPCError(RPC_TYPE_ERROR, "Amount is not a number");
+    CAmount amount;
+    if (!ParseMoney(value.getValStr(), amount))
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
-    CAmount nAmount = roundint64(dAmount * COIN);
-    if (!MoneyRange(nAmount))
-        throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
-    return nAmount;
+    if (!MoneyRange(amount))
+        throw JSONRPCError(RPC_TYPE_ERROR, "Amount out of range");
+    return amount;
 }
 
 UniValue ValueFromAmount(const CAmount& amount)
 {
-    return (double)amount / (double)COIN;
+    return UniValue(UniValue::VREAL, FormatMoney(amount, false));
 }
 
 uint256 ParseHashV(const UniValue& v, string strName)

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -133,7 +133,7 @@ CAmount AmountFromValue(const UniValue& value)
 
 UniValue ValueFromAmount(const CAmount& amount)
 {
-    return UniValue(UniValue::VREAL, FormatMoney(amount, false));
+    return UniValue(UniValue::VREAL, FormatMoney(amount));
 }
 
 uint256 ParseHashV(const UniValue& v, string strName)

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -11,7 +11,6 @@
 #include "sync.h"
 #include "ui_interface.h"
 #include "util.h"
-#include "utilmoneystr.h"
 #include "utilstrencodings.h"
 #ifdef ENABLE_WALLET
 #include "wallet/wallet.h"
@@ -133,7 +132,12 @@ CAmount AmountFromValue(const UniValue& value)
 
 UniValue ValueFromAmount(const CAmount& amount)
 {
-    return UniValue(UniValue::VREAL, FormatMoney(amount));
+    bool sign = amount < 0;
+    int64_t n_abs = (sign ? -amount : amount);
+    int64_t quotient = n_abs / COIN;
+    int64_t remainder = n_abs % COIN;
+    return UniValue(UniValue::VNUM,
+            strprintf("%s%d.%08d", sign ? "-" : "", quotient, remainder));
 }
 
 uint256 ParseHashV(const UniValue& v, string strName)

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -120,7 +120,7 @@ void RPCTypeCheckObj(const UniValue& o,
 
 CAmount AmountFromValue(const UniValue& value)
 {
-    if (!value.isReal() && !value.isNum())
+    if (!value.isNum())
         throw JSONRPCError(RPC_TYPE_ERROR, "Amount is not a number");
     CAmount amount;
     if (!ParseFixedPoint(value.getValStr(), 8, &amount))

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -124,7 +124,7 @@ CAmount AmountFromValue(const UniValue& value)
     if (!value.isReal() && !value.isNum())
         throw JSONRPCError(RPC_TYPE_ERROR, "Amount is not a number");
     CAmount amount;
-    if (!ParseMoney(value.getValStr(), amount))
+    if (!ParseFixedPoint(value.getValStr(), 8, &amount))
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
     if (!MoneyRange(amount))
         throw JSONRPCError(RPC_TYPE_ERROR, "Amount out of range");

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -927,13 +927,6 @@ static bool HTTPReq_JSONRPC(AcceptedConnection *conn,
         if (!valRequest.read(strRequest))
             throw JSONRPCError(RPC_PARSE_ERROR, "Parse error");
 
-        // Return immediately if in warmup
-        {
-            LOCK(cs_rpcWarmup);
-            if (fRPCInWarmup)
-                throw JSONRPCError(RPC_IN_WARMUP, rpcWarmupStatus);
-        }
-
         string strReply;
 
         // singleton request
@@ -1005,6 +998,13 @@ void ServiceConnection(AcceptedConnection *conn)
 
 UniValue CRPCTable::execute(const std::string &strMethod, const UniValue &params) const
 {
+    // Return immediately if in warmup
+    {
+        LOCK(cs_rpcWarmup);
+        if (fRPCInWarmup)
+            throw JSONRPCError(RPC_IN_WARMUP, rpcWarmupStatus);
+    }
+
     // Find method
     const CRPCCommand *pcmd = tableRPC[strMethod];
     if (!pcmd)

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -131,6 +131,9 @@ static UniValue ValueFromString(const std::string &str)
 
 BOOST_AUTO_TEST_CASE(rpc_parse_monetary_values)
 {
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("-0.00000001")), UniValue);
+    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0")), 0LL);
+    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.00000000")), 0LL);
     BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.00000001")), 1LL);
     BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.17622195")), 17622195LL);
     BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.5")), 50000000LL);

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -120,6 +120,29 @@ BOOST_AUTO_TEST_CASE(rpc_format_monetary_values)
     BOOST_CHECK(ValueFromAmount(100000000LL).write() == "1.00000000");
     BOOST_CHECK(ValueFromAmount(2099999999999990LL).write() == "20999999.99999990");
     BOOST_CHECK(ValueFromAmount(2099999999999999LL).write() == "20999999.99999999");
+
+    BOOST_CHECK_EQUAL(ValueFromAmount(0).write(), "0.00000000");
+    BOOST_CHECK_EQUAL(ValueFromAmount((COIN/10000)*123456789).write(), "12345.67890000");
+    BOOST_CHECK_EQUAL(ValueFromAmount(-COIN).write(), "-1.00000000");
+    BOOST_CHECK_EQUAL(ValueFromAmount(-COIN/10).write(), "-0.10000000");
+
+    BOOST_CHECK_EQUAL(ValueFromAmount(COIN*100000000).write(), "100000000.00000000");
+    BOOST_CHECK_EQUAL(ValueFromAmount(COIN*10000000).write(), "10000000.00000000");
+    BOOST_CHECK_EQUAL(ValueFromAmount(COIN*1000000).write(), "1000000.00000000");
+    BOOST_CHECK_EQUAL(ValueFromAmount(COIN*100000).write(), "100000.00000000");
+    BOOST_CHECK_EQUAL(ValueFromAmount(COIN*10000).write(), "10000.00000000");
+    BOOST_CHECK_EQUAL(ValueFromAmount(COIN*1000).write(), "1000.00000000");
+    BOOST_CHECK_EQUAL(ValueFromAmount(COIN*100).write(), "100.00000000");
+    BOOST_CHECK_EQUAL(ValueFromAmount(COIN*10).write(), "10.00000000");
+    BOOST_CHECK_EQUAL(ValueFromAmount(COIN).write(), "1.00000000");
+    BOOST_CHECK_EQUAL(ValueFromAmount(COIN/10).write(), "0.10000000");
+    BOOST_CHECK_EQUAL(ValueFromAmount(COIN/100).write(), "0.01000000");
+    BOOST_CHECK_EQUAL(ValueFromAmount(COIN/1000).write(), "0.00100000");
+    BOOST_CHECK_EQUAL(ValueFromAmount(COIN/10000).write(), "0.00010000");
+    BOOST_CHECK_EQUAL(ValueFromAmount(COIN/100000).write(), "0.00001000");
+    BOOST_CHECK_EQUAL(ValueFromAmount(COIN/1000000).write(), "0.00000100");
+    BOOST_CHECK_EQUAL(ValueFromAmount(COIN/10000000).write(), "0.00000010");
+    BOOST_CHECK_EQUAL(ValueFromAmount(COIN/100000000).write(), "0.00000001");
 }
 
 static UniValue ValueFromString(const std::string &str)

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -142,6 +142,24 @@ BOOST_AUTO_TEST_CASE(rpc_parse_monetary_values)
     BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("1.00000000")), 100000000LL);
     BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("20999999.9999999")), 2099999999999990LL);
     BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("20999999.99999999")), 2099999999999999LL);
+
+    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("1e-8")), COIN/100000000);
+    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.1e-7")), COIN/100000000);
+    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.01e-6")), COIN/100000000);
+    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.0000000000000000000000000000000000000000000000000000000000000000000000000001e+68")), COIN/100000000);
+    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("10000000000000000000000000000000000000000000000000000000000000000e-64")), COIN);
+    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000e64")), COIN);
+
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("1e-9")), UniValue); //should fail
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("0.000000019")), UniValue); //should fail
+    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.00000001000000")), 1LL); //should pass, cut trailing 0
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("19e-9")), UniValue); //should fail
+    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.19e-6")), 19); //should pass, leading 0 is present
+
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("92233720368.54775808")), UniValue); //overflow error
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("1e+11")), UniValue); //overflow error
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("1e11")), UniValue); //overflow error signless
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("93e+9")), UniValue); //overflow error
 }
 
 BOOST_AUTO_TEST_CASE(json_parse_errors)
@@ -151,6 +169,9 @@ BOOST_AUTO_TEST_CASE(json_parse_errors)
     // Valid, with leading or trailing whitespace
     BOOST_CHECK_EQUAL(ParseNonRFCJSONValue(" 1.0").get_real(), 1.0);
     BOOST_CHECK_EQUAL(ParseNonRFCJSONValue("1.0 ").get_real(), 1.0);
+
+    BOOST_CHECK_THROW(AmountFromValue(ParseNonRFCJSONValue(".19e-6")), std::runtime_error); //should fail, missing leading 0, therefore invalid JSON
+    BOOST_CHECK_EQUAL(AmountFromValue(ParseNonRFCJSONValue("0.00000000000000000000000000000000000001e+30 ")), 1);
     // Invalid, initial garbage
     BOOST_CHECK_THROW(ParseNonRFCJSONValue("[1.0"), std::runtime_error);
     BOOST_CHECK_THROW(ParseNonRFCJSONValue("a1.0"), std::runtime_error);

--- a/src/test/univalue_tests.cpp
+++ b/src/test/univalue_tests.cpp
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(univalue_constructor)
 
     double vd = -7.21;
     UniValue v7(vd);
-    BOOST_CHECK(v7.isReal());
+    BOOST_CHECK(v7.isNum());
     BOOST_CHECK_EQUAL(v7.getValStr(), "-7.21");
 
     string vs("yawn");
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE(univalue_set)
     BOOST_CHECK_EQUAL(v.getValStr(), "zum");
 
     BOOST_CHECK(v.setFloat(-1.01));
-    BOOST_CHECK(v.isReal());
+    BOOST_CHECK(v.isNum());
     BOOST_CHECK_EQUAL(v.getValStr(), "-1.01");
 
     BOOST_CHECK(v.setInt((int)1023));
@@ -272,7 +272,7 @@ BOOST_AUTO_TEST_CASE(univalue_object)
     objTypes["distance"] = UniValue::VNUM;
     objTypes["time"] = UniValue::VNUM;
     objTypes["calories"] = UniValue::VNUM;
-    objTypes["temperature"] = UniValue::VREAL;
+    objTypes["temperature"] = UniValue::VNUM;
     objTypes["cat1"] = UniValue::VNUM;
     objTypes["cat2"] = UniValue::VNUM;
     BOOST_CHECK(obj.checkObject(objTypes));

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -146,29 +146,27 @@ BOOST_AUTO_TEST_CASE(util_GetArg)
 
 BOOST_AUTO_TEST_CASE(util_FormatMoney)
 {
-    BOOST_CHECK_EQUAL(FormatMoney(0, false), "0.00");
-    BOOST_CHECK_EQUAL(FormatMoney((COIN/10000)*123456789, false), "12345.6789");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN, true), "+1.00");
-    BOOST_CHECK_EQUAL(FormatMoney(-COIN, false), "-1.00");
-    BOOST_CHECK_EQUAL(FormatMoney(-COIN, true), "-1.00");
+    BOOST_CHECK_EQUAL(FormatMoney(0), "0.00");
+    BOOST_CHECK_EQUAL(FormatMoney((COIN/10000)*123456789), "12345.6789");
+    BOOST_CHECK_EQUAL(FormatMoney(-COIN), "-1.00");
 
-    BOOST_CHECK_EQUAL(FormatMoney(COIN*100000000, false), "100000000.00");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN*10000000, false), "10000000.00");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN*1000000, false), "1000000.00");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN*100000, false), "100000.00");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN*10000, false), "10000.00");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN*1000, false), "1000.00");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN*100, false), "100.00");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN*10, false), "10.00");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN, false), "1.00");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN/10, false), "0.10");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN/100, false), "0.01");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN/1000, false), "0.001");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN/10000, false), "0.0001");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN/100000, false), "0.00001");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN/1000000, false), "0.000001");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN/10000000, false), "0.0000001");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN/100000000, false), "0.00000001");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN*100000000), "100000000.00");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN*10000000), "10000000.00");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN*1000000), "1000000.00");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN*100000), "100000.00");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN*10000), "10000.00");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN*1000), "1000.00");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN*100), "100.00");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN*10), "10.00");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN), "1.00");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN/10), "0.10");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN/100), "0.01");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN/1000), "0.001");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN/10000), "0.0001");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN/100000), "0.00001");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN/1000000), "0.000001");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN/10000000), "0.0000001");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN/100000000), "0.00000001");
 }
 
 BOOST_AUTO_TEST_CASE(util_ParseMoney)

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -419,4 +419,70 @@ BOOST_AUTO_TEST_CASE(test_FormatSubVersion)
     BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments), std::string("/Test:0.9.99(comment1)/"));
     BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments2), std::string("/Test:0.9.99(comment1; comment2)/"));
 }
+
+BOOST_AUTO_TEST_CASE(test_ParseFixedPoint)
+{
+    int64_t amount = 0;
+    BOOST_CHECK(ParseFixedPoint("0", 8, &amount));
+    BOOST_CHECK_EQUAL(amount, 0LL);
+    BOOST_CHECK(ParseFixedPoint("1", 8, &amount));
+    BOOST_CHECK_EQUAL(amount, 100000000LL);
+    BOOST_CHECK(ParseFixedPoint("0.0", 8, &amount));
+    BOOST_CHECK_EQUAL(amount, 0LL);
+    BOOST_CHECK(ParseFixedPoint("-0.1", 8, &amount));
+    BOOST_CHECK_EQUAL(amount, -10000000LL);
+    BOOST_CHECK(ParseFixedPoint("1.1", 8, &amount));
+    BOOST_CHECK_EQUAL(amount, 110000000LL);
+    BOOST_CHECK(ParseFixedPoint("1.10000000000000000", 8, &amount));
+    BOOST_CHECK_EQUAL(amount, 110000000LL);
+    BOOST_CHECK(ParseFixedPoint("1.1e1", 8, &amount));
+    BOOST_CHECK_EQUAL(amount, 1100000000LL);
+    BOOST_CHECK(ParseFixedPoint("1.1e-1", 8, &amount));
+    BOOST_CHECK_EQUAL(amount, 11000000LL);
+    BOOST_CHECK(ParseFixedPoint("1000", 8, &amount));
+    BOOST_CHECK_EQUAL(amount, 100000000000LL);
+    BOOST_CHECK(ParseFixedPoint("-1000", 8, &amount));
+    BOOST_CHECK_EQUAL(amount, -100000000000LL);
+    BOOST_CHECK(ParseFixedPoint("0.00000001", 8, &amount));
+    BOOST_CHECK_EQUAL(amount, 1LL);
+    BOOST_CHECK(ParseFixedPoint("0.0000000100000000", 8, &amount));
+    BOOST_CHECK_EQUAL(amount, 1LL);
+    BOOST_CHECK(ParseFixedPoint("-0.00000001", 8, &amount));
+    BOOST_CHECK_EQUAL(amount, -1LL);
+    BOOST_CHECK(ParseFixedPoint("1000000000.00000001", 8, &amount));
+    BOOST_CHECK_EQUAL(amount, 100000000000000001LL);
+    BOOST_CHECK(ParseFixedPoint("9999999999.99999999", 8, &amount));
+    BOOST_CHECK_EQUAL(amount, 999999999999999999LL);
+    BOOST_CHECK(ParseFixedPoint("-9999999999.99999999", 8, &amount));
+    BOOST_CHECK_EQUAL(amount, -999999999999999999LL);
+
+    BOOST_CHECK(!ParseFixedPoint("", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint("-", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint("a-1000", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint("-a1000", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint("-1000a", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint("-01000", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint("00.1", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint(".1", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint("--0.1", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint("0.000000001", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint("-0.000000001", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint("0.00000001000000001", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint("-10000000000.00000000", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint("10000000000.00000000", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint("-10000000000.00000001", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint("10000000000.00000001", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint("-10000000000.00000009", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint("10000000000.00000009", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint("-99999999999.99999999", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint("99999909999.09999999", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint("92233720368.54775807", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint("92233720368.54775808", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint("-92233720368.54775808", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint("-92233720368.54775809", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint("1.1e", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint("1.1e-", 8, &amount));
+    BOOST_CHECK(!ParseFixedPoint("1.", 8, &amount));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/univalue/univalue.cpp
+++ b/src/univalue/univalue.cpp
@@ -86,7 +86,7 @@ bool UniValue::setFloat(double val)
     oss << std::setprecision(16) << val;
 
     bool ret = setNumStr(oss.str());
-    typ = VREAL;
+    typ = VNUM;
     return ret;
 }
 
@@ -210,7 +210,6 @@ const char *uvTypeName(UniValue::VType t)
     case UniValue::VARR: return "array";
     case UniValue::VSTR: return "string";
     case UniValue::VNUM: return "number";
-    case UniValue::VREAL: return "number";
     }
 
     // not reached
@@ -280,7 +279,7 @@ int64_t UniValue::get_int64() const
 
 double UniValue::get_real() const
 {
-    if (typ != VREAL && typ != VNUM)
+    if (typ != VNUM)
         throw std::runtime_error("JSON value is not a number as expected");
     double retval;
     if (!ParseDouble(getValStr(), &retval))

--- a/src/univalue/univalue.h
+++ b/src/univalue/univalue.h
@@ -16,7 +16,7 @@
 
 class UniValue {
 public:
-    enum VType { VNULL, VOBJ, VARR, VSTR, VNUM, VREAL, VBOOL, };
+    enum VType { VNULL, VOBJ, VARR, VSTR, VNUM, VBOOL, };
 
     UniValue() { typ = VNULL; }
     UniValue(UniValue::VType initialType, const std::string& initialStr = "") {
@@ -78,7 +78,6 @@ public:
     bool isBool() const { return (typ == VBOOL); }
     bool isStr() const { return (typ == VSTR); }
     bool isNum() const { return (typ == VNUM); }
-    bool isReal() const { return (typ == VREAL); }
     bool isArray() const { return (typ == VARR); }
     bool isObject() const { return (typ == VOBJ); }
 

--- a/src/univalue/univalue_write.cpp
+++ b/src/univalue/univalue_write.cpp
@@ -61,13 +61,6 @@ string UniValue::write(unsigned int prettyIndent,
     case VSTR:
         s += "\"" + json_escape(val) + "\"";
         break;
-    case VREAL:
-        {
-            std::stringstream ss;
-            ss << std::showpoint << std::fixed << std::setprecision(8) << get_real();
-            s += ss.str();
-        }
-        break;
     case VNUM:
         s += val;
         break;

--- a/src/utilmoneystr.cpp
+++ b/src/utilmoneystr.cpp
@@ -11,7 +11,7 @@
 
 using namespace std;
 
-string FormatMoney(const CAmount& n, bool fPlus)
+std::string FormatMoney(const CAmount& n)
 {
     // Note: not using straight sprintf here because we do NOT want
     // localized number formatting.
@@ -29,8 +29,6 @@ string FormatMoney(const CAmount& n, bool fPlus)
 
     if (n < 0)
         str.insert((unsigned int)0, 1, '-');
-    else if (fPlus && n > 0)
-        str.insert((unsigned int)0, 1, '+');
     return str;
 }
 

--- a/src/utilmoneystr.h
+++ b/src/utilmoneystr.h
@@ -14,7 +14,7 @@
 
 #include "amount.h"
 
-std::string FormatMoney(const CAmount& n, bool fPlus=false);
+std::string FormatMoney(const CAmount& n);
 bool ParseMoney(const std::string& str, CAmount& nRet);
 bool ParseMoney(const char* pszIn, CAmount& nRet);
 

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -538,3 +538,123 @@ int atoi(const std::string& str)
 {
     return atoi(str.c_str());
 }
+
+/** Upper bound for mantissa.
+ * 10^18-1 is the largest arbitrary decimal that will fit in a signed 64-bit integer.
+ * Larger integers cannot consist of arbitrary combinations of 0-9:
+ *
+ *   999999999999999999  1^18-1
+ *  9223372036854775807  (1<<63)-1  (max int64_t)
+ *  9999999999999999999  1^19-1     (would overflow)
+ */
+static const int64_t UPPER_BOUND = 1000000000000000000LL - 1LL;
+
+/** Helper function for ParseFixedPoint */
+static inline bool ProcessMantissaDigit(char ch, int64_t &mantissa, int &mantissa_tzeros)
+{
+    if(ch == '0')
+        ++mantissa_tzeros;
+    else {
+        for (int i=0; i<=mantissa_tzeros; ++i) {
+            if (mantissa > (UPPER_BOUND / 10LL))
+                return false; /* overflow */
+            mantissa *= 10;
+        }
+        mantissa += ch - '0';
+        mantissa_tzeros = 0;
+    }
+    return true;
+}
+
+bool ParseFixedPoint(const std::string &val, int decimals, int64_t *amount_out)
+{
+    int64_t mantissa = 0;
+    int64_t exponent = 0;
+    int mantissa_tzeros = 0;
+    bool mantissa_sign = false;
+    bool exponent_sign = false;
+    int ptr = 0;
+    int end = val.size();
+    int point_ofs = 0;
+
+    if (ptr < end && val[ptr] == '-') {
+        mantissa_sign = true;
+        ++ptr;
+    }
+    if (ptr < end)
+    {
+        if (val[ptr] == '0') {
+            /* pass single 0 */
+            ++ptr;
+        } else if (val[ptr] >= '1' && val[ptr] <= '9') {
+            while (ptr < end && val[ptr] >= '0' && val[ptr] <= '9') {
+                if (!ProcessMantissaDigit(val[ptr], mantissa, mantissa_tzeros))
+                    return false; /* overflow */
+                ++ptr;
+            }
+        } else return false; /* missing expected digit */
+    } else return false; /* empty string or loose '-' */
+    if (ptr < end && val[ptr] == '.')
+    {
+        ++ptr;
+        if (ptr < end && val[ptr] >= '0' && val[ptr] <= '9')
+        {
+            while (ptr < end && val[ptr] >= '0' && val[ptr] <= '9') {
+                if (!ProcessMantissaDigit(val[ptr], mantissa, mantissa_tzeros))
+                    return false; /* overflow */
+                ++ptr;
+                ++point_ofs;
+            }
+        } else return false; /* missing expected digit */
+    }
+    if (ptr < end && (val[ptr] == 'e' || val[ptr] == 'E'))
+    {
+        ++ptr;
+        if (ptr < end && val[ptr] == '+')
+            ++ptr;
+        else if (ptr < end && val[ptr] == '-') {
+            exponent_sign = true;
+            ++ptr;
+        }
+        if (ptr < end && val[ptr] >= '0' && val[ptr] <= '9') {
+            while (ptr < end && val[ptr] >= '0' && val[ptr] <= '9') {
+                if (exponent > (UPPER_BOUND / 10LL))
+                    return false; /* overflow */
+                exponent = exponent * 10 + val[ptr] - '0';
+                ++ptr;
+            }
+        } else return false; /* missing expected digit */
+    }
+    if (ptr != end)
+        return false; /* trailing garbage */
+
+    /* finalize exponent */
+    if (exponent_sign)
+        exponent = -exponent;
+    exponent = exponent - point_ofs + mantissa_tzeros;
+
+    /* finalize mantissa */
+    if (mantissa_sign)
+        mantissa = -mantissa;
+
+    /* convert to one 64-bit fixed-point value */
+    exponent += decimals;
+    if (exponent < 0)
+        return false; /* cannot represent values smaller than 10^-decimals */
+    if (exponent >= 18)
+        return false; /* cannot represent values larger than or equal to 10^(18-decimals) */
+
+    for (int i=0; i < exponent; ++i) {
+        if (mantissa > (UPPER_BOUND / 10LL) || mantissa < -(UPPER_BOUND / 10LL))
+            return false; /* overflow */
+        mantissa *= 10;
+    }
+    if (mantissa > UPPER_BOUND || mantissa < -UPPER_BOUND)
+        return false; /* overflow */
+
+    if (amount_out)
+        *amount_out = mantissa;
+
+    return true;
+}
+

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -464,11 +464,12 @@ bool ParseDouble(const std::string& str, double *out)
         return false;
     if (str.size() >= 2 && str[0] == '0' && str[1] == 'x') // No hexadecimal floats allowed
         return false;
-    char *endp = NULL;
-    errno = 0; // strtod will not set errno if valid
-    double n = strtod(str.c_str(), &endp);
-    if(out) *out = n;
-    return endp && *endp == 0 && !errno;
+    std::istringstream text(str);
+    text.imbue(std::locale::classic());
+    double result;
+    text >> result;
+    if(out) *out = result;
+    return text.eof() && !text.fail();
 }
 
 std::string FormatParagraph(const std::string in, size_t width, size_t indent)

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -109,4 +109,11 @@ bool TimingResistantEqual(const T& a, const T& b)
     return accumulator == 0;
 }
 
+/** Parse number as fixed point according to JSON number syntax.
+ * See http://json.org/number.gif
+ * @returns true on success, false on error.
+ * @note The result must be in the range (-10^18,10^18), otherwise an overflow error will trigger.
+ */
+bool ParseFixedPoint(const std::string &val, int decimals, int64_t *amount_out);
+
 #endif // BITCOIN_UTILSTRENCODINGS_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -418,6 +418,8 @@ UniValue sendtoaddress(const UniValue& params, bool fHelp)
 
     // Amount
     CAmount nAmount = AmountFromValue(params[1]);
+    if (nAmount <= 0)
+        throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount for send");
 
     // Wallet comments
     CWalletTx wtx;
@@ -813,6 +815,8 @@ UniValue movecmd(const UniValue& params, bool fHelp)
     string strFrom = AccountFromValue(params[0]);
     string strTo = AccountFromValue(params[1]);
     CAmount nAmount = AmountFromValue(params[2]);
+    if (nAmount <= 0)
+        throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount for send");
     if (params.size() > 3)
         // unused parameter, used to be nMinDepth, keep type-checking it though
         (void)params[3].get_int();
@@ -892,6 +896,8 @@ UniValue sendfrom(const UniValue& params, bool fHelp)
     if (!address.IsValid())
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
     CAmount nAmount = AmountFromValue(params[2]);
+    if (nAmount <= 0)
+        throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount for send");
     int nMinDepth = 1;
     if (params.size() > 3)
         nMinDepth = params[3].get_int();
@@ -991,6 +997,8 @@ UniValue sendmany(const UniValue& params, bool fHelp)
 
         CScript scriptPubKey = GetScriptForDestination(address.Get());
         CAmount nAmount = AmountFromValue(sendTo[name_]);
+        if (nAmount <= 0)
+            throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount for send");
         totalAmount += nAmount;
 
         bool fSubtractFeeFromAmount = false;
@@ -2190,9 +2198,7 @@ UniValue settxfee(const UniValue& params, bool fHelp)
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
     // Amount
-    CAmount nAmount = 0;
-    if (params[0].get_real() != 0.0)
-        nAmount = AmountFromValue(params[0]);        // rejects 0.0 amounts
+    CAmount nAmount = AmountFromValue(params[0]);
 
     payTxFee = CFeeRate(nAmount, 1000);
     return true;


### PR DESCRIPTION
Patch to accept strings containing decimal value + other fixes leading up to it in Core.

Contains these PRs:
https://github.com/bitcoin/bitcoin/pull/5486/ - [REST] JSON support for /rest/headers
https://github.com/bitcoin/bitcoin/pull/6239/ - Don't go through double in AmountFromValue and ValueFromAmount
https://github.com/bitcoin/bitcoin/pull/6362/ - Fix null id in RPC response during startup
https://github.com/bitcoin/bitcoin/pull/6379/ - rpc: Accept scientific notation for monetary amounts in JSON
https://github.com/bitcoin/bitcoin/pull/6456/ - rpc: Avoid unnecessary parsing roundtrip in number formatting, fix locale issue
https://github.com/bitcoin/bitcoin/pull/6380/ - rpc: Accept strings in AmountFromValue
