### PR TITLE
Thin block announcements

### DIFF
--- a/qa/rpc-tests/p2p-compactblocks.py
+++ b/qa/rpc-tests/p2p-compactblocks.py
@@ -648,6 +648,8 @@ class CompactBlocksTest(BitcoinTestFramework):
         node.generate(1)
         wait_until(test_node.received_block_announcement, timeout=30)
         test_node.clear_block_announcement()
+        with mininode_lock:
+            test_node.last_block = None
         test_node.send_message(msg_getdata([CInv(4, int(new_blocks[0], 16))]))
         success = wait_until(lambda: test_node.last_block is not None, timeout=30)
         assert(success)

--- a/qa/rpc-tests/p2p-compactblocks.py
+++ b/qa/rpc-tests/p2p-compactblocks.py
@@ -300,8 +300,8 @@ class CompactBlocksTest(BitcoinTestFramework):
             assert(segwit_tx_generated) # check that our test is not broken
 
         # Wait until we've seen the block announcement for the resulting tip
-        tip = int(self.nodes[0].getbestblockhash(), 16)
-        assert(self.test_node.wait_for_block_announcement(tip))
+        tip = int(node.getbestblockhash(), 16)
+        assert(test_node.wait_for_block_announcement(tip))
 
         # Now mine a block, and look at the resulting compact block.
         test_node.clear_block_announcement()

--- a/qa/rpc-tests/p2p-compactblocks.py
+++ b/qa/rpc-tests/p2p-compactblocks.py
@@ -27,6 +27,7 @@ class TestNode(SingleNodeConnCB):
         self.last_cmpctblock = None
         self.block_announced = False
         self.last_getdata = None
+        self.last_getheaders = None
         self.last_getblocktxn = None
         self.last_block = None
         self.last_blocktxn = None
@@ -63,6 +64,9 @@ class TestNode(SingleNodeConnCB):
 
     def on_getdata(self, conn, message):
         self.last_getdata = message
+
+    def on_getheaders(self, conn, message):
+        self.last_getheaders = message
 
     def on_getblocktxn(self, conn, message):
         self.last_getblocktxn = message
@@ -393,6 +397,9 @@ class CompactBlocksTest(BitcoinTestFramework):
 
             if announce == "inv":
                 test_node.send_message(msg_inv([CInv(2, block.sha256)]))
+                success = wait_until(lambda: test_node.last_getheaders is not None, timeout=30)
+                assert(success)
+                test_node.send_header_for_blocks([block])
             else:
                 test_node.send_header_for_blocks([block])
             success = wait_until(lambda: test_node.last_getdata is not None, timeout=30)

--- a/qa/rpc-tests/p2p-compactblocks.py
+++ b/qa/rpc-tests/p2p-compactblocks.py
@@ -591,7 +591,7 @@ class CompactBlocksTest(BitcoinTestFramework):
     def test_getblocktxn_handler(self, node, test_node, version):
         # bitcoind won't respond for blocks whose height is more than 15 blocks
         # deep.
-        MAX_GETBLOCKTXN_DEPTH = 15
+        MAX_GETBLOCKTXN_DEPTH = 10
         chain_height = node.getblockcount()
         current_height = chain_height
         while (current_height >= chain_height - MAX_GETBLOCKTXN_DEPTH):
@@ -632,7 +632,7 @@ class CompactBlocksTest(BitcoinTestFramework):
 
     def test_compactblocks_not_at_tip(self, node, test_node):
         # Test that requesting old compactblocks doesn't work.
-        MAX_CMPCTBLOCK_DEPTH = 11
+        MAX_CMPCTBLOCK_DEPTH = 6
         new_blocks = []
         for i in range(MAX_CMPCTBLOCK_DEPTH):
             test_node.clear_block_announcement()

--- a/qa/rpc-tests/p2p-compactblocks.py
+++ b/qa/rpc-tests/p2p-compactblocks.py
@@ -632,9 +632,9 @@ class CompactBlocksTest(BitcoinTestFramework):
 
     def test_compactblocks_not_at_tip(self, node, test_node):
         # Test that requesting old compactblocks doesn't work.
-        MAX_CMPCTBLOCK_DEPTH = 6
+        MAX_CMPCTBLOCK_DEPTH = 5
         new_blocks = []
-        for i in range(MAX_CMPCTBLOCK_DEPTH):
+        for i in range(MAX_CMPCTBLOCK_DEPTH + 1):
             test_node.clear_block_announcement()
             new_blocks.append(node.generate(1)[0])
             wait_until(test_node.received_block_announcement, timeout=30)

--- a/qa/rpc-tests/p2p-compactblocks.py
+++ b/qa/rpc-tests/p2p-compactblocks.py
@@ -128,6 +128,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         tip = node.getbestblockhash()
         mtp = node.getblockheader(tip)['mediantime']
         block = create_block(int(tip, 16), create_coinbase(height + 1), mtp + 1)
+        block.nVersion = 4
         if segwit:
             add_witness_commitment(block)
         block.solve()

--- a/qa/rpc-tests/p2p-compactblocks.py
+++ b/qa/rpc-tests/p2p-compactblocks.py
@@ -6,7 +6,7 @@
 from test_framework.mininode import *
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-from test_framework.blocktools import create_block, create_coinbase
+from test_framework.blocktools import create_block, create_coinbase, add_witness_commitment
 from test_framework.siphash import siphash256
 from test_framework.script import CScript, OP_TRUE
 
@@ -123,11 +123,13 @@ class CompactBlocksTest(BitcoinTestFramework):
                  ["-debug", "-logtimemicros", "-txindex"]])
         connect_nodes(self.nodes[0], 1)
 
-    def build_block_on_tip(self, node):
+    def build_block_on_tip(self, node, segwit=False):
         height = node.getblockcount()
         tip = node.getbestblockhash()
         mtp = node.getblockheader(tip)['mediantime']
         block = create_block(int(tip, 16), create_coinbase(height + 1), mtp + 1)
+        if segwit:
+            add_witness_commitment(block)
         block.solve()
         return block
 
@@ -380,11 +382,11 @@ class CompactBlocksTest(BitcoinTestFramework):
     # Post-segwit: upgraded nodes would only make this request of cb-version-2,
     # NODE_WITNESS peers.  Unupgraded nodes would still make this request of
     # any cb-version-1-supporting peer.
-    def test_compactblock_requests(self, node, test_node):
+    def test_compactblock_requests(self, node, test_node, version, segwit):
         # Try announcing a block with an inv or header, expect a compactblock
         # request
         for announce in ["inv", "header"]:
-            block = self.build_block_on_tip(node)
+            block = self.build_block_on_tip(node, segwit=segwit)
             with mininode_lock:
                 test_node.last_getdata = None
 
@@ -403,8 +405,11 @@ class CompactBlocksTest(BitcoinTestFramework):
             comp_block.header = CBlockHeader(block)
             comp_block.nonce = 0
             [k0, k1] = comp_block.get_siphash_keys()
+            coinbase_hash = block.vtx[0].sha256
+            if version == 2:
+                coinbase_hash = block.vtx[0].calc_sha256(True)
             comp_block.shortids = [
-                    calculate_shortid(k0, k1, block.vtx[0].sha256) ]
+                    calculate_shortid(k0, k1, coinbase_hash) ]
             test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
             assert_equal(int(node.getbestblockhash(), 16), block.hashPrevBlock)
             # Expect a getblocktxn message.
@@ -414,7 +419,10 @@ class CompactBlocksTest(BitcoinTestFramework):
             assert_equal(absolute_indexes, [0])  # should be a coinbase request
 
             # Send the coinbase, and verify that the tip advances.
-            msg = msg_blocktxn()
+            if version == 2:
+                msg = msg_witness_blocktxn()
+            else:
+                msg = msg_blocktxn()
             msg.block_transactions.blockhash = block.sha256
             msg.block_transactions.transactions = [block.vtx[0]]
             test_node.send_and_ping(msg)
@@ -750,9 +758,9 @@ class CompactBlocksTest(BitcoinTestFramework):
         sync_blocks(self.nodes)
 
         print("\tTesting compactblock requests... ")
-        self.test_compactblock_requests(self.nodes[0], self.test_node)
+        self.test_compactblock_requests(self.nodes[0], self.test_node, 1, False)
         sync_blocks(self.nodes)
-        self.test_compactblock_requests(self.nodes[1], self.segwit_node)
+        self.test_compactblock_requests(self.nodes[1], self.segwit_node, 2, False)
         sync_blocks(self.nodes)
 
         print("\tTesting getblocktxn requests...")
@@ -800,7 +808,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         sync_blocks(self.nodes)
 
         print("\tTesting compactblock requests (unupgraded node)... ")
-        self.test_compactblock_requests(self.nodes[0], self.test_node)
+        self.test_compactblock_requests(self.nodes[0], self.test_node, 1, True)
 
         print("\tTesting getblocktxn requests (unupgraded node)...")
         self.test_getblocktxn_requests(self.nodes[0], self.test_node, 1)
@@ -815,7 +823,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].getbestblockhash(), self.nodes[1].getbestblockhash())
 
         print("\tTesting compactblock requests (segwit node)... ")
-        self.test_compactblock_requests(self.nodes[1], self.segwit_node)
+        self.test_compactblock_requests(self.nodes[1], self.segwit_node, 2, True)
 
         print("\tTesting getblocktxn requests (segwit node)...")
         self.test_getblocktxn_requests(self.nodes[1], self.segwit_node, 2)

--- a/qa/rpc-tests/p2p-compactblocks.py
+++ b/qa/rpc-tests/p2p-compactblocks.py
@@ -30,6 +30,10 @@ class TestNode(SingleNodeConnCB):
         self.last_getblocktxn = None
         self.last_block = None
         self.last_blocktxn = None
+        # Store the hashes of blocks we've seen announced.
+        # This is for synchronizing the p2p message traffic,
+        # so we can eg wait until a particular block is announced.
+        self.set_announced_blockhashes = set()
 
     def on_sendcmpct(self, conn, message):
         self.last_sendcmpct.append(message)
@@ -40,14 +44,22 @@ class TestNode(SingleNodeConnCB):
     def on_cmpctblock(self, conn, message):
         self.last_cmpctblock = message
         self.block_announced = True
+        self.last_cmpctblock.header_and_shortids.header.calc_sha256()
+        self.set_announced_blockhashes.add(self.last_cmpctblock.header_and_shortids.header.sha256)
 
     def on_headers(self, conn, message):
         self.last_headers = message
         self.block_announced = True
+        for x in self.last_headers.headers:
+            x.calc_sha256()
+            self.set_announced_blockhashes.add(x.sha256)
 
     def on_inv(self, conn, message):
         self.last_inv = message
-        self.block_announced = True
+        for x in self.last_inv.inv:
+            if x.type == 2:
+                self.block_announced = True
+                self.set_announced_blockhashes.add(x.hash)
 
     def on_getdata(self, conn, message):
         self.last_getdata = message
@@ -87,6 +99,12 @@ class TestNode(SingleNodeConnCB):
         assert(self.received_block_announcement())
         self.clear_block_announcement()
 
+    # Block until a block announcement for a particular block hash is
+    # received.
+    def wait_for_block_announcement(self, block_hash, timeout=30):
+        def received_hash():
+            return (block_hash in self.set_announced_blockhashes)
+        return wait_until(received_hash, timeout=timeout)
 
 class CompactBlocksTest(BitcoinTestFramework):
     def __init__(self):
@@ -278,7 +296,9 @@ class CompactBlocksTest(BitcoinTestFramework):
         if use_witness_address:
             assert(segwit_tx_generated) # check that our test is not broken
 
-        self.test_node.sync_with_ping()
+        # Wait until we've seen the block announcement for the resulting tip
+        tip = int(self.nodes[0].getbestblockhash(), 16)
+        assert(self.test_node.wait_for_block_announcement(tip))
 
         # Now mine a block, and look at the resulting compact block.
         test_node.clear_block_announcement()

--- a/qa/rpc-tests/p2p-compactblocks.py
+++ b/qa/rpc-tests/p2p-compactblocks.py
@@ -589,8 +589,8 @@ class CompactBlocksTest(BitcoinTestFramework):
         assert_equal(int(node.getbestblockhash(), 16), block.sha256)
 
     def test_getblocktxn_handler(self, node, test_node, version):
-        # bitcoind won't respond for blocks whose height is more than 15 blocks
-        # deep.
+        # bitcoind will not send blocktxn responses for blocks whose height is
+        # more than 10 blocks deep.
         MAX_GETBLOCKTXN_DEPTH = 10
         chain_height = node.getblockcount()
         current_height = chain_height
@@ -623,11 +623,17 @@ class CompactBlocksTest(BitcoinTestFramework):
                 test_node.last_blocktxn = None
             current_height -= 1
 
-        # Next request should be ignored, as we're past the allowed depth.
+        # Next request should send a full block response, as we're past the
+        # allowed depth for a blocktxn response.
         block_hash = node.getblockhash(current_height)
         msg.block_txn_request = BlockTransactionsRequest(int(block_hash, 16), [0])
+        with mininode_lock:
+            test_node.last_block = None
+            test_node.last_blocktxn = None
         test_node.send_and_ping(msg)
         with mininode_lock:
+            test_node.last_block.block.calc_sha256()
+            assert_equal(test_node.last_block.block.sha256, int(block_hash, 16))
             assert_equal(test_node.last_blocktxn, None)
 
     def test_compactblocks_not_at_tip(self, node, test_node):

--- a/qa/rpc-tests/p2p-compactblocks.py
+++ b/qa/rpc-tests/p2p-compactblocks.py
@@ -402,7 +402,9 @@ class CompactBlocksTest(BitcoinTestFramework):
             comp_block = HeaderAndShortIDs()
             comp_block.header = CBlockHeader(block)
             comp_block.nonce = 0
-            comp_block.shortids = [1]  # this is useless, and wrong
+            [k0, k1] = comp_block.get_siphash_keys()
+            comp_block.shortids = [
+                    calculate_shortid(k0, k1, block.vtx[0].sha256) ]
             test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
             assert_equal(int(node.getbestblockhash(), 16), block.hashPrevBlock)
             # Expect a getblocktxn message.

--- a/qa/rpc-tests/p2p-compactblocks.py
+++ b/qa/rpc-tests/p2p-compactblocks.py
@@ -710,6 +710,33 @@ class CompactBlocksTest(BitcoinTestFramework):
                 l.last_cmpctblock.header_and_shortids.header.calc_sha256()
                 assert_equal(l.last_cmpctblock.header_and_shortids.header.sha256, block.sha256)
 
+    # Test that we don't get disconnected if we relay a compact block with valid header,
+    # but invalid transactions.
+    def test_invalid_tx_in_compactblock(self, node, test_node, use_segwit):
+        assert(len(self.utxos))
+        utxo = self.utxos[0]
+
+        block = self.build_block_with_transactions(node, utxo, 5)
+        del block.vtx[3]
+        block.hashMerkleRoot = block.calc_merkle_root()
+        if use_segwit:
+            # If we're testing with segwit, also drop the coinbase witness,
+            # but include the witness commitment.
+            add_witness_commitment(block)
+            block.vtx[0].wit.vtxinwit = []
+        block.solve()
+
+        # Now send the compact block with all transactions prefilled, and
+        # verify that we don't get disconnected.
+        comp_block = HeaderAndShortIDs()
+        comp_block.initialize_from_block(block, prefill_list=[0, 1, 2, 3, 4], use_witness=use_segwit)
+        msg = msg_cmpctblock(comp_block.to_p2p())
+        test_node.send_and_ping(msg)
+
+        # Check that the tip didn't advance
+        assert(int(node.getbestblockhash(), 16) is not block.sha256)
+        test_node.sync_with_ping()
+
     # Helper for enabling cb announcements
     # Send the sendcmpct request and sync headers
     def request_cb_announcements(self, peer, node, version):
