### PR TITLE
Increase timeout in txn_doublespendrelay

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -725,6 +725,10 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet, CWalletD
         {
             BOOST_FOREACH(const uint256& conflictHash, wtxIn.GetConflicts(false))
             {
+                LogPrintf("%s %s conflicts with %s\n",
+                        __func__,
+                        wtxIn.GetHash().GetHex(),
+                        conflictHash.GetHex());
                 CWalletTx& txConflict = mapWallet[conflictHash];
                 NotifyTransactionChanged(this, conflictHash, CT_UPDATED); //Updates UI table
                 if (IsFromMe(txConflict) || IsMine(txConflict))


### PR DESCRIPTION
The test txn_doublespendrelay is randomly failing.

After investigating I can see that the double spend reporting works, however transactions some times take a very long time to be passed between nodes.

Increasing the timeout makes the test pass. I have yet to find out why transactions are slow to be passed between nodes.

This PR also makes the rpc test state explicitly when it fails due to timeout.