### PR TITLE
UAHF: REQ 6-1 This-chain replay protection

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -79,6 +79,7 @@ BITCOIN_TESTS =\
   test/rpc_tests.cpp \
   test/sanity_tests.cpp \
   test/scheduler_tests.cpp \
+  test/script_antireplay_tests.cpp \
   test/script_P2SH_tests.cpp \
   test/script_tests.cpp \
   test/scriptnum_tests.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -440,6 +440,7 @@ std::string HelpMessage(HelpMessageMode mode)
     if (showDebug)
         strUsage += HelpMessageOpt("-blockversion=<n>", "Override block version to test forking scenarios");
     strUsage += HelpMessageOpt("-uahftime=<n>", strprintf(_("Set user-activated hard fork activation time (default: %d) (0=disable)"), UAHF_DEFAULT_ACTIVATION_TIME));
+    strUsage += HelpMessageOpt("-uahfprotectsunset=<n>", strprintf(_("Set user-activated hard fork protect-this-chain-from-replay sunset height (default: %d)"), UAHF_DEFAULT_PROTECT_THIS_SUNSET));
 
     strUsage += HelpMessageGroup(_("RPC server options:"));
     strUsage += HelpMessageOpt("-server", _("Accept command line and JSON-RPC commands"));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -439,6 +439,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-maxblocksizevote=<n>", _("Set vote for maximum block size in megabytes (default: network sizelimit)"));
     if (showDebug)
         strUsage += HelpMessageOpt("-blockversion=<n>", "Override block version to test forking scenarios");
+    strUsage += HelpMessageOpt("-uahftime=<n>", strprintf(_("Set user-activated hard fork activation time (default: %d) (0=disable)"), UAHF_DEFAULT_ACTIVATION_TIME));
 
     strUsage += HelpMessageGroup(_("RPC server options:"));
     strUsage += HelpMessageOpt("-server", _("Accept command line and JSON-RPC commands"));

--- a/src/main.h
+++ b/src/main.h
@@ -135,6 +135,8 @@ static const uint64_t nMinDiskSpace = 52428800;
 
 /** Initialize respend bloom filter **/
 void InitRespendFilter();
+/** This-chain replay protection commitment value */
+std::vector<unsigned char>& GetAntiReplayCommitment();
 
 /** Pruning-related variables and constants */
 /** True if any block files have ever been pruned. */
@@ -476,6 +478,8 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW = t
 /** Context-dependent validity checks */
 bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& state, CBlockIndex *pindexPrev);
 bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIndex *pindexPrev);
+bool ContextualCheckTransaction(const CTransaction &tx, CValidationState &state, int nHeight,
+                                int64_t nLockTimeCutoff, int64_t nMedianTimePastPrev);
 
 /** Check a block is completely valid from start to finish (only works on top of our current best block, with cs_main held) */
 bool TestBlockValidity(CValidationState &state, const CBlock& block, CBlockIndex *pindexPrev, bool fCheckPOW = true, bool fCheckMerkleRoot = true);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -73,6 +73,10 @@ uint64_t Opt::MaxBlockSizeVote() {
     return Args->GetArg("-maxblocksizevote", 0);
 }
 
