### PR TITLE
UAHF: REQ 4-1. Max block size increase to 8M.

### DIFF
--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -10,6 +10,8 @@
 
 /** Legacy maximum block size */
 static const unsigned int MAX_BLOCK_SIZE = 1000000;
+/** UAHF initial block size */
+static const unsigned int UAHF_INITIAL_MAX_BLOCK_SIZE = 8000000;
 /** The maximum allowed size for a serialized transaction, in bytes */
 static const unsigned int MAX_TRANSACTION_SIZE = 1000*1000;
 /** The maximum allowed number of signature check operations in a block (network rule) */

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -439,6 +439,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-maxblocksizevote=<n>", _("Set vote for maximum block size in megabytes (default: network sizelimit)"));
     if (showDebug)
         strUsage += HelpMessageOpt("-blockversion=<n>", "Override block version to test forking scenarios");
+    strUsage += HelpMessageOpt("-uahftime=<n>", strprintf(_("Set user-activated hard fork activation time (default: %d) (0=disable)"), UAHF_DEFAULT_ACTIVATION_TIME));
 
     strUsage += HelpMessageGroup(_("RPC server options:"));
     strUsage += HelpMessageOpt("-server", _("Accept command line and JSON-RPC commands"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3785,7 +3785,8 @@ bool static LoadBlockIndexDB(bool* fRebuildRequired)
             pindex->BuildSkip();
         if (pindex->IsValid(BLOCK_VALID_TREE) && (pindexBestHeader == NULL || CBlockIndexWorkComparator()(pindexBestHeader, pindex)))
             pindexBestHeader = pindex;
-        if (item.first < chainparams.GetConsensus().bip100ActivationHeight) {
+        if (((Opt().UAHFTime() != 0) && pindex->pprev && (pindex->pprev->nTime >= Opt().UAHFTime())) ||
+            ((Opt().UAHFTime() == 0) && (item.first < chainparams.GetConsensus().bip100ActivationHeight))) {
             pindex->nMaxBlockSize = MAX_BLOCK_SIZE;
         } else if (firstBIP100Entry == vSortedByHeight.end()) {
             firstBIP100Entry = iter;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -73,6 +73,10 @@ uint64_t Opt::MaxBlockSizeVote() {
     return Args->GetArg("-maxblocksizevote", 0);
 }
 
+int64_t Opt::UAHFTime() {
+    return Args->GetArg("-uahftime", UAHF_DEFAULT_ACTIVATION_TIME);
+}
+
 bool Opt::UsingThinBlocks() {
     if (IsStealthMode())
         return false;

--- a/src/options.h
+++ b/src/options.h
@@ -15,6 +15,7 @@ struct Opt {
     int ScriptCheckThreads();
     int64_t CheckpointDays();
     uint64_t MaxBlockSizeVote();
+    int64_t UAHFTime();
 
     // Thin block options
     bool UsingThinBlocks();
@@ -29,6 +30,9 @@ static const int MAX_SCRIPTCHECK_THREADS = 16;
 static const int DEFAULT_SCRIPTCHECK_THREADS = 0;
 // Blocks newer than n days will have their script validated during sync.
 static const int DEFAULT_CHECKPOINT_DAYS = 30;
+/** User-activated hard fork default activation time */
+static const int64_t UAHF_DEFAULT_ACTIVATION_TIME = 1501590000; // Tue 1 Aug 2017 12:20:00 UTC
+
 //
 // For unit testing
 //

--- a/src/test/maxblocksize_tests.cpp
+++ b/src/test/maxblocksize_tests.cpp
@@ -6,6 +6,7 @@
 #include "maxblocksize.h"
 #include "chain.h"
 #include "chainparams.h"
+#include "options.h"
 #include <algorithm>
 
 BOOST_AUTO_TEST_SUITE(maxblocksize_tests);
@@ -14,16 +15,19 @@ void fillBlockIndex(
         Consensus::Params& params, std::vector<CBlockIndex>& blockIndexes,
         bool addVotes, int64_t currMax) {
 
-    int height = params.bip100ActivationHeight;
+    int height = 0;
+    int64_t blocktime = UAHF_DEFAULT_ACTIVATION_TIME;
+
     CBlockIndex* prev = nullptr;
     for (CBlockIndex& index : blockIndexes)
     {
         index.nHeight = height++;
+        index.nTime = blocktime++;
         index.nMaxBlockSize = currMax;
 
         if (addVotes)
             index.nMaxBlockSizeVote = std::max(
-                (index.nHeight - params.bip100ActivationHeight) * 1000000, 1000000);
+                index.nHeight * 1000000, 1000000);
 
         index.pprev = prev;
         prev = &index;


### PR DESCRIPTION
We bump the block size to 8MB with the fork block, and simultaneously activate BIP100.

Depending on where in the difficulty interval the fork occurs, a BIP100 max size change is theoretically possible at the next retargeting.

bip100-sizelimit.py hasn't been updated.  We need an efficient way to create ~8M blocks.