### PR TITLE
UAHF: REQ-1, REQ-2, REQ-DISABLE. Activation time option, default enabled.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -439,6 +439,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-maxblocksizevote=<n>", _("Set vote for maximum block size in megabytes (default: network sizelimit)"));
     if (showDebug)
         strUsage += HelpMessageOpt("-blockversion=<n>", "Override block version to test forking scenarios");
+    strUsage += HelpMessageOpt("-uahftime=<n>", strprintf(_("Set user-activated hard fork activation time (default: %d) (0=disable)"), UAHF_DEFAULT_ACTIVATION_TIME));
 
     strUsage += HelpMessageGroup(_("RPC server options:"));
     strUsage += HelpMessageOpt("-server", _("Accept command line and JSON-RPC commands"));

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -73,6 +73,10 @@ uint64_t Opt::MaxBlockSizeVote() {
     return Args->GetArg("-maxblocksizevote", 0);
 }
 
+int64_t Opt::UAHFTime() {
+    return Args->GetArg("-uahftime", UAHF_DEFAULT_ACTIVATION_TIME);
+}
+
 bool Opt::UsingThinBlocks() {
     if (IsStealthMode())
         return false;

--- a/src/options.h
+++ b/src/options.h
@@ -15,6 +15,7 @@ struct Opt {
     int ScriptCheckThreads();
     int64_t CheckpointDays();
     uint64_t MaxBlockSizeVote();
+    int64_t UAHFTime();
 
     // Thin block options
     bool UsingThinBlocks();
@@ -29,6 +30,9 @@ static const int MAX_SCRIPTCHECK_THREADS = 16;
 static const int DEFAULT_SCRIPTCHECK_THREADS = 0;
 // Blocks newer than n days will have their script validated during sync.
 static const int DEFAULT_CHECKPOINT_DAYS = 30;
+/** User-activated hard fork default activation time */
+static const int64_t UAHF_DEFAULT_ACTIVATION_TIME = 1501590000; // Tue 1 Aug 2017 12:20:00 UTC
+
 //
 // For unit testing
 //


### PR DESCRIPTION
Signed int64_t is used to allow possible special values as negative numbers, for example a way to specify the default activation time per spec, if we should change our default to 0 or create a second release that does so.
