### PR TITLE
UAHF: REQ-7 Difficulty adjustement in case of hashrate drop

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -439,6 +439,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-maxblocksizevote=<n>", _("Set vote for maximum block size in megabytes (default: network sizelimit)"));
     if (showDebug)
         strUsage += HelpMessageOpt("-blockversion=<n>", "Override block version to test forking scenarios");
+    strUsage += HelpMessageOpt("-uahftime=<n>", strprintf(_("Set user-activated hard fork activation time (default: %d) (0=disable)"), UAHF_DEFAULT_ACTIVATION_TIME));
 
     strUsage += HelpMessageGroup(_("RPC server options:"));
     strUsage += HelpMessageOpt("-server", _("Accept command line and JSON-RPC commands"));

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -73,6 +73,10 @@ uint64_t Opt::MaxBlockSizeVote() {
     return Args->GetArg("-maxblocksizevote", 0);
 }
 
+int64_t Opt::UAHFTime() {
+    return Args->GetArg("-uahftime", UAHF_DEFAULT_ACTIVATION_TIME);
+}
+
 bool Opt::UsingThinBlocks() {
     if (IsStealthMode())
         return false;

--- a/src/options.h
+++ b/src/options.h
@@ -15,6 +15,7 @@ struct Opt {
     int ScriptCheckThreads();
     int64_t CheckpointDays();
     uint64_t MaxBlockSizeVote();
+    int64_t UAHFTime();
 
     // Thin block options
     bool UsingThinBlocks();
@@ -29,6 +30,9 @@ static const int MAX_SCRIPTCHECK_THREADS = 16;
 static const int DEFAULT_SCRIPTCHECK_THREADS = 0;
 // Blocks newer than n days will have their script validated during sync.
 static const int DEFAULT_CHECKPOINT_DAYS = 30;
+/** User-activated hard fork default activation time */
+static const int64_t UAHF_DEFAULT_ACTIVATION_TIME = 1501590000; // Tue 1 Aug 2017 12:20:00 UTC
+
 //
 // For unit testing
 //

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -20,34 +20,65 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
         return nProofOfWorkLimit;
 
     // Only change once per difficulty adjustment interval
-    if ((pindexLast->nHeight+1) % params.DifficultyAdjustmentInterval() != 0)
-    {
-        if (params.fPowAllowMinDifficultyBlocks)
-        {
-            // Special difficulty rule for testnet:
-            // If the new block's timestamp is more than 2* 10 minutes
-            // then allow mining of a min-difficulty block.
-            if (pblock->GetBlockTime() > pindexLast->GetBlockTime() + params.nPowTargetSpacing*2)
-                return nProofOfWorkLimit;
-            else
-            {
-                // Return the last non-special-min-difficulty-rules-block
-                const CBlockIndex* pindex = pindexLast;
-                while (pindex->pprev && pindex->nHeight % params.DifficultyAdjustmentInterval() != 0 && pindex->nBits == nProofOfWorkLimit)
-                    pindex = pindex->pprev;
-                return pindex->nBits;
-            }
-        }
-        return pindexLast->nBits;
+    uint32_t nHeight = pindexLast->nHeight + 1;
+    if (nHeight % params.DifficultyAdjustmentInterval() == 0) {
+        // Go back by what we want to be 14 days worth of blocks
+        assert(nHeight >= params.DifficultyAdjustmentInterval());
+        uint32_t nHeightFirst = nHeight - params.DifficultyAdjustmentInterval();
+        const CBlockIndex *pindexFirst = pindexLast->GetAncestor(nHeightFirst);
+        assert(pindexFirst);
+
+        return CalculateNextWorkRequired(pindexLast,
+                                         pindexFirst->GetBlockTime(), params);
     }
 
-    // Go back by what we want to be 14 days worth of blocks
-    int nHeightFirst = pindexLast->nHeight - (params.DifficultyAdjustmentInterval()-1);
-    assert(nHeightFirst >= 0);
-    const CBlockIndex* pindexFirst = pindexLast->GetAncestor(nHeightFirst);
-    assert(pindexFirst);
+    if (params.fPowAllowMinDifficultyBlocks) {
+        // Special difficulty rule for testnet:
+        // If the new block's timestamp is more than 2* 10 minutes then allow
+        // mining of a min-difficulty block.
+        if (pblock->GetBlockTime() >
+            pindexLast->GetBlockTime() + 2 * params.nPowTargetSpacing) {
+            return nProofOfWorkLimit;
+        }
 
-    return CalculateNextWorkRequired(pindexLast, pindexFirst->GetBlockTime(), params);
+        // Return the last non-special-min-difficulty-rules-block
+        const CBlockIndex *pindex = pindexLast;
+        while (pindex->pprev &&
+               pindex->nHeight % params.DifficultyAdjustmentInterval() != 0 &&
+               pindex->nBits == nProofOfWorkLimit) {
+            pindex = pindex->pprev;
+        }
+
+        return pindex->nBits;
+    }
+
+    // Do not go lower than the POW limit.
+    uint32_t nBits = pindexLast->nBits;
+    if (nBits == nProofOfWorkLimit) {
+        return nProofOfWorkLimit;
+    }
+
+    // If producing the last 6 block took less than 12h, we keep the same difficulty.
+    const CBlockIndex *pindex6 = pindexLast->GetAncestor(nHeight - 7);
+    assert(pindex6);
+    int64_t mtp6blocks =
+        pindexLast->GetMedianTimePast() - pindex6->GetMedianTimePast();
+    if (mtp6blocks < 12 * 3600) {
+        return nBits;
+    }
+
+    // If producing the last 6 block took more than 12h, increase the difficulty
+    // target by 25% (which reduces the difficulty by 20%). This ensure the
+    // chain do not get stuck in case we lose hashrate abruptly.
+    arith_uint256 nPow;
+    nPow.SetCompact(nBits);
+    nPow += (nPow >> 2);
+
+    // Make sure we do not go below allowed values.
+    const arith_uint256 bnPowLimit = UintToArith256(params.powLimit);
+    if (nPow > bnPowLimit) nPow = bnPowLimit;
+
+    return nPow.GetCompact();
 }
 
 unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params& params)

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -7,6 +7,7 @@
 
 #include "arith_uint256.h"
 #include "chain.h"
+#include "options.h"
 #include "primitives/block.h"
 #include "uint256.h"
 #include "util.h"
@@ -57,6 +58,10 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     if (nBits == nProofOfWorkLimit) {
         return nProofOfWorkLimit;
     }
+
+    // Done, unless checking UAHF fast difficulty drop
+    if ((Opt().UAHFTime() == 0) || (pindexLast->GetMedianTimePast() < Opt().UAHFTime()))
+        return nBits;
 
     // If producing the last 6 block took less than 12h, we keep the same difficulty.
     const CBlockIndex *pindex6 = pindexLast->GetAncestor(nHeight - 7);

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -108,37 +108,78 @@ BOOST_AUTO_TEST_CASE(retargeting_test) {
     SelectParams(CBaseChainParams::MAIN);
     const Consensus::Params &params = Params().GetConsensus();
 
-    std::vector<CBlockIndex> blocks(1013);
+    std::vector<CBlockIndex> blocks(115);
+
+    const arith_uint256 powLimit = UintToArith256(params.powLimit);
+    arith_uint256 currentPow = powLimit >> 1;
+    uint32_t initialBits = currentPow.GetCompact();
 
     // Genesis block?
     blocks[0] = CBlockIndex();
     blocks[0].nHeight = 0;
     blocks[0].nTime = 1269211443;
-    blocks[0].nBits = 0x207fffff;
+    blocks[0].nBits = initialBits;
 
     // Pile up some blocks.
-    for (size_t i = 1; i < 1000; i++) {
-        blocks[i] =
-            GetBlockIndex(&blocks[i - 1], params.nPowTargetSpacing, 0x207fffff);
+    for (size_t i = 1; i < 100; i++) {
+        blocks[i] = GetBlockIndex(&blocks[i - 1], params.nPowTargetSpacing,
+                                  initialBits);
     }
 
     CBlockHeader blkHeaderDummy;
 
     // We start getting 2h blocks time. For the first 5 blocks, it doesn't
     // matter as the MTP is not affected. For the next 5 block, MTP difference
-    // increases but stays bellow 12h.
-    for (size_t i = 1000; i < 1010; i++) {
-        blocks[i] = GetBlockIndex(&blocks[i - 1], 2 * 3600, 0x207fffff);
+    // increases but stays below 12h.
+    for (size_t i = 100; i < 110; i++) {
+        blocks[i] = GetBlockIndex(&blocks[i - 1], 2 * 3600, initialBits);
         BOOST_CHECK_EQUAL(
             GetNextWorkRequired(&blocks[i], &blkHeaderDummy, params),
-            0x207fffff);
+            initialBits);
     }
 
     // Now we expect the difficulty to decrease.
-    blocks[1010] = GetBlockIndex(&blocks[1009], 2 * 3600, 0x207fffff);
+    blocks[110] = GetBlockIndex(&blocks[109], 2 * 3600, initialBits);
+    currentPow.SetCompact(currentPow.GetCompact());
+    currentPow += (currentPow >> 2);
     BOOST_CHECK_EQUAL(
-        GetNextWorkRequired(&blocks[1010], &blkHeaderDummy, params),
-        0x1d00ffff);
+        GetNextWorkRequired(&blocks[110], &blkHeaderDummy, params),
+        currentPow.GetCompact());
+
+    // As we continue with 2h blocks, difficulty continue to decrease.
+    blocks[111] =
+        GetBlockIndex(&blocks[110], 2 * 3600, currentPow.GetCompact());
+    currentPow.SetCompact(currentPow.GetCompact());
+    currentPow += (currentPow >> 2);
+    BOOST_CHECK_EQUAL(
+        GetNextWorkRequired(&blocks[111], &blkHeaderDummy, params),
+        currentPow.GetCompact());
+
+    // We decrease again.
+    blocks[112] =
+        GetBlockIndex(&blocks[111], 2 * 3600, currentPow.GetCompact());
+    currentPow.SetCompact(currentPow.GetCompact());
+    currentPow += (currentPow >> 2);
+    BOOST_CHECK_EQUAL(
+        GetNextWorkRequired(&blocks[112], &blkHeaderDummy, params),
+        currentPow.GetCompact());
+
+    // We check that we do not go below the minimal difficulty.
+    blocks[113] =
+        GetBlockIndex(&blocks[112], 2 * 3600, currentPow.GetCompact());
+    currentPow.SetCompact(currentPow.GetCompact());
+    currentPow += (currentPow >> 2);
+    BOOST_CHECK(powLimit.GetCompact() != currentPow.GetCompact());
+    BOOST_CHECK_EQUAL(
+        GetNextWorkRequired(&blocks[113], &blkHeaderDummy, params),
+        powLimit.GetCompact());
+
+    // Once we reached the minimal difficulty, we stick with it.
+    blocks[114] = GetBlockIndex(&blocks[113], 2 * 3600, powLimit.GetCompact());
+    BOOST_CHECK(powLimit.GetCompact() != currentPow.GetCompact());
+    BOOST_CHECK_EQUAL(
+        GetNextWorkRequired(&blocks[114], &blkHeaderDummy, params),
+        powLimit.GetCompact());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -105,6 +105,7 @@ static CBlockIndex GetBlockIndex(CBlockIndex *pindexPrev, int64_t nTimeInterval,
 }
 
 BOOST_AUTO_TEST_CASE(retargeting_test) {
+    mapArgs["-uahftime"] = "1";
     SelectParams(CBaseChainParams::MAIN);
     const Consensus::Params &params = Params().GetConsensus();
 
@@ -180,6 +181,8 @@ BOOST_AUTO_TEST_CASE(retargeting_test) {
     BOOST_CHECK_EQUAL(
         GetNextWorkRequired(&blocks[114], &blkHeaderDummy, params),
         powLimit.GetCompact());
+
+    mapArgs.erase("-uahftime");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -93,4 +93,52 @@ BOOST_AUTO_TEST_CASE(GetBlockProofEquivalentTime_test)
     }
 }
 
+static CBlockIndex GetBlockIndex(CBlockIndex *pindexPrev, int64_t nTimeInterval,
+                                 uint32_t nBits) {
+    CBlockIndex block;
+    block.pprev = pindexPrev;
+    block.nHeight = pindexPrev->nHeight + 1;
+    block.nTime = pindexPrev->nTime + nTimeInterval;
+    block.nBits = nBits;
+
+    return block;
+}
+
+BOOST_AUTO_TEST_CASE(retargeting_test) {
+    SelectParams(CBaseChainParams::MAIN);
+    const Consensus::Params &params = Params().GetConsensus();
+
+    std::vector<CBlockIndex> blocks(1013);
+
+    // Genesis block?
+    blocks[0] = CBlockIndex();
+    blocks[0].nHeight = 0;
+    blocks[0].nTime = 1269211443;
+    blocks[0].nBits = 0x207fffff;
+
+    // Pile up some blocks.
+    for (size_t i = 1; i < 1000; i++) {
+        blocks[i] =
+            GetBlockIndex(&blocks[i - 1], params.nPowTargetSpacing, 0x207fffff);
+    }
+
+    CBlockHeader blkHeaderDummy;
+
+    // We start getting 2h blocks time. For the first 5 blocks, it doesn't
+    // matter as the MTP is not affected. For the next 5 block, MTP difference
+    // increases but stays bellow 12h.
+    for (size_t i = 1000; i < 1010; i++) {
+        blocks[i] = GetBlockIndex(&blocks[i - 1], 2 * 3600, 0x207fffff);
+        BOOST_CHECK_EQUAL(
+            GetNextWorkRequired(&blocks[i], &blkHeaderDummy, params),
+            0x207fffff);
+    }
+
+    // Now we expect the difficulty to decrease.
+    blocks[1010] = GetBlockIndex(&blocks[1009], 2 * 3600, 0x207fffff);
+    BOOST_CHECK_EQUAL(
+        GetNextWorkRequired(&blocks[1010], &blkHeaderDummy, params),
+        0x1d00ffff);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Between regular adjustments, difficulty drops 20% when timestamp difference >= 12 hours is seen across 6 block intervals.