### PR TITLE
REGTEST: Run all tests in a post-fork environment

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -99,7 +99,6 @@ testScriptsExt = [
 # Needs update for BCC.
 #    'bip100-sizelimit.py',
     'bip9-softforks.py',
-    'bipdersig-p2p.py',
     'bip65-cltv-p2p.py',
     'bip65-cltv.py',
     'bip68-sequence.py',

--- a/qa/rpc-tests/bip100-sizelimit.py
+++ b/qa/rpc-tests/bip100-sizelimit.py
@@ -77,7 +77,7 @@ class BigBlockTest(BitcoinTestFramework):
                         if (limit >= 250):
                             break
                 rawtx = self.nodes[3].createrawtransaction(inputs, outputs)
-                txdata = self.nodes[3].signrawtransaction(rawtx, None, None, "ALL")["hex"]
+                txdata = self.nodes[3].signrawtransaction(rawtx)["hex"]
                 self.nodes[3].sendrawtransaction(txdata)
                 tx_file.write(txdata+"\n")
             tx_file.close()

--- a/qa/rpc-tests/bip65-cltv-p2p.py
+++ b/qa/rpc-tests/bip65-cltv-p2p.py
@@ -35,6 +35,7 @@ Mine 1 old-version block.
 Mine 1 new version block.
 Mine 1 old version block, see that the node rejects.
 '''
+
 class BIP65Test(ComparisonTestFramework):
 
     def __init__(self):
@@ -57,7 +58,7 @@ class BIP65Test(ComparisonTestFramework):
         inputs = [{ "txid" : from_txid, "vout" : 0}]
         outputs = { to_address : amount }
         rawtx = node.createrawtransaction(inputs, outputs)
-        signresult = node.signrawtransaction(rawtx, None, None, "ALL")
+        signresult = node.signrawtransaction(rawtx)
         tx = CTransaction()
         f = cStringIO.StringIO(unhexlify(signresult['hex']))
         tx.deserialize(f)

--- a/qa/rpc-tests/bip68-112-113-p2p.py
+++ b/qa/rpc-tests/bip68-112-113-p2p.py
@@ -125,7 +125,7 @@ class BIP68_112_113Test(ComparisonTestFramework):
 
     def sign_transaction(self, node, unsignedtx):
         rawtx = ToHex(unsignedtx)
-        signresult = node.signrawtransaction(rawtx, None, None, "ALL")
+        signresult = node.signrawtransaction(rawtx)
         tx = CTransaction()
         f = cStringIO.StringIO(unhexlify(signresult['hex']))
         tx.deserialize(f)

--- a/qa/rpc-tests/bip68-sequence.py
+++ b/qa/rpc-tests/bip68-sequence.py
@@ -71,7 +71,7 @@ class BIP68Test(BitcoinTestFramework):
         tx1.vin = [CTxIn(COutPoint(int(utxo["txid"], 16), utxo["vout"]), nSequence=sequence_value)] 
         tx1.vout = [CTxOut(value, CScript([b'a']))]
 
-        tx1_signed = self.nodes[0].signrawtransaction(ToHex(tx1), None, None, "ALL")["hex"]
+        tx1_signed = self.nodes[0].signrawtransaction(ToHex(tx1))["hex"]
         tx1_id = self.nodes[0].sendrawtransaction(tx1_signed)
         tx1_id = int(tx1_id, 16)
 
@@ -182,7 +182,7 @@ class BIP68Test(BitcoinTestFramework):
             # Overestimate the size of the tx - signatures should be less than 120 bytes, and leave 50 for the output
             tx_size = len(ToHex(tx))//2 + 120*num_inputs + 50
             tx.vout.append(CTxOut(int(value-self.relayfee*tx_size*COIN/1000), CScript([b'a'])))
-            rawtx = self.nodes[0].signrawtransaction(ToHex(tx), None, None, "ALL")["hex"]
+            rawtx = self.nodes[0].signrawtransaction(ToHex(tx))["hex"]
 
             try:
                 self.nodes[0].sendrawtransaction(rawtx)
@@ -213,7 +213,7 @@ class BIP68Test(BitcoinTestFramework):
         tx2.nVersion = 2
         tx2.vin = [CTxIn(COutPoint(tx1.sha256, 0), nSequence=0)]
         tx2.vout = [CTxOut(int(tx1.vout[0].nValue - self.relayfee*COIN), CScript([b'a']))]
-        tx2_raw = self.nodes[0].signrawtransaction(ToHex(tx2), None, None, "ALL")["hex"]
+        tx2_raw = self.nodes[0].signrawtransaction(ToHex(tx2))["hex"]
         tx2 = FromHex(tx2, tx2_raw)
         tx2.rehash()
 
@@ -287,7 +287,7 @@ class BIP68Test(BitcoinTestFramework):
         utxos = self.nodes[0].listunspent()
         tx5.vin.append(CTxIn(COutPoint(int(utxos[0]["txid"], 16), utxos[0]["vout"]), nSequence=1))
         tx5.vout[0].nValue += int(utxos[0]["amount"]*COIN)
-        raw_tx5 = self.nodes[0].signrawtransaction(ToHex(tx5), None, None, "ALL")["hex"]
+        raw_tx5 = self.nodes[0].signrawtransaction(ToHex(tx5))["hex"]
 
         try:
             self.nodes[0].sendrawtransaction(raw_tx5)
@@ -348,7 +348,7 @@ class BIP68Test(BitcoinTestFramework):
         tx2.vout = [CTxOut(int(tx1.vout[0].nValue - self.relayfee*COIN), CScript([b'a']))]
 
         # sign tx2
-        tx2_raw = self.nodes[0].signrawtransaction(ToHex(tx2), None, None, "ALL")["hex"]
+        tx2_raw = self.nodes[0].signrawtransaction(ToHex(tx2))["hex"]
         tx2 = FromHex(tx2, tx2_raw)
         tx2.rehash()
 
@@ -381,6 +381,7 @@ class BIP68Test(BitcoinTestFramework):
 
         self.nodes[0].submitblock(ToHex(block))
         assert_equal(self.nodes[0].getbestblockhash(), block.hash)
+
 
 if __name__ == '__main__':
     BIP68Test().main()

--- a/qa/rpc-tests/bip9-softforks.py
+++ b/qa/rpc-tests/bip9-softforks.py
@@ -60,7 +60,7 @@ class BIP9SoftForksTest(ComparisonTestFramework):
         return tx
 
     def sign_transaction(self, node, tx):
-        signresult = node.signrawtransaction(hexlify(tx.serialize()), None, None, "ALL")
+        signresult = node.signrawtransaction(hexlify(tx.serialize()))
         tx = CTransaction()
         f = cStringIO.StringIO(unhexlify(signresult['hex']))
         tx.deserialize(f)

--- a/qa/rpc-tests/bipdersig-p2p.py
+++ b/qa/rpc-tests/bipdersig-p2p.py
@@ -66,7 +66,7 @@ class BIP66Test(ComparisonTestFramework):
         inputs = [{ "txid" : from_txid, "vout" : 0}]
         outputs = { to_address : amount }
         rawtx = node.createrawtransaction(inputs, outputs)
-        signresult = node.signrawtransaction(rawtx, None, None, "ALL")
+        signresult = node.signrawtransaction(rawtx)
         tx = CTransaction()
         f = cStringIO.StringIO(unhexlify(signresult['hex']))
         tx.deserialize(f)

--- a/qa/rpc-tests/mempool_packages.py
+++ b/qa/rpc-tests/mempool_packages.py
@@ -33,7 +33,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         for i in xrange(num_outputs):
             outputs[node.getnewaddress()] = send_value
         rawtx = node.createrawtransaction(inputs, outputs)
-        signedtx = node.signrawtransaction(rawtx, None, None, "ALL")
+        signedtx = node.signrawtransaction(rawtx)
         txid = node.sendrawtransaction(signedtx['hex'])
         fulltx = node.getrawtransaction(txid, 1)
         assert(len(fulltx['vout']) == num_outputs) # make sure we didn't generate a change output
@@ -144,7 +144,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         for i in xrange(2):
             outputs[self.nodes[0].getnewaddress()] = send_value
         rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
-        signedtx = self.nodes[0].signrawtransaction(rawtx, None, None, "ALL")
+        signedtx = self.nodes[0].signrawtransaction(rawtx)
         txid = self.nodes[0].sendrawtransaction(signedtx['hex'])
         tx0_id = txid
         value = send_value
@@ -168,7 +168,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         inputs = [ {'txid' : tx1_id, 'vout': 0}, {'txid' : txid, 'vout': 0} ]
         outputs = { self.nodes[0].getnewaddress() : send_value + value - 4*fee }
         rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
-        signedtx = self.nodes[0].signrawtransaction(rawtx, None, None, "ALL")
+        signedtx = self.nodes[0].signrawtransaction(rawtx)
         txid = self.nodes[0].sendrawtransaction(signedtx['hex'])
         sync_mempools(self.nodes)
         

--- a/qa/rpc-tests/mempool_reorg.py
+++ b/qa/rpc-tests/mempool_reorg.py
@@ -31,7 +31,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         inputs = [{ "txid" : from_txid, "vout" : 0}]
         outputs = { to_address : amount }
         rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
-        signresult = self.nodes[0].signrawtransaction(rawtx, None, None, "ALL")
+        signresult = self.nodes[0].signrawtransaction(rawtx)
         assert_equal(signresult["complete"], True)
         return signresult["hex"]
 
@@ -63,7 +63,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         # Set the time lock
         timelock_tx = timelock_tx.replace("ffffffff", "11111111", 1)
         timelock_tx = timelock_tx[:-8] + hex(self.nodes[0].getblockcount() + 2)[2:] + "000000"
-        timelock_tx = self.nodes[0].signrawtransaction(timelock_tx, None, None, "ALL")["hex"]
+        timelock_tx = self.nodes[0].signrawtransaction(timelock_tx)["hex"]
         assert_raises(JSONRPCException, self.nodes[0].sendrawtransaction, timelock_tx)
 
         # Broadcast and mine spend_102 and 103:

--- a/qa/rpc-tests/mempool_resurrect_test.py
+++ b/qa/rpc-tests/mempool_resurrect_test.py
@@ -27,7 +27,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         inputs = [{ "txid" : from_txid, "vout" : 0}]
         outputs = { to_address : amount }
         rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
-        signresult = self.nodes[0].signrawtransaction(rawtx, None, None, "ALL")
+        signresult = self.nodes[0].signrawtransaction(rawtx)
         assert_equal(signresult["complete"], True)
         return signresult["hex"]
 

--- a/qa/rpc-tests/mempool_spendcoinbase.py
+++ b/qa/rpc-tests/mempool_spendcoinbase.py
@@ -32,7 +32,7 @@ class MempoolSpendCoinbaseTest(BitcoinTestFramework):
         inputs = [{ "txid" : from_txid, "vout" : 0}]
         outputs = { to_address : amount }
         rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
-        signresult = self.nodes[0].signrawtransaction(rawtx, None, None, "ALL")
+        signresult = self.nodes[0].signrawtransaction(rawtx)
         assert_equal(signresult["complete"], True)
         return signresult["hex"]
 

--- a/qa/rpc-tests/merkle_blocks.py
+++ b/qa/rpc-tests/merkle_blocks.py
@@ -45,9 +45,9 @@ class MerkleBlockTest(BitcoinTestFramework):
 
         node0utxos = self.nodes[0].listunspent(1)
         tx1 = self.nodes[0].createrawtransaction([node0utxos.pop()], {self.nodes[1].getnewaddress(): 50})
-        txid1 = self.nodes[0].sendrawtransaction(self.nodes[0].signrawtransaction(tx1, None, None, "ALL")["hex"])
+        txid1 = self.nodes[0].sendrawtransaction(self.nodes[0].signrawtransaction(tx1)["hex"])
         tx2 = self.nodes[0].createrawtransaction([node0utxos.pop()], {self.nodes[1].getnewaddress(): 50})
-        txid2 = self.nodes[0].sendrawtransaction(self.nodes[0].signrawtransaction(tx2, None, None, "ALL")["hex"])
+        txid2 = self.nodes[0].sendrawtransaction(self.nodes[0].signrawtransaction(tx2)["hex"])
         assert_raises(JSONRPCException, self.nodes[0].gettxoutproof, [txid1])
 
         self.nodes[0].generate(1)
@@ -65,7 +65,7 @@ class MerkleBlockTest(BitcoinTestFramework):
 
         txin_spent = self.nodes[1].listunspent(1).pop()
         tx3 = self.nodes[1].createrawtransaction([txin_spent], {self.nodes[0].getnewaddress(): 50})
-        self.nodes[0].sendrawtransaction(self.nodes[1].signrawtransaction(tx3, None, None, "ALL")["hex"])
+        self.nodes[0].sendrawtransaction(self.nodes[1].signrawtransaction(tx3)["hex"])
         self.nodes[0].generate(1)
         self.sync_all()
 

--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -125,7 +125,7 @@ class RawTransactionsTest(BitcoinTestFramework):
                 break;
 
         bal = self.nodes[0].getbalance()
-        inputs = [{ "txid" : txId, "vout" : vout['n'], "scriptPubKey" : vout['scriptPubKey']['hex']}]
+        inputs = [{ "txid" : txId, "vout" : vout['n'], "scriptPubKey" : vout['scriptPubKey']['hex'], "amount" : vout['value']}]
         outputs = { self.nodes[0].getnewaddress() : 2.19 }
         rawTx = self.nodes[2].createrawtransaction(inputs, outputs)
         rawTxPartialSigned = self.nodes[1].signrawtransaction(rawTx, inputs)

--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -55,7 +55,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         inputs  = [ {'txid' : "1d1d4e24ed99057e84c3f80fd8fbec79ed9e1acee37da269356ecea000000000", 'vout' : 1}] #won't exists
         outputs = { self.nodes[0].getnewaddress() : 4.998 }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
-        rawtx   = self.nodes[2].signrawtransaction(rawtx, None, None, "ALL")
+        rawtx   = self.nodes[2].signrawtransaction(rawtx)
 
         errorString = ""
         try:
@@ -128,13 +128,11 @@ class RawTransactionsTest(BitcoinTestFramework):
         inputs = [{ "txid" : txId, "vout" : vout['n'], "scriptPubKey" : vout['scriptPubKey']['hex']}]
         outputs = { self.nodes[0].getnewaddress() : 2.19 }
         rawTx = self.nodes[2].createrawtransaction(inputs, outputs)
-        rawTxPartialSigned = self.nodes[1].signrawtransaction(rawTx, inputs, None, "ALL")
-        # node1 only has one key, can't comp. sign the tx
-        assert_equal(rawTxPartialSigned['complete'], False)
+        rawTxPartialSigned = self.nodes[1].signrawtransaction(rawTx, inputs)
+        assert_equal(rawTxPartialSigned['complete'], False) #node1 only has one key, can't comp. sign the tx
         
-        rawTxSigned = self.nodes[2].signrawtransaction(rawTx, inputs, None, "ALL")
-        # node2 can sign the tx compl., own two of three keys
-        assert_equal(rawTxSigned['complete'], True)
+        rawTxSigned = self.nodes[2].signrawtransaction(rawTx, inputs)
+        assert_equal(rawTxSigned['complete'], True) #node2 can sign the tx compl., own two of three keys
         self.nodes[2].sendrawtransaction(rawTxSigned['hex'])
         rawTx = self.nodes[0].decoderawtransaction(rawTxSigned['hex'])
         self.sync_all()

--- a/qa/rpc-tests/signrawtransactions.py
+++ b/qa/rpc-tests/signrawtransactions.py
@@ -36,7 +36,7 @@ class SignRawTransactionsTest(BitcoinTestFramework):
         outputs = {'mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB': 0.1}
 
         rawTx = self.nodes[0].createrawtransaction(inputs, outputs)
-        rawTxSigned = self.nodes[0].signrawtransaction(rawTx, inputs, privKeys, "ALL")
+        rawTxSigned = self.nodes[0].signrawtransaction(rawTx, inputs, privKeys)
 
         # 1) The transaction has a complete set of signatures
         assert 'complete' in rawTxSigned
@@ -77,7 +77,7 @@ class SignRawTransactionsTest(BitcoinTestFramework):
         outputs = {'mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB': 0.1}
 
         rawTx = self.nodes[0].createrawtransaction(inputs, outputs)
-        rawTxSigned = self.nodes[0].signrawtransaction(rawTx, scripts, privKeys, "ALL")
+        rawTxSigned = self.nodes[0].signrawtransaction(rawTx, scripts, privKeys)
 
         # 3) The transaction has no complete set of signatures
         assert 'complete' in rawTxSigned

--- a/qa/rpc-tests/smartfees.py
+++ b/qa/rpc-tests/smartfees.py
@@ -91,7 +91,7 @@ def split_inputs(from_node, txins, txouts, initial_split = False):
     # If this is the initial split we actually need to sign the transaction
     # Otherwise we just need to insert the property ScriptSig
     if (initial_split) :
-        completetx = from_node.signrawtransaction(rawtx, None, None, "ALL")["hex"]
+        completetx = from_node.signrawtransaction(rawtx)["hex"]
     else :
         completetx = rawtx[0:82] + SCRIPT_SIG[prevtxout["vout"]] + rawtx[84:]
     txid = from_node.sendrawtransaction(completetx, True)

--- a/qa/rpc-tests/spv.py
+++ b/qa/rpc-tests/spv.py
@@ -154,7 +154,7 @@ class SPVTest(BitcoinTestFramework):
         tx2parent_output[self.nodes[1].getnewaddress()] = 12.5
         tx2parent_output[self.nodes[1].getnewaddress()] = 12.48
         tx2parent = self.nodes[1].createrawtransaction([tx2parent_input], tx2parent_output)
-        tx2parentsignresult = self.nodes[1].signrawtransaction(tx2parent, None, None, "ALL")
+        tx2parentsignresult = self.nodes[1].signrawtransaction(tx2parent)
         assert_equal(tx2parentsignresult["complete"], True)
         tx2parent_id = self.nodes[1].sendrawtransaction(tx2parentsignresult["hex"])
 
@@ -169,7 +169,7 @@ class SPVTest(BitcoinTestFramework):
         tx2_output[self.nodes[0].getnewaddress()] = 2
         tx2_output[self.nodes[1].getnewaddress()] = 10.48
         tx2 = self.nodes[1].createrawtransaction([tx2_input], tx2_output)
-        tx2signresult = self.nodes[1].signrawtransaction(tx2, None, None, "ALL")
+        tx2signresult = self.nodes[1].signrawtransaction(tx2)
         assert_equal(tx2signresult["complete"], True)
         tx2_id = self.nodes[1].sendrawtransaction(tx2signresult["hex"])
 

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -356,7 +356,7 @@ def send_zeropri_transaction(from_node, to_node, amount, fee):
     outputs[self_address] = float(amount+fee)
 
     self_rawtx = from_node.createrawtransaction(inputs, outputs)
-    self_signresult = from_node.signrawtransaction(self_rawtx, None, None, "ALL")
+    self_signresult = from_node.signrawtransaction(self_rawtx)
     self_txid = from_node.sendrawtransaction(self_signresult["hex"], True)
 
     vout = find_output(from_node, self_txid, amount+fee)
@@ -366,7 +366,7 @@ def send_zeropri_transaction(from_node, to_node, amount, fee):
     outputs = { to_node.getnewaddress() : float(amount) }
 
     rawtx = from_node.createrawtransaction(inputs, outputs)
-    signresult = from_node.signrawtransaction(rawtx, None, None, "ALL")
+    signresult = from_node.signrawtransaction(rawtx)
     txid = from_node.sendrawtransaction(signresult["hex"], True)
 
     return (txid, signresult["hex"])
@@ -396,7 +396,7 @@ def random_transaction(nodes, amount, min_fee, fee_increment, fee_variants):
     outputs[to_node.getnewaddress()] = float(amount)
 
     rawtx = from_node.createrawtransaction(inputs, outputs)
-    signresult = from_node.signrawtransaction(rawtx, None, None, "ALL")
+    signresult = from_node.signrawtransaction(rawtx)
     txid = from_node.sendrawtransaction(signresult["hex"], True)
 
     return (txid, signresult["hex"], fee)
@@ -420,7 +420,7 @@ def assert_raises(exc, fun, *args, **kwds):
         raise AssertionError("No exception raised")
 
 def satoshi_round(amount):
-    return Decimal(amount).quantize(Decimal('0.00000001'), rounding=ROUND_DOWN)
+    return  Decimal(amount).quantize(Decimal('0.00000001'), rounding=ROUND_DOWN)
 
 def get_bip9_status(node, key):
     info = node.getblockchaininfo()

--- a/qa/rpc-tests/txn_clone.py
+++ b/qa/rpc-tests/txn_clone.py
@@ -89,7 +89,7 @@ class TxnMallTest(BitcoinTestFramework):
 
         # Use a different signature hash type to sign.  This creates an equivalent but malleated clone.
         # Don't send the clone anywhere yet
-        tx1_clone = self.nodes[0].signrawtransaction(clone_raw, None, None, "ALL|ANYONECANPAY")
+        tx1_clone = self.nodes[0].signrawtransaction(clone_raw, None, None, "ALL|FORKID|ANYONECANPAY")
         assert_equal(tx1_clone["complete"], True)
 
         # Have node0 mine a block, if requested:

--- a/qa/rpc-tests/txn_clone.py
+++ b/qa/rpc-tests/txn_clone.py
@@ -33,8 +33,7 @@ class TxnMallTest(BitcoinTestFramework):
         starting_balance = 1250
         for i in range(4):
             assert_equal(self.nodes[i].getbalance(), starting_balance)
-            # bug workaround, coins generated assigned to first getnewaddress!
-            self.nodes[i].getnewaddress("")
+            self.nodes[i].getnewaddress("")  # bug workaround, coins generated assigned to first getnewaddress!
 
         # Assign coins to foo and bar accounts:
         self.nodes[0].settxfee(.001)

--- a/qa/rpc-tests/txn_doublespend.py
+++ b/qa/rpc-tests/txn_doublespend.py
@@ -60,7 +60,7 @@ class TxnMallTest(BitcoinTestFramework):
         outputs[node1_address] = 1240
         outputs[change_address] = 1248 - 1240 + doublespend_fee
         rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
-        doublespend = self.nodes[0].signrawtransaction(rawtx, None, None, "ALL")
+        doublespend = self.nodes[0].signrawtransaction(rawtx)
         assert_equal(doublespend["complete"], True)
 
         # Create two spends using 1 50 BTC coin each

--- a/qa/rpc-tests/txn_doublespendrelay.py
+++ b/qa/rpc-tests/txn_doublespendrelay.py
@@ -61,7 +61,7 @@ class DoubleSpendRelay(BitcoinTestFramework):
         change_outputs = make_change(nodes[0], total_in, amount, fee)
         outputs = dict(change_outputs)
         outputs[nodes[3].getnewaddress()] = amount
-        signed = nodes[0].signrawtransaction(nodes[0].createrawtransaction(tx1_inputs, outputs), None, None, "ALL")
+        signed = nodes[0].signrawtransaction(nodes[0].createrawtransaction(tx1_inputs, outputs))
         txid1 = nodes[0].sendrawtransaction(signed["hex"], True)
         sync_mempools([nodes[0], nodes[3]])
 
@@ -79,7 +79,7 @@ class DoubleSpendRelay(BitcoinTestFramework):
         change_outputs = make_change(nodes[0], total_in, amount, fee)
         outputs = dict(change_outputs)
         outputs[nodes[0].getnewaddress()] = amount
-        signed = nodes[0].signrawtransaction(nodes[0].createrawtransaction(inputs2, outputs), None, None, "ALL")
+        signed = nodes[0].signrawtransaction(nodes[0].createrawtransaction(inputs2, outputs))
         txid2 = nodes[1].sendrawtransaction(signed["hex"], True)
         # Wait until txid2 is relayed to nodes[3] (but don't wait forever):
         # Note we can't use sync_mempools, because the respend isn't added to
@@ -98,7 +98,7 @@ class DoubleSpendRelay(BitcoinTestFramework):
         # Third spend: nodes[0] -> nodes[0]
         outputs = dict(change_outputs)
         outputs[nodes[0].getnewaddress()] = amount
-        signed = nodes[0].signrawtransaction(nodes[0].createrawtransaction(inputs2, outputs), None, None, "ALL")
+        signed = nodes[0].signrawtransaction(nodes[0].createrawtransaction(inputs2, outputs))
         txid3 = nodes[1].sendrawtransaction(signed["hex"], True)
         # Ensure txid3 not relayed to nodes[3]:
         time.sleep(9.1)
@@ -117,7 +117,7 @@ class DoubleSpendRelay(BitcoinTestFramework):
         change_outputs = make_change(nodes[0], total_in, amount, fee)
         outputs = dict(change_outputs)
         outputs[nodes[0].getnewaddress()] = amount
-        signed = nodes[0].signrawtransaction(nodes[0].createrawtransaction(inputs4, outputs), None, None, "ALL")
+        signed = nodes[0].signrawtransaction(nodes[0].createrawtransaction(inputs4, outputs))
         txid4 = nodes[1].sendrawtransaction(signed["hex"], True)
         # Wait until txid4 is relayed to nodes[3] (but don't wait forever):
         def txid4_relay():
@@ -138,7 +138,7 @@ class DoubleSpendRelay(BitcoinTestFramework):
         change_outputs = make_change(nodes[0], total_in, amount, fee)
         outputs = dict(change_outputs)
         outputs[nodes[0].getnewaddress()] = amount
-        signed = nodes[0].signrawtransaction(nodes[0].createrawtransaction(inputs5, outputs), None, None, "ALL")
+        signed = nodes[0].signrawtransaction(nodes[0].createrawtransaction(inputs5, outputs))
         txid5 = nodes[1].sendrawtransaction(signed["hex"], True)
         # Wait until txid5 is relayed to nodes[3] (but don't wait forever):
         def txid5_relay():

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -88,7 +88,7 @@ class WalletTest (BitcoinTestFramework):
             inputs.append({ "txid" : utxo["txid"], "vout" : utxo["vout"]})
             outputs[self.nodes[2].getnewaddress("from1")] = utxo["amount"]
             raw_tx = self.nodes[0].createrawtransaction(inputs, outputs)
-            txns_to_send.append(self.nodes[0].signrawtransaction(raw_tx, None, None, "ALL"))
+            txns_to_send.append(self.nodes[0].signrawtransaction(raw_tx))
 
         # Have node 1 (miner) send the transactions
         self.nodes[1].sendrawtransaction(txns_to_send[0]["hex"], True)
@@ -161,7 +161,7 @@ class WalletTest (BitcoinTestFramework):
 
         rawTx = self.nodes[1].createrawtransaction(inputs, outputs).replace("c0833842", "00000000") #replace 11.11 with 0.0 (int32)
         decRawTx = self.nodes[1].decoderawtransaction(rawTx)
-        signedRawTx = self.nodes[1].signrawtransaction(rawTx, None, None, "ALL")
+        signedRawTx = self.nodes[1].signrawtransaction(rawTx)
         decRawTx = self.nodes[1].decoderawtransaction(signedRawTx['hex'])
         zeroValueTxid= decRawTx['txid']
         sendResp = self.nodes[1].sendrawtransaction(signedRawTx['hex'])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -322,12 +322,16 @@ libbitcoin_util_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 libbitcoin_util_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_util_a_SOURCES = \
   support/pagelocker.cpp \
+  chainparams.cpp \
   chainparamsbase.cpp \
   clientversion.cpp \
   compat/glibc_sanity.cpp \
   compat/glibcxx_sanity.cpp \
   compat/strnlen.cpp \
+  crypto/sha256.cpp \
   options.cpp \
+  primitives/block.cpp \
+  primitives/transaction.cpp \
   random.cpp \
   rpcprotocol.cpp \
   support/cleanse.cpp \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3433,7 +3433,10 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
     }
 
     const int64_t uahfTime = Opt().UAHFTime();
-    if (uahfTime != 0) {
+    if (uahfTime != 0 &&
+        !((Params().NetworkIDString() == CBaseChainParams::REGTEST) &&
+          (uahfTime == Params().GenesisBlock().nTime))) {
+
         // If UAHF is enabled for the current block, but not for the previous
         // block, this is the fork block, so we must check that the block is larger than 1MB.
         const int64_t nMTPPrevPrev = (pindexPrev == NULL || pindexPrev->pprev == NULL ? 0 :

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1,3 +1,4 @@
+#include "chainparams.h"
 #include "options.h"
 #include "util.h"
 #include <stdexcept>
@@ -74,7 +75,11 @@ uint64_t Opt::MaxBlockSizeVote() {
 }
 
 int64_t Opt::UAHFTime() {
-    return Args->GetArg("-uahftime", UAHF_DEFAULT_ACTIVATION_TIME);
+    int64_t defaultUAHFTime = Params().NetworkIDString() == CBaseChainParams::REGTEST ?
+                              Params().GenesisBlock().nTime :
+                              UAHF_DEFAULT_ACTIVATION_TIME;
+
+    return Args->GetArg("-uahftime", defaultUAHFTime);
 }
 
 int Opt::UAHFProtectSunset() {

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -532,7 +532,8 @@ UniValue signrawtransaction(const UniValue& params, bool fHelp)
             "         \"txid\":\"id\",             (string, required) The transaction id\n"
             "         \"vout\":n,                  (numeric, required) The output number\n"
             "         \"scriptPubKey\": \"hex\",   (string, required) script key\n"
-            "         \"redeemScript\": \"hex\"    (string, required for P2SH) redeem script\n"
+            "         \"redeemScript\": \"hex\",   (string, required for P2SH) redeem script\n"
+            "         \"amount\": value            (numeric, required) The amount spent\n"
             "       }\n"
             "       ,...\n"
             "    ]\n"
@@ -675,7 +676,10 @@ UniValue signrawtransaction(const UniValue& params, bool fHelp)
                 if ((unsigned int)nOut >= coins->vout.size())
                     coins->vout.resize(nOut+1);
                 coins->vout[nOut].scriptPubKey = scriptPubKey;
-                coins->vout[nOut].nValue = 0; // we don't know the actual output value
+                coins->vout[nOut].nValue = 0;
+                if (prevOut.exists("amount")) {
+                    coins->vout[nOut].nValue = AmountFromValue(find_value(prevOut, "amount"));
+                }
             }
 
             // if redeemScript given and not using the local wallet (private keys
@@ -740,7 +744,6 @@ UniValue signrawtransaction(const UniValue& params, bool fHelp)
         const CScript& prevPubKey = coins->vout[txin.prevout.n].scriptPubKey;
         const CAmount &amount = coins->vout[txin.prevout.n].nValue;
 
-        txin.scriptSig.clear();
         // Only sign SIGHASH_SINGLE if there's a corresponding output:
         if (!fHashSingle || (i < mergedTx.vout.size()))
             SignSignature(keystore, prevPubKey, mergedTx, i, amount, nHashType);

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         tx.vout.resize(1);
         tx.vout[0].nValue = 1*CENT;
         tx.vout[0].scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());
-        SignSignature(keystore, txPrev, tx, 0);
+        SignSignature(keystore, txPrev, tx, 0, SIGHASH_ALL | SIGHASH_FORKID);
 
         AddOrphanTx(tx, i);
     }
@@ -171,7 +171,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
             tx.vin[j].prevout.n = j;
             tx.vin[j].prevout.hash = txPrev.GetHash();
         }
-        SignSignature(keystore, txPrev, tx, 0);
+        SignSignature(keystore, txPrev, tx, 0, SIGHASH_ALL | SIGHASH_FORKID);
         // Re-use same signature for other inputs
         // (they don't have to be valid for this test)
         for (unsigned int j = 1; j < tx.vin.size(); j++)

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -28,7 +28,7 @@ BOOST_FIXTURE_TEST_SUITE(multisig_tests, BasicTestingSetup)
 CScript
 sign_multisig(CScript scriptPubKey, vector<CKey> keys, CTransaction transaction, int whichIn)
 {
-    uint256 hash = SignatureHash(scriptPubKey, transaction, whichIn, SIGHASH_ALL, 0);
+    uint256 hash = SignatureHash(scriptPubKey, transaction, whichIn, SIGHASH_ALL | SIGHASH_FORKID, 0);
 
     CScript result;
     result << OP_0; // CHECKMULTISIG bug workaround
@@ -36,7 +36,7 @@ sign_multisig(CScript scriptPubKey, vector<CKey> keys, CTransaction transaction,
     {
         vector<unsigned char> vchSig;
         BOOST_CHECK(key.Sign(hash, vchSig));
-        vchSig.push_back((unsigned char)SIGHASH_ALL);
+        vchSig.push_back((unsigned char)(SIGHASH_ALL | SIGHASH_FORKID));
         result << vchSig;
     }
     return result;
@@ -44,7 +44,7 @@ sign_multisig(CScript scriptPubKey, vector<CKey> keys, CTransaction transaction,
 
 BOOST_AUTO_TEST_CASE(multisig_verify)
 {
-    unsigned int flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC;
+    unsigned int flags = SCRIPT_VERIFY_P2SH | SCRIPT_ENABLE_SIGHASH_FORKID | SCRIPT_VERIFY_STRICTENC;
 
     ScriptError err;
     CKey key[4];
@@ -313,7 +313,7 @@ BOOST_AUTO_TEST_CASE(multisig_Sign)
 
     for (int i = 0; i < 3; i++)
     {
-        BOOST_CHECK_MESSAGE(SignSignature(keystore, txFrom, txTo[i], 0), strprintf("SignSignature %d", i));
+        BOOST_CHECK_MESSAGE(SignSignature(keystore, txFrom, txTo[i], 0, SIGHASH_ALL | SIGHASH_FORKID), strprintf("SignSignature %d", i));
     }
 }
 

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -108,9 +108,9 @@ BOOST_AUTO_TEST_CASE(rpc_rawsign)
     string notsigned = r.get_str();
     string privkey1 = "\"KzsXybp9jX64P5ekX1KUxRQ79Jht9uzW7LorgwE65i5rWACL6LQe\"";
     string privkey2 = "\"Kyhdf5LuKTRx4ge69ybABsiUAWjVRK4XGxAKk2FQLp2HjGMy87Z4\"";
-    r = CallRPC(string("signrawtransaction ")+notsigned+" "+prevout+" "+"[] ALL");
+    r = CallRPC(string("signrawtransaction ")+notsigned+" "+prevout+" "+"[]");
     BOOST_CHECK(find_value(r.get_obj(), "complete").get_bool() == false);
-    r = CallRPC(string("signrawtransaction ")+notsigned+" "+prevout+" "+"["+privkey1+","+privkey2+"] ALL");
+    r = CallRPC(string("signrawtransaction ")+notsigned+" "+prevout+" "+"["+privkey1+","+privkey2+"]");
     BOOST_CHECK(find_value(r.get_obj(), "complete").get_bool() == true);
 }
 

--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "core_io.h"
 #include "key.h"
 #include "keystore.h"
 #include "main.h"
@@ -44,7 +45,7 @@ Verify(const CScript& scriptSig, const CScript& scriptPubKey, bool fStrict, Scri
     txTo.vin[0].scriptSig = scriptSig;
     txTo.vout[0].nValue = 1;
 
-    return VerifyScript(scriptSig, scriptPubKey, fStrict ? SCRIPT_VERIFY_P2SH : SCRIPT_VERIFY_NONE, MutableTransactionSignatureChecker(&txTo, 0, txFrom.vout[0].nValue), &err);
+    return VerifyScript(scriptSig, scriptPubKey, fStrict ? SCRIPT_VERIFY_P2SH | SIGHASH_FORKID: SCRIPT_VERIFY_NONE, MutableTransactionSignatureChecker(&txTo, 0, txFrom.vout[0].nValue), &err);
 }
 
 
@@ -106,7 +107,7 @@ BOOST_AUTO_TEST_CASE(sign)
     }
     for (int i = 0; i < 8; i++)
     {
-        BOOST_CHECK_MESSAGE(SignSignature(keystore, txFrom, txTo[i], 0), strprintf("SignSignature %d", i));
+        BOOST_CHECK_MESSAGE(SignSignature(keystore, txFrom, txTo[i], 0, SIGHASH_ALL | SIGHASH_FORKID), strprintf("SignSignature %d", i));
     }
     // All of the above should be OK, and the txTos have valid signatures
     // Check to make sure signature verification fails if we use the wrong ScriptSig:
@@ -115,7 +116,7 @@ BOOST_AUTO_TEST_CASE(sign)
         {
             CScript sigSave = txTo[i].vin[0].scriptSig;
             txTo[i].vin[0].scriptSig = txTo[j].vin[0].scriptSig;
-            bool sigOK = CScriptCheck(CCoins(txFrom, 0), txTo[i], 0, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC, false)();
+            bool sigOK = CScriptCheck(CCoins(txFrom, 0), txTo[i], 0, SCRIPT_VERIFY_P2SH | SCRIPT_ENABLE_SIGHASH_FORKID | SCRIPT_VERIFY_STRICTENC, false)();
             if (i == j)
                 BOOST_CHECK_MESSAGE(sigOK, strprintf("VerifySignature %d %d", i, j));
             else
@@ -203,7 +204,7 @@ BOOST_AUTO_TEST_CASE(set)
     }
     for (int i = 0; i < 4; i++)
     {
-        BOOST_CHECK_MESSAGE(SignSignature(keystore, txFrom, txTo[i], 0), strprintf("SignSignature %d", i));
+        BOOST_CHECK_MESSAGE(SignSignature(keystore, txFrom, txTo[i], 0, SIGHASH_ALL | SIGHASH_FORKID), strprintf("SignSignature %d", i));
         BOOST_CHECK_MESSAGE(IsStandardTx(txTo[i], reason), strprintf("txTo[%d].IsStandard", i));
     }
 }
@@ -332,9 +333,9 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
         txTo.vin[i].prevout.n = i;
         txTo.vin[i].prevout.hash = txFrom.GetHash();
     }
-    BOOST_CHECK(SignSignature(keystore, txFrom, txTo, 0));
-    BOOST_CHECK(SignSignature(keystore, txFrom, txTo, 1));
-    BOOST_CHECK(SignSignature(keystore, txFrom, txTo, 2));
+    BOOST_CHECK(SignSignature(keystore, txFrom, txTo, 0, SIGHASH_ALL | SIGHASH_FORKID));
+    BOOST_CHECK(SignSignature(keystore, txFrom, txTo, 1, SIGHASH_ALL | SIGHASH_FORKID));
+    BOOST_CHECK(SignSignature(keystore, txFrom, txTo, 2, SIGHASH_ALL | SIGHASH_FORKID));
     // SignSignature doesn't know how to sign these. We're
     // not testing validating signatures, so just create
     // dummy signatures that DO include the correct P2SH scripts:


### PR DESCRIPTION
In regtest, default UAHF activation to the genesis block, and relax the requirement to mine a big fork block when the UAHF activation is set to the new default.

Revert earlier RPC test changes that were aimed at generating non-SIGHASH_FORKID transactions.  All RPC tests now run with the new BIP143-derived signature hashing scheme.

Remove the bipdersig test as the UAHF requires STRICTENC by consensus.