@@ -800,6 +827,11 @@ class CompactBlocksTest(BitcoinTestFramework):
         self.test_end_to_end_block_relay(self.nodes[0], [self.segwit_node, self.test_node, self.old_node])
         self.test_end_to_end_block_relay(self.nodes[1], [self.segwit_node, self.test_node, self.old_node])
 
+        print("\tTesting handling of invalid compact blocks...")
+        self.test_invalid_tx_in_compactblock(self.nodes[0], self.test_node, False)
+        self.test_invalid_tx_in_compactblock(self.nodes[1], self.segwit_node, False)
+        self.test_invalid_tx_in_compactblock(self.nodes[1], self.old_node, False)
+
         # Advance to segwit activation
         print ("\nAdvancing to segwit activation\n")
         self.activate_segwit(self.nodes[1])
@@ -845,6 +877,11 @@ class CompactBlocksTest(BitcoinTestFramework):
         self.request_cb_announcements(self.old_node, self.nodes[1], 1)
         self.request_cb_announcements(self.segwit_node, self.nodes[1], 2)
         self.test_end_to_end_block_relay(self.nodes[1], [self.segwit_node, self.test_node, self.old_node])
+
+        print("\tTesting handling of invalid compact blocks...")
+        self.test_invalid_tx_in_compactblock(self.nodes[0], self.test_node, False)
+        self.test_invalid_tx_in_compactblock(self.nodes[1], self.segwit_node, True)
+        self.test_invalid_tx_in_compactblock(self.nodes[1], self.old_node, True)
 
         print("\tTesting invalid index in cmpctblock message...")
         self.test_invalid_cmpctblock_message()

--- a/qa/rpc-tests/p2p-compactblocks.py
+++ b/qa/rpc-tests/p2p-compactblocks.py
@@ -190,12 +190,15 @@ class CompactBlocksTest(BitcoinTestFramework):
 
         def check_announcement_of_new_block(node, peer, predicate):
             peer.clear_block_announcement()
-            node.generate(1)
-            got_message = wait_until(lambda: peer.block_announced, timeout=30)
+            block_hash = int(node.generate(1)[0], 16)
+            peer.wait_for_block_announcement(block_hash, timeout=30)
             assert(peer.block_announced)
             assert(got_message)
+
             with mininode_lock:
-                assert(predicate(peer))
+                assert predicate(peer), (
+                    "block_hash={!r}, cmpctblock={!r}, inv={!r}".format(
+                        block_hash, peer.last_cmpctblock, peer.last_inv))
 
         # We shouldn't get any block announcements via cmpctblock yet.
         check_announcement_of_new_block(node, test_node, lambda p: p.last_cmpctblock is None)

--- a/qa/rpc-tests/p2p-compactblocks.py
+++ b/qa/rpc-tests/p2p-compactblocks.py
@@ -12,14 +12,16 @@ from test_framework.script import CScript, OP_TRUE
 
 '''
 CompactBlocksTest -- test compact blocks (BIP 152)
-'''
 
