### PR TITLE
Generic method to request preceding headers.

### DIFF
--- a/src/blockannounce.cpp
+++ b/src/blockannounce.cpp
@@ -80,9 +80,6 @@ BlockAnnounceReceiver::DownloadStrategy BlockAnnounceReceiver::pickDownloadStrat
 
     NodeStatePtr state(from.id);
 
-    if (!state->initialHeadersReceived)
-        return DOWNL_THIN_LATER;
-
     if (thinmg.numWorkers(block) >= Opt().ThinBlocksMaxParallel()) {
         LogPrint("thin", "max parallel thin req reached, not req %s from peer %d\n",
                 block.ToString(), from.id);
@@ -117,17 +114,6 @@ bool BlockAnnounceReceiver::onBlockAnnounced(std::vector<CInv>& toFetch,
     DownloadStrategy s = pickDownloadStrategy();
 
     if (s == DOWNL_THIN_NOW) {
-
-        if (!announcedAsHeader && nodestate->prefersHeaders) {
-            // Node we're requesting from prefers headers announcement,
-            // but sent us an inv announcement.
-            //
-            // It is likely that we don't have previous blocks,
-            // this block may be part of an reorg. So we request headers to
-            // be sure that we have all headers leading up to this block.
-            requestHeaders(from, block);
-        }
-
         int numDownloading = thinmg.numWorkers(block);
         LogPrint("thin", "requesting %s from peer %d (%d of %d parallel)\n",
             block.ToString(), from.id, (numDownloading + 1), Opt().ThinBlocksMaxParallel());
@@ -137,18 +123,12 @@ bool BlockAnnounceReceiver::onBlockAnnounced(std::vector<CInv>& toFetch,
         return true;
     }
 
-    // First request the headers preceding the announced block. In the normal fully-synced
-    // case where a new block is announced that succeeds the current tip (no reorganization),
-    // there are no such headers.
-    // Secondly, and only when we are close to being synced, we request the announced block directly,
-    // to avoid an extra round-trip. Note that we must *first* ask for the headers, so by the
-    // time the block arrives, the header chain leading up to it is already validated. Not
-    // doing this will result in the received block being rejected as an orphan in case it is
-    // not a direct successor.
-
-    if (!blocksInFlight.isInFlight(block) || !nodestate->initialHeadersReceived) {
+    // Request headers preceding the announced block (if any), so by the time
+    // the full block arrives, the header chain leading up to it is already
+    // validated. Not doing this will result in block being discarded and
+    // re-downloaded later.
+    if (!hasBlockData() && !blocksInFlight.isInFlight(block))
         requestHeaders(from, block);
-    }
 
     if (s == DONT_DOWNL)
         return false;

--- a/src/blockheaderprocessor.h
+++ b/src/blockheaderprocessor.h
@@ -17,6 +17,7 @@ class BlockHeaderProcessor {
                 bool peerSentMax,
                 bool maybeAnnouncement) = 0;
         virtual ~BlockHeaderProcessor() = 0;
+        virtual bool requestConnectHeaders(const CBlockHeader& h, CNode& from) = 0;
 };
 inline BlockHeaderProcessor::~BlockHeaderProcessor() { }
 
@@ -25,12 +26,13 @@ class DefaultHeaderProcessor : public BlockHeaderProcessor {
 
         DefaultHeaderProcessor(CNode* pfrom,
                 InFlightIndex&, ThinBlockManager&, BlockInFlightMarker&,
-                std::function<void()> checkBlockIndex,
-                std::function<void()> sendGetHeaders = [](){ });
+                std::function<void()> checkBlockIndex);
 
         bool operator()(const std::vector<CBlockHeader>& headers,
                 bool peerSentMax,
                 bool maybeAnnouncement) override;
+
+        bool requestConnectHeaders(const CBlockHeader& h, CNode& from) override;
 
     protected:
         virtual std::tuple<bool, CBlockIndex*> acceptHeaders(

--- a/src/blockprocessor.cpp
+++ b/src/blockprocessor.cpp
@@ -61,3 +61,17 @@ bool BlockProcessor::setToWork(const uint256& hash) {
     }
     return true;
 }
+
+bool BlockProcessor::requestConnectHeaders(const CBlockHeader& header) {
+    bool needPrevHeaders = headerProcessor.requestConnectHeaders(header, from);
+
+    if (needPrevHeaders) {
+        // We don't have previous block. We can't connect it to the chain.
+        // Ditch it. We will re-request it later if we see that we still want it.
+        LogPrint("thin", "Can't connect block %s. We don't have prev. Ignoring it peer=%d.\n",
+                header.GetHash().ToString(), from.id);
+
+        worker.setAvailable();
+    }
+    return needPrevHeaders;
+}

--- a/src/blockprocessor.h
+++ b/src/blockprocessor.h
@@ -11,8 +11,8 @@ class uint256;
 class BlockProcessor {
 
     public:
-        BlockProcessor(CNode& f, ThinBlockWorker& w, 
-                const std::string& netcmd, BlockHeaderProcessor& h) : 
+        BlockProcessor(CNode& f, ThinBlockWorker& w,
+                const std::string& netcmd, BlockHeaderProcessor& h) :
             from(f), worker(w), netcmd(netcmd), headerProcessor(h)
         {
         }
@@ -26,10 +26,12 @@ class BlockProcessor {
         CNode& from;
         ThinBlockWorker& worker;
         virtual void misbehave(int howmuch);
-        
+        bool requestConnectHeaders(const CBlockHeader&);
+
     private:
         std::string netcmd;
         BlockHeaderProcessor& headerProcessor;
+
 };
 
 inline BlockProcessor::~BlockProcessor() { }

--- a/src/compactblockprocessor.cpp
+++ b/src/compactblockprocessor.cpp
@@ -28,10 +28,16 @@ void CompactBlockProcessor::operator()(CDataStream& vRecv, const CTxMemPool& mem
         return;
     }
 
+    if (requestConnectHeaders(block.header)) {
+        worker.setAvailable();
+        return;
+    }
+
     CompactTxFinder txfinder(mempool,
             block.shorttxidk0, block.shorttxidk1);
 
-    processHeader(block.header);
+    if (!processHeader(block.header))
+        return;
 
     from.AddInventoryKnown(CInv(MSG_CMPCT_BLOCK, hash));
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5313,15 +5313,14 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
             return true;
         }
 
-        NodeStatePtr(pfrom->id)->initialHeadersReceived = true;
-
-        auto sendGetHeaders = [pfrom](){
-            pfrom->PushMessage("getheaders",
-                    chainActive.GetLocator(pindexBestHeader), uint256());
-        };
         MarkBlockAsInFlight inFlight;
-        DefaultHeaderProcessor p(pfrom, blocksInFlight, thinblockmg, inFlight,
-                CheckBlockIndex, sendGetHeaders);
+        DefaultHeaderProcessor p(pfrom, blocksInFlight, thinblockmg, inFlight, CheckBlockIndex);
+
+        if (p.requestConnectHeaders(headers.at(0), *pfrom))
+            // headers don't connect to active chain, requested
+            // new headers to connect.
+            return true;
+
         if (!p(headers, nCount == MAX_HEADERS_RESULTS, true))
             return false;
     }
@@ -5396,6 +5395,18 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
         LogPrintf("received block %s peer=%d\n", inv.hash.ToString(), pfrom->id);
 
         pfrom->AddInventoryKnown(inv);
+
+        LOCK(cs_main);
+        MarkBlockAsInFlight inFlight;
+        DefaultHeaderProcessor p(pfrom, blocksInFlight, thinblockmg, inFlight, CheckBlockIndex);
+
+        if (p.requestConnectHeaders(block.GetBlockHeader(), *pfrom)) {
+            LogPrintf("Received block %s from peer=%d, but headers do "
+                    "not connect. Discarding.\n");
+            InFlightEraserImpl erase;
+            erase(pfrom->id, inv.hash);
+            return true;
+        }
 
         OnBlockFinished callb(strCommand);
         callb(block, std::vector<NodeId>(1, pfrom->id));

--- a/src/nodestate.cpp
+++ b/src/nodestate.cpp
@@ -19,7 +19,6 @@ CNodeState::CNodeState(NodeId id, ThinBlockManager& thinblockmg) {
     nBlocksInFlightValidHeaders = 0;
     fPreferredDownload = false;
     prefersHeaders = false;
-    initialHeadersReceived = false;
     supportsCompactBlocks = false;
     thinblock.reset(new DummyThinWorker(thinblockmg, id));
 }

--- a/src/nodestate.h
+++ b/src/nodestate.h
@@ -70,10 +70,6 @@ struct CNodeState {
     //! Whether this peer wants invs or headers (when possible) for block announcements.
     bool prefersHeaders;
 
-    // we need to receive headers leading to a block, before we can
-    // request a block.
-    bool initialHeadersReceived;
-
     bool supportsCompactBlocks;
 
     //! the thin block the node is currently providing to us

--- a/src/process_merkleblock.cpp
+++ b/src/process_merkleblock.cpp
@@ -54,6 +54,11 @@ void ProcessMerkleBlock(CNode& pfrom, CDataStream& vRecv,
         return;
     }
 
+    if (processHeader.requestConnectHeaders(merkleBlock.header, pfrom)) {
+        worker.setAvailable();
+        return;
+    }
+
     std::vector<CBlockHeader> headers(1, merkleBlock.header);
     if (!processHeader(headers, false, false)) {
         LogPrint("thin", "Header failed for merkleblock peer=%d\n", pfrom.id);

--- a/src/process_xthinblock.cpp
+++ b/src/process_xthinblock.cpp
@@ -25,9 +25,18 @@ void XThinBlockProcessor::operator()(
         block.selfValidate();
     }
     catch (const std::invalid_argument& e) {
+        LogPrint("thin", "Invalid xthin block %s\n", e.what());
         rejectBlock(hash, e.what(), 20);
+        return;
     }
-    processHeader(block.header);
+
+    if (requestConnectHeaders(block.header)) {
+        worker.setAvailable();
+        return;
+    }
+
+    if (!processHeader(block.header))
+        return;
 
     from.AddInventoryKnown(CInv(MSG_XTHINBLOCK, hash));
 

--- a/src/test/blockannounce_tests.cpp
+++ b/src/test/blockannounce_tests.cpp
@@ -14,18 +14,18 @@
 struct DummyBlockAnnounceReceiver : public BlockAnnounceReceiver {
 
     DummyBlockAnnounceReceiver(uint256 block,
-            CNode& from, ThinBlockManager& thinmg, InFlightIndex& inFlightIndex) : 
+            CNode& from, ThinBlockManager& thinmg, InFlightIndex& inFlightIndex) :
         BlockAnnounceReceiver(block, from, thinmg, inFlightIndex),
-        updateCalled(0), 
+        updateCalled(0),
         isAlmostSynced(true),
         overrideStrategy(BlockAnnounceReceiver::INVALID)
     {
     }
-    
+
     void updateBlockAvailability() override {
         ++updateCalled;
     }
-        
+
     bool almostSynced() override {
         return isAlmostSynced;
     }
@@ -35,11 +35,11 @@ struct DummyBlockAnnounceReceiver : public BlockAnnounceReceiver {
             ? overrideStrategy
             : BlockAnnounceReceiver::pickDownloadStrategy();
     }
-        
+
     bool blockHeaderIsKnown() const override {
         return BlockAnnounceReceiver::blockHeaderIsKnown();
     }
-        
+
     bool isInitialBlockDownload() const override {
         return false;
     }
@@ -68,7 +68,6 @@ struct BlockAnnounceRecvFixture {
         nodestate(node.id)
     {
         SelectParams(CBaseChainParams::MAIN);
-        nodestate->initialHeadersReceived = true;
     }
 
     uint256 block;
@@ -82,7 +81,7 @@ struct BlockAnnounceRecvFixture {
 BOOST_FIXTURE_TEST_SUITE(blockannouncerecv_tests, BlockAnnounceRecvFixture);
 
 BOOST_AUTO_TEST_CASE(header_is_known) {
-    
+
     // We have not seen the block before.
     BOOST_CHECK(!ann.blockHeaderIsKnown());
 
@@ -94,7 +93,7 @@ BOOST_AUTO_TEST_CASE(header_is_known) {
 BOOST_AUTO_TEST_CASE(announce_updates_availability) {
 
     std::vector<CInv> toFetch;
-    
+
     ann.onBlockAnnounced(toFetch, false);
     BOOST_CHECK_EQUAL(1, ann.updateCalled);
 
@@ -114,7 +113,7 @@ BOOST_AUTO_TEST_CASE(fetch_when_wanted) {
 
     {   // We have block (we don't want it)
         std::vector<CInv> toFetch;
-        DummyBlockIndexEntry entry(block); 
+        DummyBlockIndexEntry entry(block);
         BOOST_CHECK(!ann.onBlockAnnounced(toFetch, false));
         BOOST_CHECK_EQUAL(0, toFetch.size());
     }
@@ -149,7 +148,7 @@ struct DummyArgGetter : public ArgGetter {
 };
 
 BOOST_AUTO_TEST_CASE(dowl_strategy_full_now) {
-    
+
     // Peer does not support thin blocks and we are almost synced.
     node.nServices = 0;
 
@@ -170,25 +169,12 @@ BOOST_AUTO_TEST_CASE(dowl_strategy_full_now) {
             ann.pickDownloadStrategy());
 }
 
-BOOST_AUTO_TEST_CASE(downl_strategy_thin_later) {
-
-    // Node supports thin blocks, but we have not
-    // received any headers from node yet. We may not have
-    // caught up on its longest chain. Download thin later.
-    node.nServices = NODE_THIN;
-    nodestate->initialHeadersReceived = false;
-    BOOST_CHECK_EQUAL(
-            BlockAnnounceReceiver::DOWNL_THIN_LATER,
-            ann.pickDownloadStrategy());
-}
-
-
 BOOST_AUTO_TEST_CASE(dowl_strategy_thin_later_2) {
 
     // Thin supports sending thin blocks but is busy. Request later.
     node.nServices = NODE_THIN;
 
-    // By default DummyNode uses DummyThinWorker. 
+    // By default DummyNode uses DummyThinWorker.
     // DummyThinWorker always returns false for isAvailable().
     BOOST_ASSERT(!nodestate->thinblock->isAvailable());
 
@@ -202,7 +188,7 @@ BOOST_AUTO_TEST_CASE(dowl_strategy_dont_downl_1) {
 
     // If we have requested block from max number of nodes
     // then don't download.
-    
+
     // Set max parallel to 1
     auto arg(new DummyArgGetter);
     std::unique_ptr<ArgReset> argraii
@@ -213,7 +199,6 @@ BOOST_AUTO_TEST_CASE(dowl_strategy_dont_downl_1) {
     // Put one node to work
     DummyNode node2(11, thinmg.get());
     NodeStatePtr state2(node2.id);
-    state2->initialHeadersReceived = true;
     state2->thinblock.reset(new XThinWorker(*thinmg, node2.id));
     state2->thinblock->setToWork(block);
     BOOST_CHECK_EQUAL(1, thinmg->numWorkers(block));
@@ -221,7 +206,7 @@ BOOST_AUTO_TEST_CASE(dowl_strategy_dont_downl_1) {
     // Second one should not attempt to download on announcement.
     nodestate->thinblock.reset(new XThinWorker(*thinmg, node.id));
     node.nServices = NODE_THIN;
-    
+
     BOOST_CHECK_EQUAL(BlockAnnounceReceiver::DONT_DOWNL,
             ann.pickDownloadStrategy());
 }
@@ -229,14 +214,14 @@ BOOST_AUTO_TEST_CASE(dowl_strategy_dont_downl_1) {
 BOOST_AUTO_TEST_CASE(dowl_strategy_dont_downl_2) {
     // Don't download announced block unless we are close to
     // catching up to the longest chain.
-    
+
     ann.isAlmostSynced = false;
     BOOST_CHECK_EQUAL(BlockAnnounceReceiver::DONT_DOWNL, ann.pickDownloadStrategy());
 }
 
 BOOST_AUTO_TEST_CASE(dowl_strategy_dont_dowl_3) {
     // Don't download a block that is already in flight.
-    
+
     node.nServices &= ~NODE_THIN;
 
     inFlightIndex.blockInFlight = true;
@@ -245,22 +230,22 @@ BOOST_AUTO_TEST_CASE(dowl_strategy_dont_dowl_3) {
 }
 
 BOOST_AUTO_TEST_CASE(dowl_strategy_dont_dowl_4) {
-    
+
     // Don't download a block from a peer that has
     // many blocks queued up.
-    
+
     nodestate->nBlocksInFlight = MAX_BLOCKS_IN_TRANSIT_PER_PEER;
     BOOST_CHECK_EQUAL(BlockAnnounceReceiver::DONT_DOWNL,
             ann.pickDownloadStrategy());
 }
 
 BOOST_AUTO_TEST_CASE(dowl_strategy_dont_dowl_5) {
-    
+
     // Don't download a full block from a peer if we
     // are configured to avoid full block downloads.
-    
+
     node.nServices &= ~NODE_THIN;
-    
+
     auto arg = new DummyArgGetter;
     auto argraii = SetDummyArgGetter(std::unique_ptr<ArgGetter>(arg));
     arg->usethin = 3; // xthin only, avoid full blocks
@@ -273,9 +258,9 @@ BOOST_AUTO_TEST_CASE(dowl_strategy_dont_dowl_5) {
 struct RequestBlockWorker : public DummyThinWorker {
     RequestBlockWorker(ThinBlockManager& mg, NodeId id)
         : DummyThinWorker(mg, id), reqs(0) { }
-    
+
     void requestBlock(const uint256& block,
-        std::vector<CInv>& getDataReq, CNode& node) override { 
+        std::vector<CInv>& getDataReq, CNode& node) override {
         ++reqs;
     }
     int reqs;
@@ -290,7 +275,7 @@ BOOST_AUTO_TEST_CASE(onannounced_downl_thin) {
 
     auto worker = new RequestBlockWorker(*thinmg, node.id);
     nodestate->thinblock.reset(worker); //<- takes ownership of ptr
-    
+
     std::vector<CInv> r;
     BOOST_CHECK(ann.onBlockAnnounced(r, false));
     BOOST_CHECK_EQUAL(1, worker->reqs);
@@ -303,9 +288,9 @@ BOOST_AUTO_TEST_CASE(onannounced_downl_thin) {
 BOOST_AUTO_TEST_CASE(onannounced_downl_full) {
     // Test that onBlockAnnounced requests a full block
     // with DOWL_FULL_NOW strategy.
-    
+
     ann.overrideStrategy = BlockAnnounceReceiver::DOWNL_FULL_NOW;
-    
+
     std::vector<CInv> toFetch;
     BOOST_CHECK(ann.onBlockAnnounced(toFetch, false));
     BOOST_CHECK_EQUAL(1, toFetch.size());
@@ -316,14 +301,14 @@ BOOST_AUTO_TEST_CASE(onannounced_downl_full) {
 }
 
 BOOST_AUTO_TEST_CASE(onannounced_dont_downl) {
-    // Test that onBlockAnnounced does not request anything 
+    // Test that onBlockAnnounced does not request anything
     // with DONT_DOWNL strategy.
 
     ann.overrideStrategy = BlockAnnounceReceiver::DONT_DOWNL;
 
     auto worker = new RequestBlockWorker(*thinmg, node.id);
     nodestate->thinblock.reset(worker); //<- takes ownership of ptr
-    
+
     std::vector<CInv> toFetch;
     BOOST_CHECK(!ann.onBlockAnnounced(toFetch, false));
     BOOST_CHECK_EQUAL(0, worker->reqs);
@@ -335,14 +320,14 @@ BOOST_AUTO_TEST_CASE(onannounced_dont_downl) {
 }
 
 BOOST_AUTO_TEST_CASE(onannounced_dowl_thin_later) {
-    // Test that onBlockAnnounced does not request anything 
+    // Test that onBlockAnnounced does not request anything
     // with DOWL_THIN_LATER strategy.
 
     ann.overrideStrategy = BlockAnnounceReceiver::DOWNL_THIN_LATER;
 
     auto worker = new RequestBlockWorker(*thinmg, node.id);
     nodestate->thinblock.reset(worker); //<- takes ownership of ptr
-    
+
     std::vector<CInv> toFetch;
     BOOST_CHECK(!ann.onBlockAnnounced(toFetch, false));
     BOOST_CHECK_EQUAL(0, worker->reqs);
@@ -469,7 +454,7 @@ BOOST_AUTO_TEST_CASE(announce_with_inv) {
     DummyBlockIndexEntry entry1(uint256S("0xBAD"));
     DummyBlockIndexEntry entry2(uint256S("0xBEEF"));
     entry2.index.pprev = &entry1.index;
-    
+
     to.blocksToAnnounce = { entry1.hash, entry2.hash };
     NodeStatePtr(to.id)->bestHeaderSent = &entry1.index;
 

--- a/src/test/processmessage_tests.cpp
+++ b/src/test/processmessage_tests.cpp
@@ -40,6 +40,9 @@ struct DummyHeaderProcessor : public BlockHeaderProcessor {
         called = true;
         return headerOK;
     }
+    bool requestConnectHeaders(const CBlockHeader& h, CNode& from) override {
+        return false;
+    }
     bool headerOK;
     bool called;
 };


### PR DESCRIPTION
Always request preceding headers for headers, blocks and thinblocks received. If preceding headers were missing, discard the received block (to be downloaded again later, if we still want it). 

This is mostly done already, but in a more ad-hoc fasion, so this simplifies the code.