### PR TITLE
Announce blocks with compact blocks

### DIFF
--- a/src/blockannounce.cpp
+++ b/src/blockannounce.cpp
@@ -228,8 +228,16 @@ bool BlockAnnounceSender::canAnnounceWithHeaders() const {
 // We only announce with a thin block if there is one block to announce.
 // In addition, same limitations as announcing as header apply.
 bool BlockAnnounceSender::canAnnounceWithBlock() const {
-    return to.blocksToAnnounce.size() == 1
-        && canAnnounceWithHeaders();
+
+    if(to.blocksToAnnounce.size() != 1)
+        return false;
+
+    if (!canAnnounceWithHeaders())
+        return false;
+
+    uint256 hash = to.blocksToAnnounce[0];
+    CBlockIndex* block = mapBlockIndex.find(hash)->second;
+    return block->nStatus & BLOCK_HAVE_DATA;
 }
 
 bool BlockAnnounceSender::announceWithHeaders() {

--- a/src/blockannounce.cpp
+++ b/src/blockannounce.cpp
@@ -1,13 +1,15 @@
-// Copyright (c) 2016 The Bitcoin XT developers
+// Copyright (c) 2016-2017 The Bitcoin XT developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include "blockannounce.h"
+#include "blocksender.h"
 #include "main.h" // for mapBlockIndex, UpdateBlockAvailability, IsInitialBlockDownload
 #include "options.h"
 #include "timedata.h"
 #include "inflightindex.h"
 #include "nodestate.h"
 #include "util.h"
+#include "utilprocessmsg.h"
 #include "thinblockmanager.h"
 #include "thinblock.h"
 
@@ -205,9 +207,6 @@ bool BlockAnnounceSender::canAnnounceWithHeaders() const {
     if (to.blocksToAnnounce.size() > MAX_BLOCKS_TO_ANNOUNCE)
         return false;
 
-    if (!NodeStatePtr(to.id)->prefersHeaders)
-        return false;
-
     // If we come across any
     // headers that aren't on chainActive, give up.
     for (auto h : to.blocksToAnnounce) {
@@ -224,6 +223,13 @@ bool BlockAnnounceSender::canAnnounceWithHeaders() const {
     }
 
     return blocksConnect(to.blocksToAnnounce);
+}
+
+// We only announce with a thin block if there is one block to announce.
+// In addition, same limitations as announcing as header apply.
+bool BlockAnnounceSender::canAnnounceWithBlock() const {
+    return to.blocksToAnnounce.size() == 1
+        && canAnnounceWithHeaders();
 }
 
 bool BlockAnnounceSender::announceWithHeaders() {
@@ -272,9 +278,26 @@ bool BlockAnnounceSender::announceWithHeaders() {
             headers.back().GetHash().ToString(), to.id);
 
     to.PushMessage("headers", headers);
-    NodeStatePtr(to.id)->bestHeaderSent = best;
+    UpdateBestHeaderSent(to, best);
 
     return true;
+}
+
+void BlockAnnounceSender::announceWithBlock(BlockSender& sender) {
+    assert(to.blocksToAnnounce.size() == 1);
+    uint256 hash = to.blocksToAnnounce[0];
+    CBlockIndex* block = mapBlockIndex.find(hash)->second;
+
+    if (peerHasHeader(block)) {
+        // peer may have announced this block to us.
+        return;
+    }
+
+    sender.sendBlock(to, *block, MSG_CMPCT_BLOCK, block->nHeight);
+    UpdateBestHeaderSent(to, block);
+
+    LogPrint("net", "%s: block %s to peer=%d\n",
+            __func__, hash.ToString(), to.id);
 }
 
 void BlockAnnounceSender::announce() {
@@ -283,11 +306,24 @@ void BlockAnnounceSender::announce() {
     if (to.blocksToAnnounce.empty())
         return;
 
-    LogPrint("ann", "Announce for peer=%d, %d blocks, prefersheaders: %d\n",
-            to.id, to.blocksToAnnounce.size(), NodeStatePtr(to.id)->prefersHeaders);
+    NodeStatePtr node(to.id);
+    LogPrint("ann", "Announce for peer=%d, %d blocks, prefersheaders: %d, prefersblocks: %d\n",
+            to.id, to.blocksToAnnounce.size(),
+            node->prefersHeaders, node->prefersBlocks);
 
     try {
-        if (!(canAnnounceWithHeaders() && announceWithHeaders()))
+        bool announced = false;
+
+        if (node->prefersBlocks && canAnnounceWithBlock()) {
+            BlockSender sender;
+            announceWithBlock(sender);
+            announced = true;
+        }
+
+        else if (node->prefersHeaders && canAnnounceWithHeaders())
+            announced = announceWithHeaders();
+
+        if (!announced)
             announceWithInv();
     }
     catch (const std::exception& e) {

--- a/src/blockannounce.h
+++ b/src/blockannounce.h
@@ -7,6 +7,7 @@
 #include "uint256.h"
 #include <vector>
 
+class BlockSender;
 class CInv;
 class CNode;
 class ThinBlockManager;
@@ -17,13 +18,13 @@ class BlockAnnounceReceiver {
 
     public:
         BlockAnnounceReceiver(uint256 block,
-                CNode& from, ThinBlockManager& thinmg, InFlightIndex& inFlightIndex) : 
+                CNode& from, ThinBlockManager& thinmg, InFlightIndex& inFlightIndex) :
             block(block), from(from), thinmg(thinmg), blocksInFlight(inFlightIndex)
         {
         }
 
         bool onBlockAnnounced(std::vector<CInv>& toFetch, bool announcedAsHeader);
-        
+
         enum DownloadStrategy {
             DOWNL_THIN_NOW,
             DOWNL_FULL_NOW,
@@ -64,7 +65,10 @@ class BlockAnnounceSender {
 
     protected:
         virtual bool canAnnounceWithHeaders() const;
+        virtual bool canAnnounceWithBlock() const;
+
         virtual bool announceWithHeaders();
+        virtual void announceWithBlock(BlockSender&);
         virtual void announceWithInv();
 
     private:

--- a/src/blocksender.cpp
+++ b/src/blocksender.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 The Bitcoin XT developers
+// Copyright (c) 2016-2017 The Bitcoin XT developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include "blockencodings.h"
@@ -8,6 +8,7 @@
 #include "chain.h"
 #include "chainparams.h"
 #include "util.h"
+#include "utilprocessmsg.h" //
 #include "net.h"
 #include "xthin.h"
 #include "merkleblock.h"
@@ -47,21 +48,11 @@ bool BlockSender::canSend(const CChain& activeChain, const CBlockIndex& block,
     return send;
 }
 
-void updateBestHeaderSent(CNode& node, CBlockIndex* blockIndex) {
-    // When we send a block, were also sending its header.
-    NodeStatePtr state(node.id);
-    if (!state->bestHeaderSent)
-        state->bestHeaderSent = blockIndex;
-
-    if (state->bestHeaderSent->nHeight <= blockIndex->nHeight)
-        state->bestHeaderSent = blockIndex;
-}
-
 void BlockSender::send(const CChain& activeChain, CNode& node,
         CBlockIndex& blockIndex, const CInv& inv)
 {
     sendBlock(node, blockIndex, inv.type, activeChain.Height());
-    updateBestHeaderSent(node, &blockIndex);
+    UpdateBestHeaderSent(node, &blockIndex);
     triggerNextRequest(activeChain, inv, node);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4938,9 +4938,10 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
             return true; // Ignore as per BIP152
 
         LOCK(cs_main);
-        NodeStatePtr(pfrom->id)->supportsCompactBlocks = true;
-        NodeStatePtr(pfrom->id)->thinblock.reset(
-                new CompactWorker(thinblockmg, pfrom->id));
+        NodeStatePtr node(pfrom->id);
+        node->supportsCompactBlocks = true;
+        node->prefersBlocks = highBandwidth;
+        node->thinblock.reset(new CompactWorker(thinblockmg, pfrom->id));
     }
 
     else if (strCommand == "sendheaders")
@@ -5013,6 +5014,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
 
         auto mi = mapBlockIndex.find(req.blockhash);
         bool haveBlock = mi != mapBlockIndex.end();
+        LOCK(cs_main);
         BlockSender bs;
         bool canSend = haveBlock && bs.canSend(
                 chainActive, *(mi->second), pindexBestHeader);
@@ -5432,6 +5434,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
 
         BlockMap::iterator mi = mapBlockIndex.find(req.block);
         bool haveBlock = mi != mapBlockIndex.end();
+        LOCK(cs_main);
         BlockSender bs;
         bool canSend = haveBlock && bs.canSend(
                 chainActive, *(mi->second), pindexBestHeader);

--- a/src/nodestate.cpp
+++ b/src/nodestate.cpp
@@ -19,6 +19,7 @@ CNodeState::CNodeState(NodeId id, ThinBlockManager& thinblockmg) {
     nBlocksInFlightValidHeaders = 0;
     fPreferredDownload = false;
     prefersHeaders = false;
+    prefersBlocks = false;
     initialHeadersReceived = false;
     supportsCompactBlocks = false;
     thinblock.reset(new DummyThinWorker(thinblockmg, id));

--- a/src/nodestate.h
+++ b/src/nodestate.h
@@ -67,8 +67,10 @@ struct CNodeState {
     //! Whether we consider this a preferred download peer.
     bool fPreferredDownload;
 
-    //! Whether this peer wants invs or headers (when possible) for block announcements.
+    //! Whether this peer wants headers (when possible) for block announcements.
     bool prefersHeaders;
+    //! Whether this peer wants thin blocks (when possible) for block announcements.
+    bool prefersBlocks;
 
     // we need to receive headers leading to a block, before we can
     // request a block.

--- a/src/utilprocessmsg.cpp
+++ b/src/utilprocessmsg.cpp
@@ -1,6 +1,9 @@
 #include "utilprocessmsg.h"
+#include "chain.h"
 #include "main.h" // mapBlockIndex
 #include "options.h"
+#include "net.h"
+#include "nodestate.h"
 
 bool HaveBlockData(const uint256& hash) {
     return mapBlockIndex.count(hash)
@@ -22,4 +25,14 @@ bool KeepOutgoingPeer(const CNode& node) {
         return node.SupportsXThinBlocks() || node.SupportsCompactBlocks();
 
     return SupportsThinBlocks(node);
+}
+
+void UpdateBestHeaderSent(CNode& node, CBlockIndex* blockIndex) {
+    // When we send a block, were also sending its header.
+    NodeStatePtr state(node.id);
+    if (!state->bestHeaderSent)
+        state->bestHeaderSent = blockIndex;
+
+    if (state->bestHeaderSent->nHeight <= blockIndex->nHeight)
+        state->bestHeaderSent = blockIndex;
 }

--- a/src/utilprocessmsg.h
+++ b/src/utilprocessmsg.h
@@ -24,4 +24,6 @@ inline BlockInFlightMarker::~BlockInFlightMarker() { }
 // If node matches our criteria for outgoing connections.
 bool KeepOutgoingPeer(const CNode&);
 
+void UpdateBestHeaderSent(CNode& node, CBlockIndex* blockIndex);
+
 #endif


### PR DESCRIPTION
Adds support for announcing blocks using compact blocks instead of inv or header. Remote node must requests "high bandwith mode" compact blocks to enable this.

Note: XT does not request block announcements yet, but can now serve them.