+Version 1 compact blocks are pre-segwit (txids)
+Version 2 compact blocks are post-segwit (wtxids)
+'''
 
 # TestNode: A peer we use to send messages to bitcoind, and store responses.
 class TestNode(SingleNodeConnCB):
     def __init__(self):
         SingleNodeConnCB.__init__(self)
-        self.last_sendcmpct = None
+        self.last_sendcmpct = []
         self.last_headers = None
         self.last_inv = None
         self.last_cmpctblock = None
@@ -30,7 +32,7 @@ class TestNode(SingleNodeConnCB):
         self.last_blocktxn = None
 
     def on_sendcmpct(self, conn, message):
-        self.last_sendcmpct = message
+        self.last_sendcmpct.append(message)
 
     def on_block(self, conn, message):
         self.last_block = message
@@ -90,29 +92,31 @@ class CompactBlocksTest(BitcoinTestFramework):
     def __init__(self):
         super(CompactBlocksTest, self).__init__()
         self.setup_clean_chain = True
-        self.num_nodes = 1
+        # Node0 = pre-segwit, node1 = segwit-aware
+        self.num_nodes = 2
         self.utxos = []
 
     def setup_network(self):
         self.nodes = []
 
-        # Turn off segwit in this test, as compact blocks don't currently work
-        # with segwit.  (After BIP 152 is updated to support segwit, we can
-        # test behavior with and without segwit enabled by adding a second node
-        # to the test.)
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [["-debug", "-logtimemicros=1", "-bip9params=segwit:0:0"]])
+        # Start up node0 to be a version 1, pre-segwit node.
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, 
+                [["-debug", "-logtimemicros=1", "-bip9params=segwit:0:0"], 
+                 ["-debug", "-logtimemicros", "-txindex"]])
+        connect_nodes(self.nodes[0], 1)
 
-    def build_block_on_tip(self):
-        height = self.nodes[0].getblockcount()
-        tip = self.nodes[0].getbestblockhash()
-        mtp = self.nodes[0].getblockheader(tip)['mediantime']
+    def build_block_on_tip(self, node):
+        height = node.getblockcount()
+        tip = node.getbestblockhash()
+        mtp = node.getblockheader(tip)['mediantime']
         block = create_block(int(tip, 16), create_coinbase(height + 1), mtp + 1)
         block.solve()
         return block
 
     # Create 10 more anyone-can-spend utxo's for testing.
     def make_utxos(self):
-        block = self.build_block_on_tip()
+        # Doesn't matter which node we use, just use node0.
+        block = self.build_block_on_tip(self.nodes[0])
         self.test_node.send_and_ping(msg_block(block))
         assert(int(self.nodes[0].getbestblockhash(), 16) == block.sha256)
         self.nodes[0].generate(100)
@@ -125,7 +129,7 @@ class CompactBlocksTest(BitcoinTestFramework):
             tx.vout.append(CTxOut(out_value, CScript([OP_TRUE])))
         tx.rehash()
 
-        block2 = self.build_block_on_tip()
+        block2 = self.build_block_on_tip(self.nodes[0])
         block2.vtx.append(tx)
         block2.hashMerkleRoot = block2.calc_merkle_root()
         block2.solve()
@@ -134,26 +138,30 @@ class CompactBlocksTest(BitcoinTestFramework):
         self.utxos.extend([[tx.sha256, i, out_value] for i in range(10)])
         return
 
-    # Test "sendcmpct":
-    # - No compact block announcements or getdata(MSG_CMPCT_BLOCK) unless
-    #   sendcmpct is sent.
-    # - If sendcmpct is sent with version > 1, the message is ignored.
+    # Test "sendcmpct" (between peers preferring the same version):
+    # - No compact block announcements unless sendcmpct is sent.
+    # - If sendcmpct is sent with version > preferred_version, the message is ignored.
     # - If sendcmpct is sent with boolean 0, then block announcements are not
     #   made with compact blocks.
     # - If sendcmpct is then sent with boolean 1, then new block announcements
     #   are made with compact blocks.
-    def test_sendcmpct(self):
-        print("Testing SENDCMPCT p2p message... ")
-
-        # Make sure we get a version 0 SENDCMPCT message from our peer
+    # If old_node is passed in, request compact blocks with version=preferred-1
+    # and verify that it receives block announcements via compact block.
+    def test_sendcmpct(self, node, test_node, preferred_version, old_node=None):
+        # Make sure we get a SENDCMPCT message from our peer
         def received_sendcmpct():
-            return (self.test_node.last_sendcmpct is not None)
+            return (len(test_node.last_sendcmpct) > 0)
         got_message = wait_until(received_sendcmpct, timeout=30)
         assert(received_sendcmpct())
         assert(got_message)
-        assert_equal(self.test_node.last_sendcmpct.version, 1)
+        with mininode_lock:
+            # Check that the first version received is the preferred one
+            assert_equal(test_node.last_sendcmpct[0].version, preferred_version)
+            # And that we receive versions down to 1.
+            assert_equal(test_node.last_sendcmpct[-1].version, 1)
+            test_node.last_sendcmpct = []
 
-        tip = int(self.nodes[0].getbestblockhash(), 16)
+        tip = int(node.getbestblockhash(), 16)
 
         def check_announcement_of_new_block(node, peer, predicate):
             peer.clear_block_announcement()
@@ -165,56 +173,75 @@ class CompactBlocksTest(BitcoinTestFramework):
                 assert(predicate(peer))
 
         # We shouldn't get any block announcements via cmpctblock yet.
-        check_announcement_of_new_block(self.nodes[0], self.test_node, lambda p: p.last_cmpctblock is None)
+        check_announcement_of_new_block(node, test_node, lambda p: p.last_cmpctblock is None)
 
         # Try one more time, this time after requesting headers.
-        self.test_node.request_headers_and_sync(locator=[tip])
-        check_announcement_of_new_block(self.nodes[0], self.test_node, lambda p: p.last_cmpctblock is None and p.last_inv is not None)
+        test_node.request_headers_and_sync(locator=[tip])
+        check_announcement_of_new_block(node, test_node, lambda p: p.last_cmpctblock is None and p.last_inv is not None)
 
         # Test a few ways of using sendcmpct that should NOT
         # result in compact block announcements.
         # Before each test, sync the headers chain.
-        self.test_node.request_headers_and_sync(locator=[tip])
+        test_node.request_headers_and_sync(locator=[tip])
 
         # Now try a SENDCMPCT message with too-high version
         sendcmpct = msg_sendcmpct()
-        sendcmpct.version = 2
-        self.test_node.send_and_ping(sendcmpct)
-        check_announcement_of_new_block(self.nodes[0], self.test_node, lambda p: p.last_cmpctblock is None)
+        sendcmpct.version = preferred_version+1
+        sendcmpct.announce = True
+        test_node.send_and_ping(sendcmpct)
+        check_announcement_of_new_block(node, test_node, lambda p: p.last_cmpctblock is None)
 
         # Headers sync before next test.
-        self.test_node.request_headers_and_sync(locator=[tip])
+        test_node.request_headers_and_sync(locator=[tip])
 
         # Now try a SENDCMPCT message with valid version, but announce=False
-        self.test_node.send_and_ping(msg_sendcmpct())
-        check_announcement_of_new_block(self.nodes[0], self.test_node, lambda p: p.last_cmpctblock is None)
+        sendcmpct.version = preferred_version
+        sendcmpct.announce = False
+        test_node.send_and_ping(sendcmpct)
+        check_announcement_of_new_block(node, test_node, lambda p: p.last_cmpctblock is None)
 
         # Headers sync before next test.
-        self.test_node.request_headers_and_sync(locator=[tip])
+        test_node.request_headers_and_sync(locator=[tip])
 
         # Finally, try a SENDCMPCT message with announce=True
-        sendcmpct.version = 1
+        sendcmpct.version = preferred_version
         sendcmpct.announce = True
-        self.test_node.send_and_ping(sendcmpct)
-        check_announcement_of_new_block(self.nodes[0], self.test_node, lambda p: p.last_cmpctblock is not None)
+        test_node.send_and_ping(sendcmpct)
+        check_announcement_of_new_block(node, test_node, lambda p: p.last_cmpctblock is not None)
 
         # Try one more time (no headers sync should be needed!)
-        check_announcement_of_new_block(self.nodes[0], self.test_node, lambda p: p.last_cmpctblock is not None)
+        check_announcement_of_new_block(node, test_node, lambda p: p.last_cmpctblock is not None)
 
         # Try one more time, after turning on sendheaders
-        self.test_node.send_and_ping(msg_sendheaders())
-        check_announcement_of_new_block(self.nodes[0], self.test_node, lambda p: p.last_cmpctblock is not None)
+        test_node.send_and_ping(msg_sendheaders())
+        check_announcement_of_new_block(node, test_node, lambda p: p.last_cmpctblock is not None)
+
+        # Try one more time, after sending a version-1, announce=false message.
+        sendcmpct.version = preferred_version-1
+        sendcmpct.announce = False
+        test_node.send_and_ping(sendcmpct)
+        check_announcement_of_new_block(node, test_node, lambda p: p.last_cmpctblock is not None)
 
         # Now turn off announcements
+        sendcmpct.version = preferred_version
         sendcmpct.announce = False
-        self.test_node.send_and_ping(sendcmpct)
-        check_announcement_of_new_block(self.nodes[0], self.test_node, lambda p: p.last_cmpctblock is None and p.last_headers is not None)
+        test_node.send_and_ping(sendcmpct)
+        check_announcement_of_new_block(node, test_node, lambda p: p.last_cmpctblock is None and p.last_headers is not None)
+
+        if old_node is not None:
+            # Verify that a peer using an older protocol version can receive
+            # announcements from this node.
+            sendcmpct.version = preferred_version-1
+            sendcmpct.announce = True
+            old_node.send_and_ping(sendcmpct)
+            # Header sync
+            old_node.request_headers_and_sync(locator=[tip])
+            check_announcement_of_new_block(node, old_node, lambda p: p.last_cmpctblock is not None)
 
     # This test actually causes bitcoind to (reasonably!) disconnect us, so do this last.
     def test_invalid_cmpctblock_message(self):
-        print("Testing invalid index in cmpctblock message...")
         self.nodes[0].generate(101)
-        block = self.build_block_on_tip()
+        block = self.build_block_on_tip(self.nodes[0])
 
         cmpct_block = P2PHeaderAndShortIDs()
         cmpct_block.header = CBlockHeader(block)
@@ -227,45 +254,61 @@ class CompactBlocksTest(BitcoinTestFramework):
 
     # Compare the generated shortids to what we expect based on BIP 152, given
     # bitcoind's choice of nonce.
-    def test_compactblock_construction(self):
-        print("Testing compactblock headers and shortIDs are correct...")
-
+    def test_compactblock_construction(self, node, test_node, version, use_witness_address):
         # Generate a bunch of transactions.
-        self.nodes[0].generate(101)
+        node.generate(101)
         num_transactions = 25
-        address = self.nodes[0].getnewaddress()
+        address = node.getnewaddress()
+        if use_witness_address:
+            # Want at least one segwit spend, so move all funds to
+            # a witness address.
+            address = node.addwitnessaddress(address)
+            value_to_send = node.getbalance()
+            node.sendtoaddress(address, satoshi_round(value_to_send-Decimal(0.1)))
+            node.generate(1)
+
+        segwit_tx_generated = False
         for i in range(num_transactions):
-            self.nodes[0].sendtoaddress(address, 0.1)
+            txid = node.sendtoaddress(address, 0.1)
+            hex_tx = node.gettransaction(txid)["hex"]
+            tx = FromHex(CTransaction(), hex_tx)
+            if not tx.wit.is_null():
+                segwit_tx_generated = True
+
+        if use_witness_address:
+            assert(segwit_tx_generated) # check that our test is not broken
 
         self.test_node.sync_with_ping()
 
         # Now mine a block, and look at the resulting compact block.
-        self.test_node.clear_block_announcement()
-        block_hash = int(self.nodes[0].generate(1)[0], 16)
+        test_node.clear_block_announcement()
+        block_hash = int(node.generate(1)[0], 16)
 
         # Store the raw block in our internal format.
-        block = FromHex(CBlock(), self.nodes[0].getblock("%02x" % block_hash, False))
+        block = FromHex(CBlock(), node.getblock("%02x" % block_hash, False))
         [tx.calc_sha256() for tx in block.vtx]
         block.rehash()
 
         # Don't care which type of announcement came back for this test; just
         # request the compact block if we didn't get one yet.
-        wait_until(self.test_node.received_block_announcement, timeout=30)
+        wait_until(test_node.received_block_announcement, timeout=30)
+        assert(test_node.received_block_announcement())
 
         with mininode_lock:
-            if self.test_node.last_cmpctblock is None:
-                self.test_node.clear_block_announcement()
+            if test_node.last_cmpctblock is None:
+                test_node.clear_block_announcement()
                 inv = CInv(4, block_hash)  # 4 == "CompactBlock"
-                self.test_node.send_message(msg_getdata([inv]))
+                test_node.send_message(msg_getdata([inv]))
 
-        wait_until(self.test_node.received_block_announcement, timeout=30)
+        wait_until(test_node.received_block_announcement, timeout=30)
+        assert(test_node.received_block_announcement())
 
         # Now we should have the compactblock
         header_and_shortids = None
         with mininode_lock:
-            assert(self.test_node.last_cmpctblock is not None)
+            assert(test_node.last_cmpctblock is not None)
             # Convert the on-the-wire representation to absolute indexes
-            header_and_shortids = HeaderAndShortIDs(self.test_node.last_cmpctblock.header_and_shortids)
+            header_and_shortids = HeaderAndShortIDs(test_node.last_cmpctblock.header_and_shortids)
 
         # Check that we got the right block!
         header_and_shortids.header.calc_sha256()
@@ -278,7 +321,16 @@ class CompactBlocksTest(BitcoinTestFramework):
         # Check that all prefilled_txn entries match what's in the block.
         for entry in header_and_shortids.prefilled_txn:
             entry.tx.calc_sha256()
+            # This checks the non-witness parts of the tx agree
             assert_equal(entry.tx.sha256, block.vtx[entry.index].sha256)
+
+            # And this checks the witness
+            wtxid = entry.tx.calc_sha256(True)
+            if version == 2:
+                assert_equal(wtxid, block.vtx[entry.index].calc_sha256(True))
+            else:
+                # Shouldn't have received a witness
+                assert(entry.tx.wit.is_null())
 
         # Check that the cmpctblock message announced all the transactions.
         assert_equal(len(header_and_shortids.prefilled_txn) + len(header_and_shortids.shortids), len(block.vtx))
@@ -294,7 +346,10 @@ class CompactBlocksTest(BitcoinTestFramework):
                 # Already checked prefilled transactions above
                 header_and_shortids.prefilled_txn.pop(0)
             else:
-                shortid = calculate_shortid(k0, k1, block.vtx[index].sha256)
+                tx_hash = block.vtx[index].sha256
+                if version == 2:
+                    tx_hash = block.vtx[index].calc_sha256(True)
+                shortid = calculate_shortid(k0, k1, tx_hash)
                 assert_equal(shortid, header_and_shortids.shortids[0])
                 header_and_shortids.shortids.pop(0)
             index += 1
@@ -302,49 +357,50 @@ class CompactBlocksTest(BitcoinTestFramework):
     # Test that bitcoind requests compact blocks when we announce new blocks
     # via header or inv, and that responding to getblocktxn causes the block
     # to be successfully reconstructed.
-    def test_compactblock_requests(self):
-        print("Testing compactblock requests... ")
-
+    # Post-segwit: upgraded nodes would only make this request of cb-version-2,
+    # NODE_WITNESS peers.  Unupgraded nodes would still make this request of
+    # any cb-version-1-supporting peer.
+    def test_compactblock_requests(self, node, test_node):
         # Try announcing a block with an inv or header, expect a compactblock
         # request
         for announce in ["inv", "header"]:
-            block = self.build_block_on_tip()
+            block = self.build_block_on_tip(node)
             with mininode_lock:
-                self.test_node.last_getdata = None
+                test_node.last_getdata = None
 
             if announce == "inv":
-                self.test_node.send_message(msg_inv([CInv(2, block.sha256)]))
+                test_node.send_message(msg_inv([CInv(2, block.sha256)]))
             else:
-                self.test_node.send_header_for_blocks([block])
-            success = wait_until(lambda: self.test_node.last_getdata is not None, timeout=30)
+                test_node.send_header_for_blocks([block])
+            success = wait_until(lambda: test_node.last_getdata is not None, timeout=30)
             assert(success)
-            assert_equal(len(self.test_node.last_getdata.inv), 1)
-            assert_equal(self.test_node.last_getdata.inv[0].type, 4)
-            assert_equal(self.test_node.last_getdata.inv[0].hash, block.sha256)
+            assert_equal(len(test_node.last_getdata.inv), 1)
+            assert_equal(test_node.last_getdata.inv[0].type, 4)
+            assert_equal(test_node.last_getdata.inv[0].hash, block.sha256)
 
             # Send back a compactblock message that omits the coinbase
             comp_block = HeaderAndShortIDs()
             comp_block.header = CBlockHeader(block)
             comp_block.nonce = 0
             comp_block.shortids = [1]  # this is useless, and wrong
-            self.test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
-            assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.hashPrevBlock)
+            test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
+            assert_equal(int(node.getbestblockhash(), 16), block.hashPrevBlock)
             # Expect a getblocktxn message.
             with mininode_lock:
-                assert(self.test_node.last_getblocktxn is not None)
-                absolute_indexes = self.test_node.last_getblocktxn.block_txn_request.to_absolute()
+                assert(test_node.last_getblocktxn is not None)
+                absolute_indexes = test_node.last_getblocktxn.block_txn_request.to_absolute()
             assert_equal(absolute_indexes, [0])  # should be a coinbase request
 
             # Send the coinbase, and verify that the tip advances.
             msg = msg_blocktxn()
             msg.block_transactions.blockhash = block.sha256
             msg.block_transactions.transactions = [block.vtx[0]]
-            self.test_node.send_and_ping(msg)
-            assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.sha256)
+            test_node.send_and_ping(msg)
+            assert_equal(int(node.getbestblockhash(), 16), block.sha256)
 
     # Create a chain of transactions from given utxo, and add to a new block.
-    def build_block_with_transactions(self, utxo, num_transactions):
-        block = self.build_block_on_tip()
+    def build_block_with_transactions(self, node, utxo, num_transactions):
+        block = self.build_block_on_tip(node)
 
         for i in range(num_transactions):
             tx = CTransaction()
@@ -361,118 +417,113 @@ class CompactBlocksTest(BitcoinTestFramework):
     # Test that we only receive getblocktxn requests for transactions that the
     # node needs, and that responding to them causes the block to be
     # reconstructed.
-    def test_getblocktxn_requests(self):
-        print("Testing getblocktxn requests...")
+    def test_getblocktxn_requests(self, node, test_node, version):
+        with_witness = (version==2)
+
+        def test_getblocktxn_response(compact_block, peer, expected_result):
+            msg = msg_cmpctblock(compact_block.to_p2p())
+            peer.send_and_ping(msg)
+            with mininode_lock:
+                assert(peer.last_getblocktxn is not None)
+                absolute_indexes = peer.last_getblocktxn.block_txn_request.to_absolute()
+            assert_equal(absolute_indexes, expected_result)
+
+        def test_tip_after_message(node, peer, msg, tip):
+            peer.send_and_ping(msg)
+            assert_equal(int(node.getbestblockhash(), 16), tip)
 
         # First try announcing compactblocks that won't reconstruct, and verify
         # that we receive getblocktxn messages back.
         utxo = self.utxos.pop(0)
 
-        block = self.build_block_with_transactions(utxo, 5)
+        block = self.build_block_with_transactions(node, utxo, 5)
         self.utxos.append([block.vtx[-1].sha256, 0, block.vtx[-1].vout[0].nValue])
-
         comp_block = HeaderAndShortIDs()
-        comp_block.initialize_from_block(block)
+        comp_block.initialize_from_block(block, use_witness=with_witness)
 
-        self.test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
-        with mininode_lock:
-            assert(self.test_node.last_getblocktxn is not None)
-            absolute_indexes = self.test_node.last_getblocktxn.block_txn_request.to_absolute()
-        assert_equal(absolute_indexes, [1, 2, 3, 4, 5])
-        msg = msg_blocktxn()
-        msg.block_transactions = BlockTransactions(block.sha256, block.vtx[1:])
-        self.test_node.send_and_ping(msg)
-        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.sha256)
+        test_getblocktxn_response(comp_block, test_node, [1, 2, 3, 4, 5])
+
+        msg_bt = msg_blocktxn()
+        if with_witness:
+            msg_bt = msg_witness_blocktxn() # serialize with witnesses
+        msg_bt.block_transactions = BlockTransactions(block.sha256, block.vtx[1:])
+        test_tip_after_message(node, test_node, msg_bt, block.sha256)
 
         utxo = self.utxos.pop(0)
-        block = self.build_block_with_transactions(utxo, 5)
+        block = self.build_block_with_transactions(node, utxo, 5)
         self.utxos.append([block.vtx[-1].sha256, 0, block.vtx[-1].vout[0].nValue])
 
         # Now try interspersing the prefilled transactions
-        comp_block.initialize_from_block(block, prefill_list=[0, 1, 5])
-        self.test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
-        with mininode_lock:
-            assert(self.test_node.last_getblocktxn is not None)
-            absolute_indexes = self.test_node.last_getblocktxn.block_txn_request.to_absolute()
-        assert_equal(absolute_indexes, [2, 3, 4])
-        msg.block_transactions = BlockTransactions(block.sha256, block.vtx[2:5])
-        self.test_node.send_and_ping(msg)
-        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.sha256)
+        comp_block.initialize_from_block(block, prefill_list=[0, 1, 5], use_witness=with_witness)
+        test_getblocktxn_response(comp_block, test_node, [2, 3, 4])
+        msg_bt.block_transactions = BlockTransactions(block.sha256, block.vtx[2:5])
+        test_tip_after_message(node, test_node, msg_bt, block.sha256)
 
         # Now try giving one transaction ahead of time.
         utxo = self.utxos.pop(0)
-        block = self.build_block_with_transactions(utxo, 5)
+        block = self.build_block_with_transactions(node, utxo, 5)
         self.utxos.append([block.vtx[-1].sha256, 0, block.vtx[-1].vout[0].nValue])
-        self.test_node.send_and_ping(msg_tx(block.vtx[1]))
-        assert(block.vtx[1].hash in self.nodes[0].getrawmempool())
+        test_node.send_and_ping(msg_tx(block.vtx[1]))
+        assert(block.vtx[1].hash in node.getrawmempool())
 
         # Prefill 4 out of the 6 transactions, and verify that only the one
         # that was not in the mempool is requested.
-        comp_block.initialize_from_block(block, prefill_list=[0, 2, 3, 4])
-        self.test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
-        with mininode_lock:
-            assert(self.test_node.last_getblocktxn is not None)
-            absolute_indexes = self.test_node.last_getblocktxn.block_txn_request.to_absolute()
-        assert_equal(absolute_indexes, [5])
+        comp_block.initialize_from_block(block, prefill_list=[0, 2, 3, 4], use_witness=with_witness)
+        test_getblocktxn_response(comp_block, test_node, [5])
 
-        msg.block_transactions = BlockTransactions(block.sha256, [block.vtx[5]])
-        self.test_node.send_and_ping(msg)
-        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.sha256)
+        msg_bt.block_transactions = BlockTransactions(block.sha256, [block.vtx[5]])
+        test_tip_after_message(node, test_node, msg_bt, block.sha256)
 
         # Now provide all transactions to the node before the block is
         # announced and verify reconstruction happens immediately.
         utxo = self.utxos.pop(0)
-        block = self.build_block_with_transactions(utxo, 10)
+        block = self.build_block_with_transactions(node, utxo, 10)
         self.utxos.append([block.vtx[-1].sha256, 0, block.vtx[-1].vout[0].nValue])
         for tx in block.vtx[1:]:
-            self.test_node.send_message(msg_tx(tx))
-        self.test_node.sync_with_ping()
+            test_node.send_message(msg_tx(tx))
+        test_node.sync_with_ping()
         # Make sure all transactions were accepted.
-        mempool = self.nodes[0].getrawmempool()
+        mempool = node.getrawmempool()
         for tx in block.vtx[1:]:
             assert(tx.hash in mempool)
 
         # Clear out last request.
         with mininode_lock:
-            self.test_node.last_getblocktxn = None
+            test_node.last_getblocktxn = None
 
         # Send compact block
-        comp_block.initialize_from_block(block, prefill_list=[0])
-        self.test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
+        comp_block.initialize_from_block(block, prefill_list=[0], use_witness=with_witness)
+        test_tip_after_message(node, test_node, msg_cmpctblock(comp_block.to_p2p()), block.sha256)
         with mininode_lock:
             # Shouldn't have gotten a request for any transaction
-            assert(self.test_node.last_getblocktxn is None)
-        # Tip should have updated
-        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.sha256)
+            assert(test_node.last_getblocktxn is None)
 
     # Incorrectly responding to a getblocktxn shouldn't cause the block to be
     # permanently failed.
-    def test_incorrect_blocktxn_response(self):
-        print("Testing handling of incorrect blocktxn responses...")
-
+    def test_incorrect_blocktxn_response(self, node, test_node, version):
         if (len(self.utxos) == 0):
             self.make_utxos()
         utxo = self.utxos.pop(0)
 
-        block = self.build_block_with_transactions(utxo, 10)
+        block = self.build_block_with_transactions(node, utxo, 10)
         self.utxos.append([block.vtx[-1].sha256, 0, block.vtx[-1].vout[0].nValue])
         # Relay the first 5 transactions from the block in advance
         for tx in block.vtx[1:6]:
-            self.test_node.send_message(msg_tx(tx))
-        self.test_node.sync_with_ping()
+            test_node.send_message(msg_tx(tx))
+        test_node.sync_with_ping()
         # Make sure all transactions were accepted.
-        mempool = self.nodes[0].getrawmempool()
+        mempool = node.getrawmempool()
         for tx in block.vtx[1:6]:
             assert(tx.hash in mempool)
 
         # Send compact block
         comp_block = HeaderAndShortIDs()
-        comp_block.initialize_from_block(block, prefill_list=[0])
-        self.test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
+        comp_block.initialize_from_block(block, prefill_list=[0], use_witness=(version == 2))
+        test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
         absolute_indexes = []
         with mininode_lock:
-            assert(self.test_node.last_getblocktxn is not None)
-            absolute_indexes = self.test_node.last_getblocktxn.block_txn_request.to_absolute()
+            assert(test_node.last_getblocktxn is not None)
+            absolute_indexes = test_node.last_getblocktxn.block_txn_request.to_absolute()
         assert_equal(absolute_indexes, [6, 7, 8, 9, 10])
 
         # Now give an incorrect response.
@@ -484,100 +535,107 @@ class CompactBlocksTest(BitcoinTestFramework):
         # verifying that the block isn't marked bad permanently. This is good
         # enough for now.
         msg = msg_blocktxn()
+        if version==2:
+            msg = msg_witness_blocktxn()
         msg.block_transactions = BlockTransactions(block.sha256, [block.vtx[5]] + block.vtx[7:])
-        self.test_node.send_and_ping(msg)
+        test_node.send_and_ping(msg)
 
         # Tip should not have updated
-        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.hashPrevBlock)
+        assert_equal(int(node.getbestblockhash(), 16), block.hashPrevBlock)
 
         # We should receive a getdata request
-        success = wait_until(lambda: self.test_node.last_getdata is not None, timeout=10)
+        success = wait_until(lambda: test_node.last_getdata is not None, timeout=10)
         assert(success)
-        assert_equal(len(self.test_node.last_getdata.inv), 1)
-        assert_equal(self.test_node.last_getdata.inv[0].type, 2)
-        assert_equal(self.test_node.last_getdata.inv[0].hash, block.sha256)
+        assert_equal(len(test_node.last_getdata.inv), 1)
+        assert(test_node.last_getdata.inv[0].type == 2 or test_node.last_getdata.inv[0].type == 2|MSG_WITNESS_FLAG)
+        assert_equal(test_node.last_getdata.inv[0].hash, block.sha256)
 
         # Deliver the block
-        self.test_node.send_and_ping(msg_block(block))
-        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.sha256)
+        if version==2:
+            test_node.send_and_ping(msg_witness_block(block))
+        else:
+            test_node.send_and_ping(msg_block(block))
+        assert_equal(int(node.getbestblockhash(), 16), block.sha256)
 
-    def test_getblocktxn_handler(self):
-        print("Testing getblocktxn handler...")
-
+    def test_getblocktxn_handler(self, node, test_node, version):
         # bitcoind won't respond for blocks whose height is more than 15 blocks
         # deep.
         MAX_GETBLOCKTXN_DEPTH = 15
-        chain_height = self.nodes[0].getblockcount()
+        chain_height = node.getblockcount()
         current_height = chain_height
         while (current_height >= chain_height - MAX_GETBLOCKTXN_DEPTH):
-            block_hash = self.nodes[0].getblockhash(current_height)
-            block = FromHex(CBlock(), self.nodes[0].getblock(block_hash, False))
+            block_hash = node.getblockhash(current_height)
+            block = FromHex(CBlock(), node.getblock(block_hash, False))
 
             msg = msg_getblocktxn()
             msg.block_txn_request = BlockTransactionsRequest(int(block_hash, 16), [])
             num_to_request = random.randint(1, len(block.vtx))
             msg.block_txn_request.from_absolute(sorted(random.sample(range(len(block.vtx)), num_to_request)))
-            self.test_node.send_message(msg)
-            success = wait_until(lambda: self.test_node.last_blocktxn is not None, timeout=10)
+            test_node.send_message(msg)
+            success = wait_until(lambda: test_node.last_blocktxn is not None, timeout=10)
             assert(success)
 
             [tx.calc_sha256() for tx in block.vtx]
             with mininode_lock:
-                assert_equal(self.test_node.last_blocktxn.block_transactions.blockhash, int(block_hash, 16))
+                assert_equal(test_node.last_blocktxn.block_transactions.blockhash, int(block_hash, 16))
                 all_indices = msg.block_txn_request.to_absolute()
                 for index in all_indices:
-                    tx = self.test_node.last_blocktxn.block_transactions.transactions.pop(0)
+                    tx = test_node.last_blocktxn.block_transactions.transactions.pop(0)
                     tx.calc_sha256()
                     assert_equal(tx.sha256, block.vtx[index].sha256)
-                self.test_node.last_blocktxn = None
+                    if version == 1:
+                        # Witnesses should have been stripped
+                        assert(tx.wit.is_null())
+                    else:
+                        # Check that the witness matches
+                        assert_equal(tx.calc_sha256(True), block.vtx[index].calc_sha256(True))
+                test_node.last_blocktxn = None
             current_height -= 1
 
         # Next request should be ignored, as we're past the allowed depth.
-        block_hash = self.nodes[0].getblockhash(current_height)
+        block_hash = node.getblockhash(current_height)
         msg.block_txn_request = BlockTransactionsRequest(int(block_hash, 16), [0])
-        self.test_node.send_and_ping(msg)
+        test_node.send_and_ping(msg)
         with mininode_lock:
-            assert_equal(self.test_node.last_blocktxn, None)
+            assert_equal(test_node.last_blocktxn, None)
 
-    def test_compactblocks_not_at_tip(self):
-        print("Testing compactblock requests/announcements not at chain tip...")
-
+    def test_compactblocks_not_at_tip(self, node, test_node):
         # Test that requesting old compactblocks doesn't work.
         MAX_CMPCTBLOCK_DEPTH = 11
         new_blocks = []
         for i in range(MAX_CMPCTBLOCK_DEPTH):
-            self.test_node.clear_block_announcement()
-            new_blocks.append(self.nodes[0].generate(1)[0])
-            wait_until(self.test_node.received_block_announcement, timeout=30)
+            test_node.clear_block_announcement()
+            new_blocks.append(node.generate(1)[0])
+            wait_until(test_node.received_block_announcement, timeout=30)
 
-        self.test_node.clear_block_announcement()
-        self.test_node.send_message(msg_getdata([CInv(4, int(new_blocks[0], 16))]))
-        success = wait_until(lambda: self.test_node.last_cmpctblock is not None, timeout=30)
+        test_node.clear_block_announcement()
+        test_node.send_message(msg_getdata([CInv(4, int(new_blocks[0], 16))]))
+        success = wait_until(lambda: test_node.last_cmpctblock is not None, timeout=30)
         assert(success)
 
-        self.test_node.clear_block_announcement()
-        self.nodes[0].generate(1)
-        wait_until(self.test_node.received_block_announcement, timeout=30)
-        self.test_node.clear_block_announcement()
-        self.test_node.send_message(msg_getdata([CInv(4, int(new_blocks[0], 16))]))
-        success = wait_until(lambda: self.test_node.last_block is not None, timeout=30)
+        test_node.clear_block_announcement()
+        node.generate(1)
+        wait_until(test_node.received_block_announcement, timeout=30)
+        test_node.clear_block_announcement()
+        test_node.send_message(msg_getdata([CInv(4, int(new_blocks[0], 16))]))
+        success = wait_until(lambda: test_node.last_block is not None, timeout=30)
         assert(success)
         with mininode_lock:
-            self.test_node.last_block.block.calc_sha256()
-            assert_equal(self.test_node.last_block.block.sha256, int(new_blocks[0], 16))
+            test_node.last_block.block.calc_sha256()
+            assert_equal(test_node.last_block.block.sha256, int(new_blocks[0], 16))
 
         # Generate an old compactblock, and verify that it's not accepted.
-        cur_height = self.nodes[0].getblockcount()
-        hashPrevBlock = int(self.nodes[0].getblockhash(cur_height-5), 16)
-        block = self.build_block_on_tip()
+        cur_height = node.getblockcount()
+        hashPrevBlock = int(node.getblockhash(cur_height-5), 16)
+        block = self.build_block_on_tip(node)
         block.hashPrevBlock = hashPrevBlock
         block.solve()
 
         comp_block = HeaderAndShortIDs()
         comp_block.initialize_from_block(block)
-        self.test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
+        test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
 
-        tips = self.nodes[0].getchaintips()
+        tips = node.getchaintips()
         found = False
         for x in tips:
             if x["hash"] == block.hash:
@@ -591,18 +649,61 @@ class CompactBlocksTest(BitcoinTestFramework):
         msg = msg_getblocktxn()
         msg.block_txn_request = BlockTransactionsRequest(block.sha256, [0])
         with mininode_lock:
-            self.test_node.last_blocktxn = None
-        self.test_node.send_and_ping(msg)
+            test_node.last_blocktxn = None
+        test_node.send_and_ping(msg)
         with mininode_lock:
-            assert(self.test_node.last_blocktxn is None)
+            assert(test_node.last_blocktxn is None)
+
+    def activate_segwit(self, node):
+        node.generate(144*3)
+        assert_equal(get_bip9_status(node, "segwit")["status"], 'active')
+
+    def test_end_to_end_block_relay(self, node, listeners):
+        utxo = self.utxos.pop(0)
+
+        block = self.build_block_with_transactions(node, utxo, 10)
+
+        [l.clear_block_announcement() for l in listeners]
+
+        # ToHex() won't serialize with witness, but this block has no witnesses
+        # anyway. TODO: repeat this test with witness tx's to a segwit node.
+        node.submitblock(ToHex(block))
+
+        for l in listeners:
+            wait_until(lambda: l.received_block_announcement(), timeout=30)
+        with mininode_lock:
+            for l in listeners:
+                assert(l.last_cmpctblock is not None)
+                l.last_cmpctblock.header_and_shortids.header.calc_sha256()
+                assert_equal(l.last_cmpctblock.header_and_shortids.header.sha256, block.sha256)
+
+    # Helper for enabling cb announcements
+    # Send the sendcmpct request and sync headers
+    def request_cb_announcements(self, peer, node, version):
+        tip = node.getbestblockhash()
+        peer.get_headers(locator=[int(tip, 16)], hashstop=0)
+
+        msg = msg_sendcmpct()
+        msg.version = version
+        msg.announce = True
+        peer.send_and_ping(msg)
+
 
     def run_test(self):
         # Setup the p2p connections and start up the network thread.
         self.test_node = TestNode()
+        self.segwit_node = TestNode()
+        self.old_node = TestNode()  # version 1 peer <--> segwit node
 
         connections = []
         connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], self.test_node))
+        connections.append(NodeConn('127.0.0.1', p2p_port(1), self.nodes[1],
+                    self.segwit_node, services=NODE_NETWORK|NODE_WITNESS))
+        connections.append(NodeConn('127.0.0.1', p2p_port(1), self.nodes[1],
+                    self.old_node, services=NODE_NETWORK))
         self.test_node.add_connection(connections[0])
+        self.segwit_node.add_connection(connections[1])
+        self.old_node.add_connection(connections[2])
 
         NetworkThread().start()  # Start up network handling in another thread
 
@@ -612,13 +713,107 @@ class CompactBlocksTest(BitcoinTestFramework):
         # We will need UTXOs to construct transactions in later tests.
         self.make_utxos()
 
-        self.test_sendcmpct()
-        self.test_compactblock_construction()
-        self.test_compactblock_requests()
-        self.test_getblocktxn_requests()
-        self.test_getblocktxn_handler()
-        self.test_compactblocks_not_at_tip()
-        self.test_incorrect_blocktxn_response()
+        print("Running tests, pre-segwit activation:")
+
+        print("\tTesting SENDCMPCT p2p message... ")
+        self.test_sendcmpct(self.nodes[0], self.test_node, 1)
+        sync_blocks(self.nodes)
+        self.test_sendcmpct(self.nodes[1], self.segwit_node, 2, old_node=self.old_node)
+        sync_blocks(self.nodes)
+
+        print("\tTesting compactblock construction...")
+        self.test_compactblock_construction(self.nodes[0], self.test_node, 1, False)
+        sync_blocks(self.nodes)
+        self.test_compactblock_construction(self.nodes[1], self.segwit_node, 2, False)
+        sync_blocks(self.nodes)
+
+        print("\tTesting compactblock requests... ")
+        self.test_compactblock_requests(self.nodes[0], self.test_node)
+        sync_blocks(self.nodes)
+        self.test_compactblock_requests(self.nodes[1], self.segwit_node)
+        sync_blocks(self.nodes)
+
+        print("\tTesting getblocktxn requests...")
+        self.test_getblocktxn_requests(self.nodes[0], self.test_node, 1)
+        sync_blocks(self.nodes)
+        self.test_getblocktxn_requests(self.nodes[1], self.segwit_node, 2)
+        sync_blocks(self.nodes)
+
+        print("\tTesting getblocktxn handler...")
+        self.test_getblocktxn_handler(self.nodes[0], self.test_node, 1)
+        sync_blocks(self.nodes)
+        self.test_getblocktxn_handler(self.nodes[1], self.segwit_node, 2)
+        self.test_getblocktxn_handler(self.nodes[1], self.old_node, 1)
+        sync_blocks(self.nodes)
+
+        print("\tTesting compactblock requests/announcements not at chain tip...")
+        self.test_compactblocks_not_at_tip(self.nodes[0], self.test_node)
+        sync_blocks(self.nodes)
+        self.test_compactblocks_not_at_tip(self.nodes[1], self.segwit_node)
+        self.test_compactblocks_not_at_tip(self.nodes[1], self.old_node)
+        sync_blocks(self.nodes)
+
+        print("\tTesting handling of incorrect blocktxn responses...")
+        self.test_incorrect_blocktxn_response(self.nodes[0], self.test_node, 1)
+        sync_blocks(self.nodes)
+        self.test_incorrect_blocktxn_response(self.nodes[1], self.segwit_node, 2)
+        sync_blocks(self.nodes)
+
+        # End-to-end block relay tests
+        print("\tTesting end-to-end block relay...")
+        self.request_cb_announcements(self.test_node, self.nodes[0], 1)
+        self.request_cb_announcements(self.old_node, self.nodes[1], 1)
+        self.request_cb_announcements(self.segwit_node, self.nodes[1], 2)
+        self.test_end_to_end_block_relay(self.nodes[0], [self.segwit_node, self.test_node, self.old_node])
+        self.test_end_to_end_block_relay(self.nodes[1], [self.segwit_node, self.test_node, self.old_node])
+
+        # Advance to segwit activation
+        print ("\nAdvancing to segwit activation\n")
+        self.activate_segwit(self.nodes[1])
+        print ("Running tests, post-segwit activation...")
+
+        print("\tTesting compactblock construction...")
+        self.test_compactblock_construction(self.nodes[1], self.old_node, 1, True)
+        self.test_compactblock_construction(self.nodes[1], self.segwit_node, 2, True)
+        sync_blocks(self.nodes)
+
+        print("\tTesting compactblock requests (unupgraded node)... ")
+        self.test_compactblock_requests(self.nodes[0], self.test_node)
+
+        print("\tTesting getblocktxn requests (unupgraded node)...")
+        self.test_getblocktxn_requests(self.nodes[0], self.test_node, 1)
+
+        # Need to manually sync node0 and node1, because post-segwit activation,
+        # node1 will not download blocks from node0.
+        print("\tSyncing nodes...")
+        assert(self.nodes[0].getbestblockhash() != self.nodes[1].getbestblockhash())
+        while (self.nodes[0].getblockcount() > self.nodes[1].getblockcount()):
+            block_hash = self.nodes[0].getblockhash(self.nodes[1].getblockcount()+1)
+            self.nodes[1].submitblock(self.nodes[0].getblock(block_hash, False))
+        assert_equal(self.nodes[0].getbestblockhash(), self.nodes[1].getbestblockhash())
+
+        print("\tTesting compactblock requests (segwit node)... ")
+        self.test_compactblock_requests(self.nodes[1], self.segwit_node)
+
+        print("\tTesting getblocktxn requests (segwit node)...")
+        self.test_getblocktxn_requests(self.nodes[1], self.segwit_node, 2)
+        sync_blocks(self.nodes)
+
+        print("\tTesting getblocktxn handler (segwit node should return witnesses)...")
+        self.test_getblocktxn_handler(self.nodes[1], self.segwit_node, 2)
+        self.test_getblocktxn_handler(self.nodes[1], self.old_node, 1)
+
+        # Test that if we submitblock to node1, we'll get a compact block
+        # announcement to all peers.
+        # (Post-segwit activation, blocks won't propagate from node0 to node1
+        # automatically, so don't bother testing a block announced to node0.)
+        print("\tTesting end-to-end block relay...")
+        self.request_cb_announcements(self.test_node, self.nodes[0], 1)
+        self.request_cb_announcements(self.old_node, self.nodes[1], 1)
+        self.request_cb_announcements(self.segwit_node, self.nodes[1], 2)
+        self.test_end_to_end_block_relay(self.nodes[1], [self.segwit_node, self.test_node, self.old_node])
+
+        print("\tTesting invalid index in cmpctblock message...")
         self.test_invalid_cmpctblock_message()
 
 

--- a/qa/rpc-tests/p2p-compactblocks.py
+++ b/qa/rpc-tests/p2p-compactblocks.py
@@ -130,8 +130,8 @@ class CompactBlocksTest(BitcoinTestFramework):
 
         # Start up node0 to be a version 1, pre-segwit node.
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
-                [["-prefer-compact-blocks", "-debug", "-logtimemicros=1", "-bip9params=segwit:0:0"],
-                 ["-prefer-compact-blocks", "-debug", "-logtimemicros", "-txindex"]])
+                [["-debug", "-logtimemicros=1", "-bip9params=segwit:0:0"],
+                 ["-debug", "-logtimemicros", "-txindex"]])
         connect_nodes(self.nodes[0], 1)
 
     def build_block_on_tip(self, node, segwit=False):

--- a/qa/rpc-tests/sendheaders.py
+++ b/qa/rpc-tests/sendheaders.py
@@ -365,14 +365,13 @@ class SendHeadersTest(BitcoinTestFramework):
                 if j == 0:
                     # Announce via inv
                     test_node.send_block_inv(tip)
-                    test_node.wait_for_getdata([tip], timeout=5)
+                    test_node.wait_for_getheaders(timeout=5)
+                    # Should have received a getheaders now
+                    test_node.send_header_for_blocks(blocks)
                     # Test that duplicate inv's won't result in duplicate
                     # getdata requests, or duplicate headers announcements
-                    inv_node.send_block_inv(tip)
-                    # Should have received a getheaders as well!
-                    test_node.send_header_for_blocks(blocks)
-                    test_node.wait_for_getdata([x.sha256 for x in blocks[0:-1]], timeout=5)
-                    [ inv_node.send_block_inv(x.sha256) for x in blocks[0:-1] ]
+                    [ inv_node.send_block_inv(x.sha256) for x in blocks ]
+                    test_node.wait_for_getdata([x.sha256 for x in blocks], timeout=5)
                     inv_node.sync_with_ping()
                 else:
                     # Announce via headers

--- a/qa/rpc-tests/test_framework/blocktools.py
+++ b/qa/rpc-tests/test_framework/blocktools.py
@@ -5,7 +5,7 @@
 #
 
 from mininode import *
-from script import CScript, CScriptOp, OP_TRUE
+from script import CScript, CScriptOp
 
 # Create a block (with regtest difficulty)
 def create_block(hashprev, coinbase, nTime=None):
@@ -43,14 +43,14 @@ def create_coinbase(heightAdjust = 0, absoluteHeight = None):
     global counter
     height = absoluteHeight if absoluteHeight is not None else counter+heightAdjust
     coinbase = CTransaction()
-    coinbase.vin.append(CTxIn(COutPoint(0, 0xffffffff),
+    coinbase.vin.append(CTxIn(COutPoint(0, 0xffffffff), 
                 ser_string(serialize_script_num(height)), 0xffffffff))
     counter += 1
     coinbaseoutput = CTxOut()
     coinbaseoutput.nValue = 50*100000000
     halvings = int((height)/150) # regtest
     coinbaseoutput.nValue >>= halvings
-    coinbaseoutput.scriptPubKey = CScript([OP_TRUE])
+    coinbaseoutput.scriptPubKey = ""
     coinbase.vout = [ coinbaseoutput ]
     coinbase.calc_sha256()
     return coinbase

--- a/qa/rpc-tests/test_framework/blocktools.py
+++ b/qa/rpc-tests/test_framework/blocktools.py
@@ -5,7 +5,7 @@
 #
 
 from mininode import *
-from script import CScript, CScriptOp
+from script import CScript, CScriptOp, OP_TRUE, OP_CHECKSIG
 
 # Create a block (with regtest difficulty)
 def create_block(hashprev, coinbase, nTime=None):
@@ -38,19 +38,24 @@ def serialize_script_num(value):
     return r
 
 counter=1
-# Create an anyone-can-spend coinbase transaction, assuming no miner fees
-def create_coinbase(heightAdjust = 0, absoluteHeight = None):
+# Create a coinbase transaction, assuming no miner fees.
+# If pubkey is passed in, the coinbase output will be a P2PK output;
+# otherwise an anyone-can-spend output.
+def create_coinbase(heightAdjust = 0, absoluteHeight = None, pubkey = None):
     global counter
     height = absoluteHeight if absoluteHeight is not None else counter+heightAdjust
     coinbase = CTransaction()
-    coinbase.vin.append(CTxIn(COutPoint(0, 0xffffffff), 
+    coinbase.vin.append(CTxIn(COutPoint(0, 0xffffffff),
                 ser_string(serialize_script_num(height)), 0xffffffff))
     counter += 1
     coinbaseoutput = CTxOut()
     coinbaseoutput.nValue = 50*100000000
     halvings = int((height)/150) # regtest
     coinbaseoutput.nValue >>= halvings
-    coinbaseoutput.scriptPubKey = ""
+    if (pubkey != None):
+        coinbaseoutput.scriptPubKey = CScript([pubkey, OP_CHECKSIG])
+    else:
+        coinbaseoutput.scriptPubKey = CScript([OP_TRUE])
     coinbase.vout = [ coinbaseoutput ]
     coinbase.calc_sha256()
     return coinbase

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -49,6 +49,7 @@ BITCOIN_TESTS =\
   test/Checkpoints_tests.cpp \
   test/clientversion_tests.cpp \
   test/coins_tests.cpp \
+  test/compactblockprocessor_tests.cpp \
   test/compactprefiller_tests.cpp \
   test/compactthin_tests.cpp \
   test/compacttxfinder_tests.cpp \

--- a/src/blockannounce.cpp
+++ b/src/blockannounce.cpp
@@ -85,11 +85,6 @@ BlockAnnounceReceiver::DownloadStrategy BlockAnnounceReceiver::pickDownloadStrat
         return DONT_DOWNL;
     }
 
-    if (!state->thinblock->isAvailable()) {
-        LogPrint("thin", "peer %d is busy with %s, won't req %s\n",
-                from.id, state->thinblock->blockStr(), block.ToString());
-        return DOWNL_THIN_LATER;
-    }
     return DOWNL_THIN_NOW;
 }
 
@@ -117,7 +112,7 @@ bool BlockAnnounceReceiver::onBlockAnnounced(std::vector<CInv>& toFetch) {
             block.ToString(), from.id, (numDownloading + 1), Opt().ThinBlocksMaxParallel());
 
         nodestate->thinblock->requestBlock(block, toFetch, from);
-        nodestate->thinblock->setToWork(block);
+        nodestate->thinblock->addWork(block);
         return true;
     }
 

--- a/src/blockannounce.cpp
+++ b/src/blockannounce.cpp
@@ -50,6 +50,7 @@ bool BlockAnnounceReceiver::almostSynced() {
 
 BlockAnnounceReceiver::DownloadStrategy BlockAnnounceReceiver::pickDownloadStrategy() {
 
+
     if (!almostSynced())
         return DONT_DOWNL;
 

--- a/src/blockannounce.cpp
+++ b/src/blockannounce.cpp
@@ -73,7 +73,7 @@ BlockAnnounceReceiver::DownloadStrategy BlockAnnounceReceiver::pickDownloadStrat
             return DONT_DOWNL;
         }
 
-        return blockHeaderIsKnown() ? DOWNL_FULL_NOW : DONT_DOWNL;
+        return DOWNL_FULL_NOW;
     }
 
     // At this point we know we want a thin block.

--- a/src/blockannounce.cpp
+++ b/src/blockannounce.cpp
@@ -73,7 +73,7 @@ BlockAnnounceReceiver::DownloadStrategy BlockAnnounceReceiver::pickDownloadStrat
             return DONT_DOWNL;
         }
 
-        return DOWNL_FULL_NOW;
+        return blockHeaderIsKnown() ? DOWNL_FULL_NOW : DONT_DOWNL;
     }
 
     // At this point we know we want a thin block.
@@ -121,7 +121,7 @@ bool BlockAnnounceReceiver::onBlockAnnounced(std::vector<CInv>& toFetch) {
     // the full block arrives, the header chain leading up to it is already
     // validated. Not doing this will result in block being discarded and
     // re-downloaded later.
-    if (!hasBlockData() && !blocksInFlight.isInFlight(block))
+    if (!hasBlockData() && !blockHeaderIsKnown() && !blocksInFlight.isInFlight(block))
         requestHeaders(from, block);
 
     if (s == DONT_DOWNL)

--- a/src/blockencodings.h
+++ b/src/blockencodings.h
@@ -164,6 +164,7 @@ public:
 };
 
 unsigned int minTxSize();
+void validateNumTxs(size_t transactions, uint64_t currMaxBlockSize);
 void validateCompactBlock(const CompactBlock& cmpctblock, uint64_t currMaxBlockSize);
 
 #endif

--- a/src/blockprocessor.cpp
+++ b/src/blockprocessor.cpp
@@ -26,8 +26,11 @@ bool BlockProcessor::processHeader(const CBlockHeader& header) {
 
         std::vector<CBlockHeader> h(1, header);
 
-        if (!headerProcessor(h, false, false)) {
-            rejectBlock(header.GetHash(), "invalid header", 20);
+        try {
+            headerProcessor(h, false, false);
+        }
+        catch (const BlockHeaderError& e) {
+            rejectBlock(header.GetHash(), e.what(), 20);
             return false;
         }
         return true;

--- a/src/blockprocessor.h
+++ b/src/blockprocessor.h
@@ -7,6 +7,7 @@ class ThinBlockWorker;
 class BlockHeaderProcessor;
 class CBlockHeader;
 class uint256;
+class CBlockIndex;
 
 class BlockProcessor {
 
@@ -19,14 +20,14 @@ class BlockProcessor {
 
         virtual ~BlockProcessor() = 0;
         void rejectBlock(const uint256& block, const std::string& reason, int misbehave);
-        bool processHeader(const CBlockHeader& header);
-        bool setToWork(const uint256& hash);
+        bool setToWork(const CBlockHeader& hash, int activeChainHeight);
 
     protected:
         CNode& from;
         ThinBlockWorker& worker;
         virtual void misbehave(int howmuch);
         bool requestConnectHeaders(const CBlockHeader&);
+        CBlockIndex* processHeader(const CBlockHeader& header, bool maybeAnnouncement);
 
     private:
         std::string netcmd;

--- a/src/blocksender.h
+++ b/src/blocksender.h
@@ -27,7 +27,7 @@ class BlockSender {
         void send(const CChain& activeChain, CNode& node,
             CBlockIndex& blockIndex, const CInv& inv);
 
-        void sendBlock(CNode& node,
+        virtual void sendBlock(CNode& node,
             const CBlockIndex& blockIndex, int invType, int activeChainHeight);
 
         // Creates a response for a re-request for transactions missing

--- a/src/blocksender.h
+++ b/src/blocksender.h
@@ -33,12 +33,12 @@ class BlockSender {
         // Creates a response for a re-request for transactions missing
         // from a thin block.
         void sendReReqReponse(CNode& node, const CBlockIndex& blockIndex,
-            const XThinReRequest& req);
+            const XThinReRequest& req, int activeChainHeight);
 
         // Creates a response for a re-request for transactions missing
         // from a compact thin block.
         void sendReReqReponse(CNode& node, const CBlockIndex& blockIndex,
-            const CompactReRequest& req);
+            const CompactReRequest& req, int activeChainHeight);
 
     protected: // used in unit tests
         void triggerNextRequest(const CChain& activeChain, const CInv& inv, CNode& node);

--- a/src/compactblockprocessor.cpp
+++ b/src/compactblockprocessor.cpp
@@ -48,7 +48,7 @@ void CompactBlockProcessor::operator()(CDataStream& vRecv, const CTxMemPool& mem
                 block.shorttxidk0, block.shorttxidk1);
 
         stub.reset(new CompactStub(block));
-        worker.buildStub(*stub, txfinder);
+        worker.buildStub(*stub, txfinder, from);
     }
     catch (const thinblock_error& e) {
         rejectBlock(hash, e.what(), 10);

--- a/src/compactblockprocessor.cpp
+++ b/src/compactblockprocessor.cpp
@@ -10,7 +10,7 @@
 #include "compacttxfinder.h"
 
 void CompactBlockProcessor::operator()(CDataStream& vRecv, const CTxMemPool& mempool,
-        uint64_t currMaxBlockSize)
+        uint64_t currMaxBlockSize, int activeChainHeight)
 {
     CompactBlock block;
     vRecv >> block;
@@ -34,13 +34,10 @@ void CompactBlockProcessor::operator()(CDataStream& vRecv, const CTxMemPool& mem
         return;
     }
 
-    if (!processHeader(block.header))
+    if (!setToWork(block.header, activeChainHeight))
         return;
 
     from.AddInventoryKnown(CInv(MSG_CMPCT_BLOCK, hash));
-
-    if (!setToWork(hash))
-        return;
 
     std::unique_ptr<CompactStub> stub;
     try {

--- a/src/compactblockprocessor.h
+++ b/src/compactblockprocessor.h
@@ -15,7 +15,7 @@ class CompactBlockProcessor : public BlockProcessor {
         }
 
         void operator()(CDataStream& vRecv, const CTxMemPool& mempool,
-                uint64_t currMaxBlockSize);
+                uint64_t currMaxBlockSize, int activeChainHeight);
 };
 
 #endif

--- a/src/compactthin.h
+++ b/src/compactthin.h
@@ -20,6 +20,7 @@ class CompactWorker : public ThinBlockWorker {
 
         void requestBlock(const uint256& block,
                 std::vector<CInv>& getDataReq, CNode& node) override;
+        std::unique_ptr<BlockAnnHandle> requestBlockAnnouncements(CNode& n) override;
 };
 
 
@@ -49,5 +50,7 @@ struct CompactStub : public StubData {
     private:
         CompactBlock block;
 };
+
+void enableCompactBlocks(CNode& node, bool highBandwidth);
 
 #endif

--- a/src/dummythin.h
+++ b/src/dummythin.h
@@ -13,17 +13,15 @@ class DummyThinWorker : public ThinBlockWorker {
         DummyThinWorker(ThinBlockManager& mg, NodeId id)
             : ThinBlockWorker(mg, id) { }
 
-        virtual bool addTx(const CTransaction& tx) { return false; }
+        bool addTx(const uint256&, const CTransaction& tx) override { return false; }
 
-        virtual void setAvailable() { }
-        virtual bool isAvailable() const { return false; }
+        void buildStub(const StubData&, const TxFinder&) override { }
+        void addWork(const uint256& block) override { }
+        void stopWork(const uint256& block) override { }
+        void stopAllWork() override { }
 
-        virtual void buildStub(const StubData&, const TxFinder&) { }
-        virtual void setToWork(const uint256& block) { }
-
-        virtual void requestBlock(const uint256& block,
-                std::vector<CInv>& getDataReq, CNode& node) { }
-
+        void requestBlock(const uint256& block,
+                std::vector<CInv>& getDataReq, CNode& node) override { }
 };
 
 #endif

--- a/src/dummythin.h
+++ b/src/dummythin.h
@@ -15,7 +15,7 @@ class DummyThinWorker : public ThinBlockWorker {
 
         bool addTx(const uint256&, const CTransaction& tx) override { return false; }
 
-        void buildStub(const StubData&, const TxFinder&) override { }
+        void buildStub(const StubData&, const TxFinder&, CNode& from) override { }
         void addWork(const uint256& block) override { }
         void stopWork(const uint256& block) override { }
         void stopAllWork() override { }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5378,7 +5378,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
             DefaultHeaderProcessor headerp(pfrom, blocksInFlight, thinblockmg,
                 inFlight, CheckBlockIndex);
             XThinBlockProcessor blockp(*pfrom, *(nodestate->thinblock), headerp);
-            blockp(vRecv, TxFinderImpl());
+            blockp(vRecv, TxFinderImpl(), chainActive.Height());
         }
         catch (const std::exception& e) {
             unexpectedThinError(strCommand, *pfrom, e.what());
@@ -5397,7 +5397,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
             DefaultHeaderProcessor headerp(pfrom, blocksInFlight, thinblockmg,
                     inFlight, CheckBlockIndex);
             CompactBlockProcessor blockp(*pfrom, *(nodestate->thinblock), headerp);
-            blockp(vRecv, mempool, chainActive.Tip()->nMaxBlockSize);
+            blockp(vRecv, mempool, chainActive.Tip()->nMaxBlockSize, chainActive.Height());
         }
         catch (const std::exception& e) {
             unexpectedThinError(strCommand, *pfrom, e.what());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5378,7 +5378,8 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
             DefaultHeaderProcessor headerp(pfrom, blocksInFlight, thinblockmg,
                 inFlight, CheckBlockIndex);
             XThinBlockProcessor blockp(*pfrom, *(nodestate->thinblock), headerp);
-            blockp(vRecv, TxFinderImpl(), chainActive.Height());
+            blockp(vRecv, TxFinderImpl(),
+                    chainActive.Tip()->nMaxBlockSize, chainActive.Height());
         }
         catch (const std::exception& e) {
             unexpectedThinError(strCommand, *pfrom, e.what());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -540,13 +540,16 @@ void InFlightEraserImpl::operator()(NodeId node, const uint256& hash) {
     if (q == QueuedBlockPtr())
         return;
 
-    NodeStatePtr state(q->node);
-    assert(!state.IsNull());
     nQueuedValidatedHeaders -= q->fValidatedHeaders;
-    state->nBlocksInFlightValidHeaders -= q->fValidatedHeaders;
-    state->vBlocksInFlight.erase(q);
-    state->nBlocksInFlight--;
-    state->nStallingSince = 0;
+    NodeStatePtr state(q->node);
+    if (!state.IsNull()) {
+        // state can be null if a node that has a block
+        // in flight is being destructed.
+        state->nBlocksInFlightValidHeaders -= q->fValidatedHeaders;
+        state->vBlocksInFlight.erase(q);
+        state->nBlocksInFlight--;
+        state->nStallingSince = 0;
+    }
     blocksInFlight.erase(q);
 
     int64_t getdataTime = q->nTime;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5359,8 +5359,12 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
             // new headers to connect.
             return true;
 
-        if (!p(headers, nCount == MAX_HEADERS_RESULTS, true))
-            return false;
+        try {
+            p(headers, nCount == MAX_HEADERS_RESULTS, true);
+        }
+        catch (const BlockHeaderError& e) {
+            return error(e.what());
+        }
     }
     else if (strCommand == "xthinblock" && !fImporting && !fReindex) // Ignore blocks received while importing
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5063,7 +5063,8 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
 
         try {
             if (canSend)
-                bs.sendReReqReponse(*pfrom, *(mi->second), req);
+                bs.sendReReqReponse(*pfrom, *(mi->second), req,
+                        chainActive.Height());
         }
         catch (const std::exception& e) {
             LogPrintf("error in re-request from peer=%d: %s\n",
@@ -5466,7 +5467,8 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
 
         try {
             if (canSend)
-                bs.sendReReqReponse(*pfrom, *(mi->second), req);
+                bs.sendReReqReponse(*pfrom, *(mi->second), req,
+                        chainActive.Height());
         }
         catch (const std::exception& e) {
             LogPrintf("error in xthin re-request from peer=%d: %s\n",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4889,13 +4889,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
         }
 
         if (pfrom->nVersion >= SHORT_IDS_BLOCKS_VERSION
-                && (!(pfrom->nServices & NODE_THIN) || Opt().PreferCompactBlocks())) {
-
-            // We prefer xthin, however if node does not support it,
-            // we ask it for thin block variant compact blocks.
-            //
-            // This also acts as announcement to tell the peer that we
-            // support compact blocks.
+                && !(pfrom->SupportsXThinBlocks() && Opt().PreferXThinBlocks())) {
             enableCompactBlocks(*pfrom, false);
         }
     }

--- a/src/main.h
+++ b/src/main.h
@@ -157,7 +157,32 @@ void RegisterNodeSignals(CNodeSignals& nodeSignals);
 /** Unregister a network node */
 void UnregisterNodeSignals(CNodeSignals& nodeSignals);
 
-/** 
+/**
+ * Sources of received blocks, saved to be able to send them reject
+ * messages or ban them when processing happens afterwards.
+ */
+struct BlockSource {
+    BlockSource() : canMisbehave(true) { }
+    BlockSource(const uint256& block, const std::set<NodeId> n, bool canMisbehave)
+        : block(block), nodes(n), canMisbehave(canMisbehave) {
+    }
+
+    uint256 block;
+
+    // Block can be provided from multiple peers
+    // with thin blocks.
+    std::set<NodeId> nodes;
+
+    // If it's ok to misbehave the node
+    // when the block is invalid.
+    //
+    // Blocks received as block announcements
+    // should not be misbehaved. They are allowed to
+    // be sent before being fully validated.
+    bool canMisbehave;
+};
+
+/**
  * Process an incoming block. This only returns after the best known valid
  * block is made active. Note that it does not, however, guarantee that the
  * specific block passed to it has been checked for validity!
@@ -169,7 +194,7 @@ void UnregisterNodeSignals(CNodeSignals& nodeSignals);
  * @param[out]  dbp     The already known disk position of pblock, or NULL if not yet stored.
  * @return True if state.IsValid()
  */
-bool ProcessNewBlock(CValidationState &state, CNode* pfrom, CBlock* pblock, bool fForceProcessing, const CDiskBlockPos *dbp);
+bool ProcessNewBlock(CValidationState &state, const BlockSource& from, CBlock* pblock, bool fForceProcessing, const CDiskBlockPos *dbp);
 /** Check whether enough disk space is available for an incoming block */
 bool CheckDiskSpace(uint64_t nAdditionalBytes = 0);
 /** Open a block file (blk?????.dat) */
@@ -209,7 +234,7 @@ std::string GetWarnings(std::string strFor);
 /** Retrieve a transaction (from memory pool, or from disk, if possible) */
 bool GetTransaction(const uint256 &hash, CTransaction &tx, uint256 &hashBlock, bool fAllowSlow = false);
 /** Find the best known block, and make it the tip of the block chain */
-bool ActivateBestChain(CValidationState &state, CBlock *pblock = NULL);
+bool ActivateBestChain(CValidationState &state, CBlock *pblock = NULL, const BlockSource& = BlockSource());
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams);
 
 /**

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -338,7 +338,7 @@ static bool ProcessBlockFound(CBlock* pblock, CWallet& wallet, CReserveKey& rese
 
     // Process this block the same as if we had received it from another node
     CValidationState state;
-    if (!ProcessNewBlock(state, NULL, pblock, true, NULL))
+    if (!ProcessNewBlock(state, BlockSource{}, pblock, true, NULL))
         return error("BitcoinMiner: ProcessNewBlock, block not accepted");
 
     return true;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -89,8 +89,8 @@ int Opt::ThinBlocksMaxParallel() {
     return Args->GetArg("-thin-blocks-max-parallel", 3);
 }
 
-bool Opt::PreferCompactBlocks() const {
-    return Args->GetBool("-prefer-compact-blocks", false);
+bool Opt::PreferXThinBlocks() const {
+    return Args->GetBool("-prefer-xthin-blocks", false);
 }
 
 std::unique_ptr<ArgReset> SetDummyArgGetter(std::unique_ptr<ArgGetter> getter) {

--- a/src/options.h
+++ b/src/options.h
@@ -20,7 +20,7 @@ struct Opt {
     bool UsingThinBlocks();
     bool AvoidFullBlocks();
     int ThinBlocksMaxParallel();
-    bool PreferCompactBlocks() const; // Added for rpc test
+    bool PreferXThinBlocks() const;
 };
 
 /** Maximum number of script-checking threads allowed */

--- a/src/process_xthinblock.cpp
+++ b/src/process_xthinblock.cpp
@@ -11,7 +11,7 @@
 
 
 void XThinBlockProcessor::operator()(
-        CDataStream& vRecv, const TxFinder& txfinder)
+        CDataStream& vRecv, const TxFinder& txfinder, int activeChainHeight)
 {
     XThinBlock block;
     vRecv >> block;
@@ -35,12 +35,7 @@ void XThinBlockProcessor::operator()(
         return;
     }
 
-    if (!processHeader(block.header)) {
-        worker.stopWork(hash);
-        return;
-    }
-
-    if (!setToWork(hash))
+    if (!setToWork(block.header, activeChainHeight))
         return;
 
     from.AddInventoryKnown(CInv(MSG_XTHINBLOCK, hash));

--- a/src/process_xthinblock.cpp
+++ b/src/process_xthinblock.cpp
@@ -61,14 +61,13 @@ void XThinBlockProcessor::operator()(
     }
 
     // Request missing
-    std::vector<ThinTx> missing = worker.getTxsMissing(hash);
-    assert(!missing.empty());
+    std::vector<std::pair<int, ThinTx> > missing = worker.getTxsMissing(hash);
 
     XThinReRequest req;
     req.block = hash;
 
     for (auto& t : missing)
-        req.txRequesting.insert(t.cheap());
+        req.txRequesting.insert(t.second.cheap());
 
     LogPrintf("re-requesting xthin %d missing transactions for %s from peer=%d\n",
             missing.size(), hash.ToString(), from.id);

--- a/src/process_xthinblock.cpp
+++ b/src/process_xthinblock.cpp
@@ -11,7 +11,8 @@
 
 
 void XThinBlockProcessor::operator()(
-        CDataStream& vRecv, const TxFinder& txfinder, int activeChainHeight)
+        CDataStream& vRecv, const TxFinder& txfinder,
+        uint64_t currMaxBlockSize, int activeChainHeight)
 {
     XThinBlock block;
     vRecv >> block;
@@ -22,7 +23,7 @@ void XThinBlockProcessor::operator()(
             hash.ToString(), worker.nodeID());
 
     try {
-        block.selfValidate();
+        block.selfValidate(currMaxBlockSize);
     }
     catch (const std::invalid_argument& e) {
         LogPrint("thin", "Invalid xthin block %s\n", e.what());

--- a/src/process_xthinblock.cpp
+++ b/src/process_xthinblock.cpp
@@ -47,7 +47,7 @@ void XThinBlockProcessor::operator()(
 
     try {
         XThinStub stub(block);
-        worker.buildStub(stub, txfinder);
+        worker.buildStub(stub, txfinder, from);
     }
     catch (const thinblock_error& e) {
         rejectBlock(hash, e.what(), 10);

--- a/src/process_xthinblock.h
+++ b/src/process_xthinblock.h
@@ -13,7 +13,8 @@ class XThinBlockProcessor : private BlockProcessor {
         {
         }
 
-        void operator()(CDataStream& vRecv, const TxFinder& txfinder);
+        void operator()(CDataStream& vRecv, const TxFinder& txfinder,
+                int activeChainHeight);
 };
 
 #endif

--- a/src/process_xthinblock.h
+++ b/src/process_xthinblock.h
@@ -14,7 +14,7 @@ class XThinBlockProcessor : private BlockProcessor {
         }
 
         void operator()(CDataStream& vRecv, const TxFinder& txfinder,
-                int activeChainHeight);
+                uint64_t currMaxBlockSize, int activeChainHeight);
 };
 
 #endif

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -673,7 +673,7 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate)
     statusBar()->clearMessage();
 
     // Acquire current block source
-    enum BlockSource blockSource = clientModel->getBlockSource();
+    enum FetchBlockSource blockSource = clientModel->getBlockSource();
     switch (blockSource) {
         case BLOCK_SOURCE_NETWORK:
             progressBarLabel->setText(tr("Synchronizing with network..."));

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -137,7 +137,7 @@ bool ClientModel::inInitialBlockDownload() const
     return IsInitialBlockDownload();
 }
 
-enum BlockSource ClientModel::getBlockSource() const
+enum FetchBlockSource ClientModel::getBlockSource() const
 {
     if (fReindex)
         return BLOCK_SOURCE_REINDEX;

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -19,7 +19,7 @@ QT_BEGIN_NAMESPACE
 class QTimer;
 QT_END_NAMESPACE
 
-enum BlockSource {
+enum FetchBlockSource {
     BLOCK_SOURCE_NONE,
     BLOCK_SOURCE_REINDEX,
     BLOCK_SOURCE_DISK,
@@ -58,7 +58,7 @@ public:
     //! Return true if core is doing initial block download
     bool inInitialBlockDownload() const;
     //! Return true if core is importing blocks
-    enum BlockSource getBlockSource() const;
+    enum FetchBlockSource getBlockSource() const;
     //! Return warnings to be displayed in status bar
     QString getStatusBarWarnings() const;
 

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -164,7 +164,7 @@ UniValue generate(const UniValue& params, bool fHelp)
             ++pblock->nNonce;
         }
         CValidationState state;
-        if (!ProcessNewBlock(state, NULL, pblock, true, NULL))
+        if (!ProcessNewBlock(state, BlockSource{}, pblock, true, NULL))
             throw JSONRPCError(RPC_INTERNAL_ERROR, "ProcessNewBlock, block not accepted");
         ++nHeight;
         blockHashes.push_back(pblock->GetHash().GetHex());
@@ -655,7 +655,7 @@ UniValue submitblock(const UniValue& params, bool fHelp)
     CValidationState state;
     submitblock_StateCatcher sc(block.GetHash());
     RegisterValidationInterface(&sc);
-    bool fAccepted = ProcessNewBlock(state, NULL, &block, true, NULL);
+    bool fAccepted = ProcessNewBlock(state, BlockSource{}, &block, true, NULL);
     UnregisterValidationInterface(&sc);
     if (fBlockPresent)
     {

--- a/src/test/blockannounce_tests.cpp
+++ b/src/test/blockannounce_tests.cpp
@@ -170,21 +170,6 @@ BOOST_AUTO_TEST_CASE(dowl_strategy_full_now) {
             ann.pickDownloadStrategy());
 }
 
-BOOST_AUTO_TEST_CASE(dowl_strategy_thin_later_2) {
-
-    // Thin supports sending thin blocks but is busy. Request later.
-    node.nServices = NODE_THIN;
-
-    // By default DummyNode uses DummyThinWorker.
-    // DummyThinWorker always returns false for isAvailable().
-    BOOST_ASSERT(!nodestate->thinblock->isAvailable());
-
-
-    BOOST_CHECK_EQUAL(
-            BlockAnnounceReceiver::DOWNL_THIN_LATER,
-            ann.pickDownloadStrategy());
-}
-
 BOOST_AUTO_TEST_CASE(dowl_strategy_dont_downl_1) {
 
     // If we have requested block from max number of nodes
@@ -201,7 +186,7 @@ BOOST_AUTO_TEST_CASE(dowl_strategy_dont_downl_1) {
     DummyNode node2(11, thinmg.get());
     NodeStatePtr state2(node2.id);
     state2->thinblock.reset(new XThinWorker(*thinmg, node2.id));
-    state2->thinblock->setToWork(block);
+    state2->thinblock->addWork(block);
     BOOST_CHECK_EQUAL(1, thinmg->numWorkers(block));
 
     // Second one should not attempt to download on announcement.

--- a/src/test/blockannounce_tests.cpp
+++ b/src/test/blockannounce_tests.cpp
@@ -106,10 +106,18 @@ BOOST_AUTO_TEST_CASE(announce_updates_availability) {
 
 BOOST_AUTO_TEST_CASE(fetch_when_wanted) {
 
-    {   // We want block.
+    {   // We have header, but not data. We want the block.
         std::vector<CInv> toFetch;
+        DummyBlockIndexEntry entry(block);
+        entry.index.nStatus &= ~BLOCK_HAVE_DATA;
         BOOST_CHECK(ann.onBlockAnnounced(toFetch));
         BOOST_CHECK(!toFetch.empty());
+    }
+
+    {   // We don't have header. We don't want block.
+        std::vector<CInv> toFetch;
+        BOOST_CHECK(!ann.onBlockAnnounced(toFetch));
+        BOOST_CHECK(toFetch.empty());
     }
 
     {   // We have block (we don't want it)
@@ -152,6 +160,9 @@ BOOST_AUTO_TEST_CASE(dowl_strategy_full_now) {
 
     // Peer does not support thin blocks and we are almost synced.
     node.nServices = 0;
+
+    DummyBlockIndexEntry entry(block);
+    entry.index.nStatus &= ~BLOCK_HAVE_DATA;
 
     BOOST_CHECK_EQUAL(
             BlockAnnounceReceiver::DOWNL_FULL_NOW,

--- a/src/test/blockannounce_tests.cpp
+++ b/src/test/blockannounce_tests.cpp
@@ -114,10 +114,10 @@ BOOST_AUTO_TEST_CASE(fetch_when_wanted) {
         BOOST_CHECK(!toFetch.empty());
     }
 
-    {   // We don't have header. We don't want block.
+    {   // We don't have header. We still want block.
         std::vector<CInv> toFetch;
-        BOOST_CHECK(!ann.onBlockAnnounced(toFetch));
-        BOOST_CHECK(toFetch.empty());
+        BOOST_CHECK(ann.onBlockAnnounced(toFetch));
+        BOOST_CHECK(!toFetch.empty());
     }
 
     {   // We have block (we don't want it)

--- a/src/test/compactblockprocessor_tests.cpp
+++ b/src/test/compactblockprocessor_tests.cpp
@@ -16,8 +16,8 @@ struct CmpctDummyHeaderProcessor : public BlockHeaderProcessor {
 
     CmpctDummyHeaderProcessor() : reqConnHeadResp(false) { }
 
-    bool operator()(const std::vector<CBlockHeader>&, bool, bool) override {
-        return true;
+    CBlockIndex* operator()(const std::vector<CBlockHeader>&, bool, bool) override {
+        return nullptr;
     }
     bool requestConnectHeaders(const CBlockHeader& h, CNode& from) override {
         return reqConnHeadResp;

--- a/src/test/compactblockprocessor_tests.cpp
+++ b/src/test/compactblockprocessor_tests.cpp
@@ -1,0 +1,143 @@
+// Copyright (c) 2016 The Bitcoin XT developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <boost/test/unit_test.hpp>
+
+#include "test/thinblockutil.h"
+#include "compactblockprocessor.h"
+#include "blockheaderprocessor.h"
+#include "streams.h"
+#include "txmempool.h"
+#include "compactthin.h"
+#include "chainparams.h"
+#include "consensus/consensus.h"
+
+struct CmpctDummyHeaderProcessor : public BlockHeaderProcessor {
+
+    CmpctDummyHeaderProcessor() : reqConnHeadResp(false) { }
+
+    bool operator()(const std::vector<CBlockHeader>&, bool, bool) override {
+        return true;
+    }
+    bool requestConnectHeaders(const CBlockHeader& h, CNode& from) override {
+        return reqConnHeadResp;
+    }
+    bool reqConnHeadResp;
+};
+
+struct CBProcessorFixture {
+
+    CBProcessorFixture() :
+        thinmg(GetDummyThinBlockMg()),
+        mpool(CFeeRate(0))
+    {
+        // test assert when pushing ping to pfrom if consensus params
+        // are not set.
+        SelectParams(CBaseChainParams::MAIN);
+
+        // asserts if fPrintToDebugLog is true
+        fPrintToDebugLog = false;
+    }
+
+    CDataStream toStream(const CompactBlock& b) {
+        CDataStream blockstream(SER_NETWORK, PROTOCOL_VERSION);
+        blockstream << b;
+        return blockstream;
+    }
+
+    std::unique_ptr<ThinBlockManager> thinmg;
+    CmpctDummyHeaderProcessor headerp;
+    CTxMemPool mpool;
+};
+
+BOOST_FIXTURE_TEST_SUITE(compactblockprocessor_tests, CBProcessorFixture);
+
+BOOST_AUTO_TEST_CASE(accepts_parallel_compacts) {
+
+    // We may receive a block announcement
+    // as a compact block while we've already
+    // requested a different block as compact.
+    // We need to be willing to receive both.
+
+    DummyNode node(42, thinmg.get());
+    CompactWorker w(*thinmg, node.id);
+
+    // start work on first block.
+    uint256 block1 = uint256S("0xf00");
+    w.addWork(block1);
+
+    CompactBlockProcessor p(node, w, headerp);
+
+    CBlock block2 = TestBlock1();
+    CDataStream blockstream = toStream(
+            CompactBlock(block2, CoinbaseOnlyPrefiller{}));
+
+    // cblock2 is announced, should start work on
+    // that too.
+    p(blockstream, mpool, MAX_BLOCK_SIZE);
+
+    BOOST_CHECK(w.isWorkingOn(block1));
+    BOOST_CHECK(w.isWorkingOn(block2.GetHash()));
+    BOOST_CHECK_EQUAL(1, thinmg->numWorkers(block1));
+    BOOST_CHECK_EQUAL(1, thinmg->numWorkers(block2.GetHash()));
+    w.stopAllWork();
+    thinmg.reset();
+}
+
+BOOST_AUTO_TEST_CASE(two_process_same) {
+    // Check that two nodes can process the same block at the same time,
+    // even though it's two compact blocks with different idks
+
+    CBlock block = TestBlock1();
+
+    DummyNode node1(12, thinmg.get());
+    DummyNode node2(21, thinmg.get());
+
+    CompactWorker w1(*thinmg, node1.id);
+    CompactWorker w2(*thinmg, node2.id);
+
+    CompactBlock c1(block, CoinbaseOnlyPrefiller{});
+    CompactBlock c2(block, CoinbaseOnlyPrefiller{}); // Has differet idks
+
+    CompactBlockProcessor p1(node1, w1, headerp);
+    CompactBlockProcessor p2(node2, w2, headerp);
+
+    CDataStream s1 = toStream(c1);
+    CDataStream s2 = toStream(c2);
+    p1(s1, mpool, MAX_BLOCK_SIZE);
+    p2(s2, mpool, MAX_BLOCK_SIZE);
+
+    // both should be working on the block still
+    BOOST_CHECK(w1.isWorkingOn(block.GetHash()));
+    BOOST_CHECK(w2.isWorkingOn(block.GetHash()));
+
+    // both should have sent a transaction re-request
+    auto has_msg = [](DummyNode& n, const std::string& msg) {
+        return std::find(begin(n.messages), end(n.messages), msg)
+            != end(n.messages);
+    };
+    BOOST_CHECK(has_msg(node1, "getblocktxn"));
+    BOOST_CHECK(has_msg(node2, "getblocktxn"));
+};
+
+BOOST_AUTO_TEST_CASE(discard_if_missing_prev) {
+    // discard block (stop working on it) if we don't
+    // have header for the previous block.
+
+    CBlock block = TestBlock1();
+
+    DummyNode node(11, thinmg.get());
+    CompactWorker w(*thinmg, node.id);
+    CompactBlock c(block, CoinbaseOnlyPrefiller{});
+    CDataStream s = toStream(c);
+
+    headerp.reqConnHeadResp = true; // we need to request prev header (we don't have it)
+
+    CompactBlockProcessor p(node, w, headerp);
+    p(s, mpool, MAX_BLOCK_SIZE);
+
+    // should have discarded block.
+    BOOST_CHECK(!w.isWorkingOn(block.GetHash()));
+};
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/test/compactthin_tests.cpp
+++ b/src/test/compactthin_tests.cpp
@@ -4,8 +4,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include "test/thinblockutil.h"
-//#include "bloom.h"
-//#include "uint256.h"
 #include "compactthin.h"
 #include "chainparams.h"
 #include "blockencodings.h"
@@ -81,6 +79,24 @@ BOOST_AUTO_TEST_CASE(ids_are_correct) {
 
         BOOST_CHECK_EQUAL(shortID, all[i].obfuscated());
     }
+}
+
+BOOST_AUTO_TEST_CASE(request_block_announcements) {
+    auto mg = GetDummyThinBlockMg();
+
+    DummyNode node(42, mg.get());
+    CompactWorker w(*mg, node.id);
+    {
+        auto h = w.requestBlockAnnouncements(node);
+
+        // Should send a request for header announcements
+        BOOST_CHECK_EQUAL(1, node.messages.size());
+        BOOST_CHECK_EQUAL("sendcmpct", node.messages.at(0));
+    }
+    // hande goes out of scope,
+    // should send a request to disable header announcements
+    BOOST_CHECK_EQUAL(2, node.messages.size());
+    BOOST_CHECK_EQUAL("sendcmpct", node.messages.at(1));
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         pblock->hashMerkleRoot = pblock->BuildMerkleTree();
         pblock->nNonce = blockinfo[i].nonce;
         CValidationState state;
-        BOOST_CHECK(ProcessNewBlock(state, NULL, pblock, true, NULL));
+        BOOST_CHECK(ProcessNewBlock(state, BlockSource{}, pblock, true, NULL));
         BOOST_CHECK(state.IsValid());
         pblock->hashPrevBlock = pblock->GetHash();
     }

--- a/src/test/processmessage_tests.cpp
+++ b/src/test/processmessage_tests.cpp
@@ -37,9 +37,11 @@ struct DummyHeaderProcessor : public BlockHeaderProcessor {
 
     DummyHeaderProcessor() : headerOK(true), called(false) { }
 
-    bool operator()(const std::vector<CBlockHeader>&, bool, bool) override {
+    CBlockIndex* operator()(const std::vector<CBlockHeader>&, bool, bool) override {
         called = true;
-        return headerOK;
+        if (!headerOK)
+            throw BlockHeaderError("header not OK");
+        return nullptr;
     }
     bool requestConnectHeaders(const CBlockHeader& h, CNode& from) override {
         return false;

--- a/src/test/processmessage_tests.cpp
+++ b/src/test/processmessage_tests.cpp
@@ -22,9 +22,9 @@ struct DummyWorker : public WORKER_TYPE {
         WORKER_TYPE(m, i), isBuilt(false), buildStubCalled(false)
     { }
 
-    void buildStub(const StubData& s, const TxFinder& f) override {
+    void buildStub(const StubData& s, const TxFinder& f, CNode& n) override {
         buildStubCalled = true;
-        WORKER_TYPE::buildStub(s, f);
+        WORKER_TYPE::buildStub(s, f, n);
     }
     bool isStubBuilt(const uint256& block) const override {
         return isBuilt;

--- a/src/test/processmessage_tests.cpp
+++ b/src/test/processmessage_tests.cpp
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(xthinblock_ignore_invalid) {
     worker.addWork(xblock.header.GetHash());
     CDataStream s = stream(xblock);
     DummyXThinProcessor process(pfrom, worker, headerprocessor);
-    process(s, NullFinder(), 1);
+    process(s, NullFinder(), MAX_BLOCK_SIZE, 1);
 
     // Should reset the worker.
     BOOST_CHECK(!worker.isWorking());
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(xthinblock_ignore_if_has_block_data) {
     worker.addWork(xblock.header.GetHash());
     CDataStream s = stream(xblock);
     DummyXThinProcessor process(pfrom, worker, headerprocessor);
-    process(s, NullFinder(), 1);
+    process(s, NullFinder(), MAX_BLOCK_SIZE, 1);
 
     // peer should not be working on anything
     BOOST_CHECK(!worker.isWorking());
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(xthinblock_header_is_processed) {
     worker.addWork(xblock.header.GetHash());
     CDataStream s = stream(xblock);
     DummyXThinProcessor process(pfrom, worker, headerprocessor);
-    process(s, NullFinder(), 1);
+    process(s, NullFinder(), MAX_BLOCK_SIZE, 1);
 
     BOOST_CHECK(headerprocessor.called);
     BOOST_CHECK(worker.isStubBuilt(xblock.header.GetHash()));
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(xthinblock_stop_if_header_fails) {
     headerprocessor.headerOK = false;
     CDataStream s = stream(xblock);
     DummyXThinProcessor process(pfrom, worker, headerprocessor);
-    process(s, NullFinder(), 1);
+    process(s, NullFinder(), MAX_BLOCK_SIZE, 1);
 
     BOOST_CHECK(!worker.isWorkingOn(xblock.header.GetHash()));
     BOOST_CHECK(!worker.isStubBuilt(xblock.header.GetHash()));
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE(xthinblock_rerequest_missing) {
     worker.addWork(xblock.header.GetHash());
     CDataStream s = stream(xblock);
     DummyXThinProcessor process(pfrom, worker, headerprocessor);
-    process(s, NullFinder(), 1);
+    process(s, NullFinder(), MAX_BLOCK_SIZE, 1);
 
     BOOST_CHECK(headerprocessor.called);
     BOOST_CHECK(worker.isStubBuilt(xblock.header.GetHash()));
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(xthinblock_rerequest_missing) {
     pfrom.messages.clear();
     xblock = XThinBlock(TestBlock1(), f);
     s = stream(xblock);
-    process(s, NullFinder(), 1);
+    process(s, NullFinder(), MAX_BLOCK_SIZE, 1);
     BOOST_CHECK(pfrom.messages.empty());
 }
 
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE(rebuild_stub) {
     worker.isBuilt = true;
     CDataStream s = stream(xblock);
     DummyXThinProcessor process(pfrom, worker, headerprocessor);
-    process(s, NullFinder(), 1);
+    process(s, NullFinder(), MAX_BLOCK_SIZE, 1);
 
     BOOST_CHECK(worker.buildStubCalled);
 }

--- a/src/test/thinblockconcluder_tests.cpp
+++ b/src/test/thinblockconcluder_tests.cpp
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(xthin_concluder) {
         DummyWorker(ThinBlockManager& mg, NodeId id) :
             XThinWorker(mg, id), addTxCalled(false) { }
 
-        bool addTx(const CTransaction& tx) override {
+        bool addTx(const uint256& block, const CTransaction& tx) override {
             addTxCalled = true;
             return true;
         }
@@ -64,18 +64,17 @@ BOOST_AUTO_TEST_CASE(xthin_concluder) {
     XThinBlockConcluder conclude;
     // Should ignore since worker is not working
     // on anything.
-    worker.setAvailable();
     conclude(resp, pfrom, worker, markInFlight);
     BOOST_CHECK(!worker.addTxCalled);
 
     // Should ignore since worker is assigned to a
     // different block.
-    worker.setToWork(uint256S("0xf00d"));
+    worker.addWork(uint256S("0xf00d"));
     conclude(resp, pfrom, worker, markInFlight);
     BOOST_CHECK(!worker.addTxCalled);
 
     // Should add tx.
-    worker.setToWork(resp.block);
+    worker.addWork(resp.block);
     conclude(resp, pfrom, worker, markInFlight);
     BOOST_CHECK(worker.addTxCalled);
 }
@@ -90,7 +89,7 @@ BOOST_AUTO_TEST_CASE(compact_concluder) {
         DummyWorker(ThinBlockManager& mg, NodeId id) :
             CompactWorker(mg, id), addTxCalled(false) { }
 
-        bool addTx(const CTransaction& tx) override {
+        bool addTx(const uint256& block, const CTransaction& tx) override {
             addTxCalled = true;
             return true;
         }
@@ -102,18 +101,17 @@ BOOST_AUTO_TEST_CASE(compact_concluder) {
     CompactBlockConcluder conclude;
     // Should ignore since worker is not working
     // on anything.
-    worker.setAvailable();
     conclude(resp, pfrom, worker, markInFlight);
     BOOST_CHECK(!worker.addTxCalled);
 
     // Should ignore since worker is assigned to a
     // different block.
-    worker.setToWork(uint256S("0xf00d"));
+    worker.addWork(uint256S("0xf00d"));
     conclude(resp, pfrom, worker, markInFlight);
     BOOST_CHECK(!worker.addTxCalled);
 
     // Should add tx.
-    worker.setToWork(resp.blockhash);
+    worker.addWork(resp.blockhash);
     conclude(resp, pfrom, worker, markInFlight);
     BOOST_CHECK(worker.addTxCalled);
 };

--- a/src/test/thinblockmanager_tests.cpp
+++ b/src/test/thinblockmanager_tests.cpp
@@ -25,13 +25,13 @@ BOOST_AUTO_TEST_CASE(add_and_del_worker) {
 
     // Assigning a worker to a block adds it to the manager.
     uint256 block = uint256S("0xFF");
-    worker->setToWork(block);
+    worker->addWork(block);
     BOOST_CHECK_EQUAL(1, mg->numWorkers(block));
 
-    worker->setAvailable();
+    worker->stopWork(block);
     BOOST_CHECK_EQUAL(0, mg->numWorkers(block));
 
-    worker->setToWork(block);
+    worker->addWork(block);
     worker.reset();
     BOOST_CHECK_EQUAL(0, mg->numWorkers(block));
 };

--- a/src/test/thinblockmanager_tests.cpp
+++ b/src/test/thinblockmanager_tests.cpp
@@ -6,8 +6,10 @@
 #include "thinblockmanager.h"
 #include "uint256.h"
 #include "xthin.h"
+#include "compactthin.h"
 #include "chainparams.h"
 #include <memory>
+#include <iostream>
 
 // Workaround for segfaulting
 struct Workaround {
@@ -35,5 +37,108 @@ BOOST_AUTO_TEST_CASE(add_and_del_worker) {
     worker.reset();
     BOOST_CHECK_EQUAL(0, mg->numWorkers(block));
 };
+
+struct DummyAnn : public BlockAnnHandle {
+    DummyAnn(NodeId id, std::vector<NodeId>& announcers)
+        : id(id), announcers(announcers)
+    {
+        announcers.push_back(id);
+    }
+    ~DummyAnn() {
+        auto i = std::find(begin(announcers), end(announcers), id);
+        if (i != end(announcers))
+            announcers.erase(i);
+    }
+    virtual NodeId nodeID() const { return id; }
+
+    NodeId id;
+    std::vector<NodeId>& announcers;
+};
+
+
+struct BlockAnnWorker : public ThinBlockWorker {
+    BlockAnnWorker(ThinBlockManager& m, NodeId i, std::vector<NodeId>& a)
+        : ThinBlockWorker(m, i), announcers(a)
+    {
+    }
+    std::unique_ptr<BlockAnnHandle> requestBlockAnnouncements(CNode&) override {
+        return std::unique_ptr<DummyAnn>(
+                new DummyAnn(nodeID(), announcers));
+    }
+    void requestBlock(const uint256& block,
+        std::vector<CInv>& getDataReq, CNode& node) override { }
+
+    std::vector<NodeId>& announcers;
+};
+
+BOOST_AUTO_TEST_CASE(request_block_announcements) {
+
+
+    std::unique_ptr<ThinBlockManager> mg = GetDummyThinBlockMg();
+    std::vector<NodeId> announcers;
+    DummyNode n;
+
+    BlockAnnWorker w1(*mg, 11, announcers);
+    BlockAnnWorker w2(*mg, 12, announcers);
+    BlockAnnWorker w3(*mg, 13, announcers);
+    mg->requestBlockAnnouncements(w1, n);
+    mg->requestBlockAnnouncements(w2, n);
+    mg->requestBlockAnnouncements(w3, n);
+
+    // We want 3 block announcers, so all should have been kept.
+    std::vector<NodeId> expected = { 11, 12, 13 };
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        begin(announcers), end(announcers),
+        begin(expected), end(expected));
+
+    // Move 11 to the front,
+    mg->requestBlockAnnouncements(w1, n);
+
+    // ...which means 14 should bump 12 out
+    BlockAnnWorker w4(*mg, 14, announcers);
+    mg->requestBlockAnnouncements(w4, n);
+    expected = { 11, 13, 14 };
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        begin(announcers), end(announcers),
+        begin(expected), end(expected));
+
+    // Requesting from a node that does not support
+    // block announcements should have no effect.
+    struct DummyWorker : public ThinBlockWorker {
+        DummyWorker(ThinBlockManager& m, NodeId i) : ThinBlockWorker(m, i) { }
+        void requestBlock(const uint256& block,
+            std::vector<CInv>& getDataReq, CNode& node) override { }
+    };
+    DummyWorker w5(*mg, 15);
+    mg->requestBlockAnnouncements(w5, n);
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        begin(announcers), end(announcers),
+        begin(expected), end(expected));
+}
+
+BOOST_AUTO_TEST_CASE(add_and_delete_workers) {
+    std::unique_ptr<ThinBlockManager> mg = GetDummyThinBlockMg();
+
+    CompactWorker w1(*mg, 42);
+    XThinWorker w2(*mg, 43);
+
+    uint256 blockA = uint256S("0xf00");
+    uint256 blockB = uint256S("0xbaa");
+
+    mg->addWorker(blockA, w1);
+    mg->addWorker(blockB, w1);
+    mg->addWorker(blockA, w2);
+
+    BOOST_CHECK_EQUAL(2, mg->numWorkers(blockA));
+    BOOST_CHECK_EQUAL(1, mg->numWorkers(blockB));
+
+    mg->delWorker(blockA, w1);
+    BOOST_CHECK_EQUAL(1, mg->numWorkers(blockA));
+
+    mg->delWorker(blockA, w2);
+    mg->delWorker(blockB, w1);
+    BOOST_CHECK_EQUAL(0, mg->numWorkers(blockA));
+    BOOST_CHECK_EQUAL(0, mg->numWorkers(blockB));
+}
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -129,9 +129,9 @@ ThinBlockWorker::~ThinBlockWorker() {
     stopAllWork();
 }
 
-void ThinBlockWorker::buildStub(const StubData& d, const TxFinder& f) {
+void ThinBlockWorker::buildStub(const StubData& d, const TxFinder& f, CNode& from) {
     assert(isWorkingOn(d.header().GetHash()));
-    return mg.buildStub(d, f);
+    return mg.buildStub(d, f, *this, from);
 }
 
 bool ThinBlockWorker::isStubBuilt(const uint256& block) const {

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -142,7 +142,7 @@ bool ThinBlockWorker::addTx(const uint256& block, const CTransaction& tx) {
     return mg.addTx(block, tx);
 }
 
-std::vector<ThinTx> ThinBlockWorker::getTxsMissing(const uint256& block) const {
+std::vector<std::pair<int, ThinTx> > ThinBlockWorker::getTxsMissing(const uint256& block) const {
     return mg.getTxsMissing(block);
 }
 

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -93,7 +93,7 @@ class ThinBlockWorker : boost::noncopyable {
 
         virtual bool addTx(const uint256& block, const CTransaction& tx);
 
-        virtual std::vector<ThinTx> getTxsMissing(const uint256&) const;
+        virtual std::vector<std::pair<int, ThinTx> > getTxsMissing(const uint256&) const;
 
         virtual void buildStub(const StubData&, const TxFinder&);
         virtual bool isStubBuilt(const uint256& block) const;

--- a/src/thinblockbuilder.cpp
+++ b/src/thinblockbuilder.cpp
@@ -57,14 +57,14 @@ int ThinBlockBuilder::numTxsMissing() const {
     return missing;
 }
 
-std::vector<ThinTx> ThinBlockBuilder::getTxsMissing() const {
+std::vector<std::pair<int, ThinTx> > ThinBlockBuilder::getTxsMissing() const {
     assert(wantedTxs.size() == thinBlock.vtx.size());
 
-    std::vector<ThinTx> missing;
+    std::vector<std::pair<int, ThinTx> > missing;
 
     for (size_t i = 0; i < wantedTxs.size(); ++i)
         if (thinBlock.vtx[i].IsNull())
-            missing.push_back(wantedTxs[i]);
+            missing.push_back(std::make_pair(i, wantedTxs[i]));
 
     assert(missing.size() == this->missing);
     return missing;

--- a/src/thinblockbuilder.h
+++ b/src/thinblockbuilder.h
@@ -24,7 +24,7 @@ class ThinBlockBuilder {
         TXAddRes addTransaction(const CTransaction& tx);
 
         int numTxsMissing() const;
-        std::vector<ThinTx> getTxsMissing() const;
+        std::vector<std::pair<int, ThinTx> > getTxsMissing() const;
 
         // If builder has uint256 hashes in wantedTxs list,
         // this will do nothing.

--- a/src/thinblockmanager.cpp
+++ b/src/thinblockmanager.cpp
@@ -149,7 +149,7 @@ void ThinBlockManager::removeIfExists(const uint256& h) {
     builders.erase(h);
 }
 
-std::vector<ThinTx> ThinBlockManager::getTxsMissing(const uint256& hash) const {
+std::vector<std::pair<int, ThinTx> > ThinBlockManager::getTxsMissing(const uint256& hash) const {
     assert(builders.count(hash));
     ThinBlockBuilder* b = builders.find(hash)->second.builder.get();
     assert(b);

--- a/src/thinblockmanager.h
+++ b/src/thinblockmanager.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 class CBlock;
+class CNode;
 class TxFinder;
 struct ThinBloomStub;
 struct XThinStub;
@@ -46,10 +47,10 @@ class ThinBlockManager : boost::noncopyable {
                 std::unique_ptr<InFlightEraser> inFlightEraser);
 
         void addWorker(const uint256& block, ThinBlockWorker& w);
-        void delWorker(ThinBlockWorker& w, NodeId);
+        void delWorker(const uint256& block, ThinBlockWorker& w);
         int numWorkers(const uint256& block) const;
 
-        void buildStub(const StubData&, const TxFinder& txFinder);
+        void buildStub(const StubData&, const TxFinder&);
         bool isStubBuilt(const uint256& block);
 
         bool addTx(const uint256& block, const CTransaction& tx);

--- a/src/thinblockmanager.h
+++ b/src/thinblockmanager.h
@@ -22,6 +22,7 @@ class ThinBlockBuilder;
 class ThinBlockWorker;
 class CTransaction;
 class ThinTx;
+class CNode;
 typedef int NodeId;
 
 // Call when a block is reassembled.
@@ -50,12 +51,15 @@ class ThinBlockManager : boost::noncopyable {
         void delWorker(const uint256& block, ThinBlockWorker& w);
         int numWorkers(const uint256& block) const;
 
-        void buildStub(const StubData&, const TxFinder&);
+        void buildStub(const StubData&, const TxFinder&, ThinBlockWorker&, CNode& from);
         bool isStubBuilt(const uint256& block);
 
         bool addTx(const uint256& block, const CTransaction& tx);
         void removeIfExists(const uint256& block);
         std::vector<std::pair<int, ThinTx> > getTxsMissing(const uint256& block) const;
+
+        // public for unittest
+        void requestBlockAnnouncements(ThinBlockWorker& w, CNode& n);
 
     private:
         struct ActiveBuilder {
@@ -65,6 +69,7 @@ class ThinBlockManager : boost::noncopyable {
         std::map<uint256, ActiveBuilder> builders;
         std::unique_ptr<ThinBlockFinishedCallb> finishedCallb;
         std::unique_ptr<InFlightEraser> inFlightEraser;
+        std::vector<std::unique_ptr<class BlockAnnHandle> > announcers;
 
         void finishBlock(const uint256& block, ThinBlockBuilder&);
 };

--- a/src/thinblockmanager.h
+++ b/src/thinblockmanager.h
@@ -55,7 +55,7 @@ class ThinBlockManager : boost::noncopyable {
 
         bool addTx(const uint256& block, const CTransaction& tx);
         void removeIfExists(const uint256& block);
-        std::vector<ThinTx> getTxsMissing(const uint256& block) const;
+        std::vector<std::pair<int, ThinTx> > getTxsMissing(const uint256& block) const;
 
     private:
         struct ActiveBuilder {

--- a/src/version.h
+++ b/src/version.h
@@ -9,7 +9,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70014;
+static const int PROTOCOL_VERSION = 70015;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -40,7 +40,12 @@ static const int NO_BLOOM_VERSION = 70011;
 //! "sendheaders" command and announcing blocks with headers starts with this version
 static const int SENDHEADERS_VERSION = 70012;
 
-//! Core added "compact blocks".
+//! "compact blocks".
 static const int SHORT_IDS_BLOCKS_VERSION = 70014;
+
+//! not banning for invalid compact blocks starts with this version
+//  this was a bug in Bitcoin Core
+static const int INVALID_CB_NO_BAN_VERSION = 70015;
+
 
 #endif // BITCOIN_VERSION_H

--- a/src/xthin.cpp
+++ b/src/xthin.cpp
@@ -8,6 +8,7 @@
 #include "net.h"
 #include "pow.h"
 #include "protocol.h"
+#include "blockencodings.h"
 #include <algorithm>
 
 bool isCollision(const std::vector<uint64_t>& txHashes, const uint64_t& hash) {
@@ -42,7 +43,7 @@ XThinBlock::XThinBlock(const CBlock& block, const CBloomFilter& bloom, bool chec
     }
 }
 
-void XThinBlock::selfValidate() const {
+void XThinBlock::selfValidate(uint64_t currMaxBlockSize) const {
 
     if (header.GetHash().IsNull())
         throw std::invalid_argument("xthinblock is Null");
@@ -53,6 +54,8 @@ void XThinBlock::selfValidate() const {
     if (missing.size() > txHashes.size())
         throw std::invalid_argument("xthinblock cannot provide more transactions"
                 " than it claims are in block");
+
+    validateNumTxs(txHashes.size(), currMaxBlockSize);
 
     typedef std::vector<uint64_t>::const_iterator auto_;
     std::vector<uint64_t> copy;

--- a/src/xthin.h
+++ b/src/xthin.h
@@ -38,7 +38,7 @@ class XThinBlock {
 
         // primitive check to see if block is valid
         // throws on error
-        void selfValidate() const;
+        void selfValidate(uint64_t currMaxBlockSize) const;
 
         template <typename Stream, typename Operation>
         inline void SerializationOp(Stream& s,
@@ -77,13 +77,6 @@ inline TxHashProvider::~TxHashProvider() { }
 
 struct XThinStub : public StubData {
     XThinStub(const XThinBlock& b) : xblock(b) {
-        try {
-            xblock.selfValidate();
-        }
-        catch (const std::exception& e) {
-            throw thinblock_error(e.what());
-        }
-
         LogPrint("thin", "Created xthin stub for %s, %d transactions.\n",
                 header().GetHash().ToString(), allTransactions().size());
     }


### PR DESCRIPTION
This adds support for thin block announcements and implements BIP152's _high bandwith mode_. The rpc test changes are ports from Core with the segwit parts of it disabled.