+int64_t Opt::UAHFTime() {
+    return Args->GetArg("-uahftime", UAHF_DEFAULT_ACTIVATION_TIME);
+}
+
 bool Opt::UsingThinBlocks() {
     if (IsStealthMode())
         return false;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -77,6 +77,10 @@ int64_t Opt::UAHFTime() {
     return Args->GetArg("-uahftime", UAHF_DEFAULT_ACTIVATION_TIME);
 }
 
+int Opt::UAHFProtectSunset() {
+    return Args->GetArg("-uahfprotectsunset", UAHF_DEFAULT_PROTECT_THIS_SUNSET);
+}
+
 bool Opt::UsingThinBlocks() {
     if (IsStealthMode())
         return false;

--- a/src/options.h
+++ b/src/options.h
@@ -15,6 +15,7 @@ struct Opt {
     int ScriptCheckThreads();
     int64_t CheckpointDays();
     uint64_t MaxBlockSizeVote();
+    int64_t UAHFTime();
 
     // Thin block options
     bool UsingThinBlocks();
@@ -29,6 +30,9 @@ static const int MAX_SCRIPTCHECK_THREADS = 16;
 static const int DEFAULT_SCRIPTCHECK_THREADS = 0;
 // Blocks newer than n days will have their script validated during sync.
 static const int DEFAULT_CHECKPOINT_DAYS = 30;
+/** User-activated hard fork default activation time */
+static const int64_t UAHF_DEFAULT_ACTIVATION_TIME = 1501590000; // Tue 1 Aug 2017 12:20:00 UTC
+
 //
 // For unit testing
 //

--- a/src/options.h
+++ b/src/options.h
@@ -16,6 +16,7 @@ struct Opt {
     int64_t CheckpointDays();
     uint64_t MaxBlockSizeVote();
     int64_t UAHFTime();
+    int UAHFProtectSunset();
 
     // Thin block options
     bool UsingThinBlocks();
@@ -32,6 +33,8 @@ static const int DEFAULT_SCRIPTCHECK_THREADS = 0;
 static const int DEFAULT_CHECKPOINT_DAYS = 30;
 /** User-activated hard fork default activation time */
 static const int64_t UAHF_DEFAULT_ACTIVATION_TIME = 1501590000; // Tue 1 Aug 2017 12:20:00 UTC
+/** User-activated hard fork protect-this-chain-from-replay sunset height */
+static const int UAHF_DEFAULT_PROTECT_THIS_SUNSET = 530000;
 
 //
 // For unit testing

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -227,3 +227,24 @@ bool CScript::IsPushOnly() const
     }
     return true;
 }
+
+bool CScript::IsCommitment(const std::vector<unsigned char> &data) const {
+    // To ensure we have an immediate push, we limit the commitment size to 64
+    // bytes. In addition to the data themselves, we have 2 extra bytes:
+    // OP_RETURN and the push opcode itself.
+    if (data.size() > 64 || this->size() != data.size() + 2) {
+        return false;
+    }
+
+    if ((*this)[0] != OP_RETURN || (*this)[1] != data.size()) {
+        return false;
+    }
+
+    for (size_t i = 0; i < data.size(); i++) {
+        if ((*this)[i + 2] != data[i]) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -608,6 +608,7 @@ public:
     unsigned int GetSigOpCount(const CScript& scriptSig) const;
 
     bool IsPayToScriptHash() const;
+    bool IsCommitment(const std::vector<unsigned char> &data) const;
 
     /** Called by IsStandardTx and P2SH/BIP62 VerifyScript (which makes it consensus-critical). */
     bool IsPushOnly() const;

--- a/src/test/script_antireplay_tests.cpp
+++ b/src/test/script_antireplay_tests.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2017 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "script/script.h"
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <string>
+#include <vector>
+
+BOOST_FIXTURE_TEST_SUITE(antireplay_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(test_is_commitment) {
+    std::vector<unsigned char> data{};
+
+    // Empty commitment.
+    auto s = CScript() << OP_RETURN << data;
+    BOOST_CHECK(s.IsCommitment(data));
+
+    // Commitment to a value of the wrong size.
+    data.push_back(42);
+    BOOST_CHECK(!s.IsCommitment(data));
+
+    // Not a commitment.
+    s = CScript() << data;
+    BOOST_CHECK(!s.IsCommitment(data));
+
+    // Non empty commitment.
+    s = CScript() << OP_RETURN << data;
+    BOOST_CHECK(s.IsCommitment(data));
+
+    // Commitment to the wrong value.
+    data[0] = 0x42;
+    BOOST_CHECK(!s.IsCommitment(data));
+
+    // Commitment to a larger value.
+    std::string str = "Bitcoin: A peer-to-peer Electronic Cash System";
+    data = std::vector<unsigned char>(str.begin(), str.end());
+    BOOST_CHECK(!s.IsCommitment(data));
+
+    s = CScript() << OP_RETURN << data;
+    BOOST_CHECK(s.IsCommitment(data));
+
+    // 64 bytes commitment, still valid.
+    data.resize(64);
+    s = CScript() << OP_RETURN << data;
+    BOOST_CHECK(s.IsCommitment(data));
+
+    // Commitment is too large.
+    data.push_back(23);
+    s = CScript() << OP_RETURN << data;
+    BOOST_CHECK(!s.IsCommitment(data));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/script_antireplay_tests.cpp
+++ b/src/test/script_antireplay_tests.cpp
@@ -5,6 +5,10 @@
 #include "script/script.h"
 #include "test/test_bitcoin.h"
 
+#include "consensus/validation.h"
+#include "main.h"
+#include "options.h"
+
 #include <boost/test/unit_test.hpp>
 
 #include <string>
@@ -52,6 +56,73 @@ BOOST_AUTO_TEST_CASE(test_is_commitment) {
     data.push_back(23);
     s = CScript() << OP_RETURN << data;
     BOOST_CHECK(!s.IsCommitment(data));
+
+    // Check with the actual replay commitment we are going to use.
+    s = CScript() << OP_RETURN << GetAntiReplayCommitment();
+    BOOST_CHECK(s.IsCommitment(GetAntiReplayCommitment()));
+}
+
+BOOST_AUTO_TEST_CASE(test_antireplay) {
+    const int nBlockHeight = UAHF_DEFAULT_PROTECT_THIS_SUNSET;
+    const int64_t nBlockTime = UAHF_DEFAULT_ACTIVATION_TIME;
+
+    CMutableTransaction tx;
+    tx.nVersion = 1;
+    tx.vin.resize(1);
+    tx.vin[0].prevout.hash = GetRandHash();
+    tx.vin[0].prevout.n = 0;
+    tx.vin[0].scriptSig = CScript();
+    tx.vout.resize(1);
+    tx.vout[0].nValue = 1;
+    tx.vout[0].scriptPubKey = CScript();
+
+    {
+        // Base transaction is valid.
+        CValidationState state;
+        BOOST_CHECK(ContextualCheckTransaction(tx, state, nBlockHeight, nBlockTime, nBlockTime));
+    }
+
+    {
+        // Base transaction is still valid after sunset.
+        CValidationState state;
+        BOOST_CHECK(ContextualCheckTransaction(tx, state, nBlockHeight + 1, nBlockTime, nBlockTime));
+    }
+
+    {
+        // Base transaction is valid before the fork.
+        CValidationState state;
+        BOOST_CHECK(ContextualCheckTransaction(tx, state, nBlockHeight, nBlockTime - 1, nBlockTime -1));
+    }
+
+    tx.vout[0].scriptPubKey = CScript() << OP_RETURN << OP_0;
+
+    {
+        // Wrong commitment, still valid.
+        CValidationState state;
+        BOOST_CHECK(ContextualCheckTransaction(tx, state, nBlockHeight, nBlockTime, nBlockTime));
+    }
+
+    tx.vout[0].scriptPubKey = CScript() << OP_RETURN
+                                        << GetAntiReplayCommitment();
+
+    {
+        // Anti replay commitment, not valid anymore.
+        CValidationState state;
+        BOOST_CHECK(!ContextualCheckTransaction(tx, state, nBlockHeight, nBlockTime, nBlockTime));
+        BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-txn-replay");
+    }
+
+    {
+        // Anti replay commitment, disabled before start time.
+        CValidationState state;
+        BOOST_CHECK(ContextualCheckTransaction(tx, state, nBlockHeight, nBlockTime - 1, nBlockTime - 1));
+    }
+
+    {
+        // Anti replay commitment, disabled after sunset.
+        CValidationState state;
+        BOOST_CHECK(ContextualCheckTransaction(tx, state, nBlockHeight + 1, nBlockTime, nBlockTime));
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
REQ-6-1 This-chain replay protection.

Disallow a special OP_RETURN commitment, to enable transactions to be protected from execution on the UAHF chain.  A configurable sunset height is set to the specified default of 530000.
