### PR TITLE
Don't keep outgoing connections to UASF nodes.

### DIFF
--- a/src/test/utilprocessmsg_tests.cpp
+++ b/src/test/utilprocessmsg_tests.cpp
@@ -43,7 +43,7 @@ struct UtilDummyArgGetter : public ArgGetter {
 
 BOOST_AUTO_TEST_SUITE(utilprocessmsg_tests);
 
-BOOST_AUTO_TEST_CASE(keep_outgoing_peer) {
+BOOST_AUTO_TEST_CASE(keep_outgoing_peer_thin) {
 
     auto arg = new UtilDummyArgGetter;
     auto argraii = SetDummyArgGetter(std::unique_ptr<ArgGetter>(arg));
@@ -83,5 +83,19 @@ BOOST_AUTO_TEST_CASE(keep_outgoing_peer) {
     node.nServices = SHORT_IDS_BLOCKS_VERSION;
     BOOST_CHECK(KeepOutgoingPeer(node));
 }
+
+BOOST_AUTO_TEST_CASE(keep_outgoing_peer_uasf) {
+    DummyNode node;
+    node.nServices = 0;
+    auto arg = new UtilDummyArgGetter;
+    auto argraii = SetDummyArgGetter(std::unique_ptr<ArgGetter>(arg));
+    arg->usethin = 0;
+
+    node.strSubVer = "Nice node";
+    BOOST_CHECK(KeepOutgoingPeer(node));
+
+    node.strSubVer = "Bad UASF node";
+    BOOST_CHECK(!KeepOutgoingPeer(node));
+};
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/utilprocessmsg.cpp
+++ b/src/utilprocessmsg.cpp
@@ -18,6 +18,11 @@ bool SupportsThinBlocks(const CNode& node) {
 bool KeepOutgoingPeer(const CNode& node) {
     assert(!node.fInbound);
 
+    // UASF nodes reject blocks that are valid, but do not vote for a
+    // consensus change the node operator is trying to force onto the network.
+    if (node.strSubVer.find("UASF") != std::string::npos)
+        return false;
+
     if (!Opt().UsingThinBlocks())
         return true;
 


### PR DESCRIPTION
UASF nodes reject blocks that are valid, but do not vote for a consensus change the node operator is trying to force onto the network. Avoid UASF nodes to always see the best chain.

These nodes can still have incoming connections to us.