### PR TITLE
UAHF: Adjust block size DoS limit

### DIFF
--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -8,6 +8,7 @@
 #include "consensus/validation.h"
 #include "chainparams.h"
 #include "hash.h"
+#include "maxblocksize.h"
 #include "random.h"
 #include "streams.h"
 #include "txmempool.h"
@@ -71,7 +72,7 @@ unsigned int minTxSize() {
 }
 
 void validateNumTxs(size_t transactions, uint64_t currMaxBlockSize) {
-    uint64_t maxBlockSize =  currMaxBlockSize * 105 / 100; // max size after next block adjustmnet
+    uint64_t maxBlockSize = NextBlockRaiseCap(currMaxBlockSize);
     if (transactions > maxBlockSize / minTxSize())
         throw std::invalid_argument("compact block exceeds max txs in a block");
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4490,7 +4490,7 @@ static std::map<std::string, size_t> maxMessageSizes = boost::assign::map_list_o
 bool static SanityCheckMessage(CNode* peer, const CNetMessage& msg)
 {
     const std::string& strCommand = msg.hdr.GetCommand();
-    uint64_t nMaxMessageSize = GetMaxBlockSize() * 105 / 100;
+    uint64_t nMaxMessageSize = NextBlockRaiseCap(GetMaxBlockSize());
     if (msg.hdr.nMessageSize > nMaxMessageSize ||
         (maxMessageSizes.count(strCommand) && msg.hdr.nMessageSize > maxMessageSizes[strCommand])) {
         LogPrint("net", "Oversized %s message from peer=%i (%d bytes)\n",

--- a/src/maxblocksize.cpp
+++ b/src/maxblocksize.cpp
@@ -146,3 +146,13 @@ uint64_t GetMaxBlockSizeVote(const CScript &coinbase, int32_t nHeight)
 
     return static_cast<uint64_t>(FindVote(s)) * 1000000;
 }
+
+uint64_t NextBlockRaiseCap(uint64_t maxCurrBlock) {
+    if (maxCurrBlock == MAX_BLOCK_SIZE) {
+        // next block may be a UAHF block
+        return UAHF_INITIAL_MAX_BLOCK_SIZE;
+    }
+
+    // BIP100 allows block size limit to be increased 5%.
+    return maxCurrBlock * 105 / 100;
+}

--- a/src/maxblocksize.h
+++ b/src/maxblocksize.h
@@ -19,4 +19,8 @@ uint64_t GetNextMaxBlockSize(const CBlockIndex* pindexLast, const Consensus::Par
 
 uint64_t GetMaxBlockSizeVote(const CScript &coinbase, int32_t nHeight);
 
+// Max potential size for next block.
+// Accounts for UAHF and BIP100 adjustment.
+uint64_t NextBlockRaiseCap(uint64_t maxCurrBlock);
+
 #endif // BITCOIN_MAXBLOCKSIZE_H

--- a/src/test/ReceiveMsgBytes_tests.cpp
+++ b/src/test/ReceiveMsgBytes_tests.cpp
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(TooLargeBlock)
     s << block;
 
     // Test: too large
-    size_t nMaxMessageSize = chainActive.Tip()->nMaxBlockSize * 105 / 100;
+    size_t nMaxMessageSize = NextBlockRaiseCap(chainActive.Tip()->nMaxBlockSize);
     s.resize(nMaxMessageSize + headerLen + 1);
     CNetMessage::FinalizeHeader(s);
 

--- a/src/test/maxblocksize_tests.cpp
+++ b/src/test/maxblocksize_tests.cpp
@@ -205,4 +205,9 @@ BOOST_AUTO_TEST_CASE(get_max_blocksize_vote_no_vote) {
     BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(coinbase, 47));
 }
 
+BOOST_AUTO_TEST_CASE(next_block_raise_cap) {
+    BOOST_CHECK_EQUAL(UAHF_INITIAL_MAX_BLOCK_SIZE, NextBlockRaiseCap(MAX_BLOCK_SIZE));
+    BOOST_CHECK_EQUAL(MAX_BLOCK_SIZE * 10 * 1.05, NextBlockRaiseCap(MAX_BLOCK_SIZE * 10));
+}
+
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/test/xthin_tests.cpp
+++ b/src/test/xthin_tests.cpp
@@ -10,6 +10,7 @@
 #include "chainparams.h"
 #include "blockencodings.h"
 #include "consensus/consensus.h" // MAX_BLOCK_SIZE
+#include "maxblocksize.h"
 #include <iostream>
 
 // Workaround for segfaulting
@@ -158,7 +159,7 @@ BOOST_AUTO_TEST_CASE(xthin_stub_self_validate) {
     // not too big
     {
         XThinBlock xblock(TestBlock1(), CBloomFilter(), false);
-        uint64_t nextMaxBlockSize = currMaxBlockSize * 105 / 100;
+        uint64_t nextMaxBlockSize = NextBlockRaiseCap(currMaxBlockSize);
         uint64_t notTooMany = nextMaxBlockSize / minTxSize();
         xblock.txHashes.resize(notTooMany);
         for (size_t i = 1 /* skip coinbase */; i < notTooMany; ++i)


### PR DESCRIPTION
DoS limits for block size was adjusted for BIP100, but not a sudden jump to 8MB.