### PR TITLE
Add comptool.RejectResult

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -93,7 +93,9 @@ testScripts = [
     'walletbackup.py',
     'p2p-versionbits-warning.py',
     'decodescript.py',
-    'sendheaders.py'
+    'sendheaders.py',
+    'invalidblockrequest.py',
+    'invalidtxrequest.py'
 ]
 testScriptsExt = [
 # Needs update for BCC.
@@ -116,7 +118,6 @@ testScriptsExt = [
     'rpcbind_test.py',
     'smartfees.py',
     'maxblocksinflight.py',
-    'invalidblockrequest.py',
     'rawtransactions.py',
     'p2p-acceptblock.py',
     'p2p-compactblocks.py',

--- a/qa/rpc-tests/invalidblockrequest.py
+++ b/qa/rpc-tests/invalidblockrequest.py
@@ -6,7 +6,7 @@
 
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.util import *
-from test_framework.comptool import TestManager, TestInstance
+from test_framework.comptool import TestManager, TestInstance, RejectResult
 from test_framework.mininode import *
 from test_framework.blocktools import *
 import logging
@@ -25,7 +25,7 @@ re-requested.
 # Use the ComparisonTestFramework with 1 node: only use --testbinary.
 class InvalidBlockRequestTest(ComparisonTestFramework):
 
-    ''' Can either run this test as 1 node with expected answers, or two and compare them. 
+    ''' Can either run this test as 1 node with expected answers, or two and compare them.
         Change the "outcome" variable from each TestInstance object to only do the comparison. '''
     def __init__(self):
         self.num_nodes = 1
@@ -70,7 +70,7 @@ class InvalidBlockRequestTest(ComparisonTestFramework):
         Now we use merkle-root malleability to generate an invalid block with
         same blockheader.
         Manufacture a block with 3 transactions (coinbase, spend of prior
-        coinbase, spend of that spend).  Duplicate the 3rd transaction to 
+        coinbase, spend of that spend).  Duplicate the 3rd transaction to
         leave merkle root and blockheader unchanged but invalidate the block.
         '''
         block2 = create_block(self.tip, create_coinbase(), self.block_time)
@@ -94,7 +94,7 @@ class InvalidBlockRequestTest(ComparisonTestFramework):
         assert(block2_orig.vtx != block2.vtx)
 
         self.tip = block2.sha256
-        yield TestInstance([[block2, False], [block2_orig, True]])
+        yield TestInstance([[block2, RejectResult(16,'bad-txns-duplicate')], [block2_orig, True]])
 
         '''
         Make sure that a totally screwed up block is not valid.
@@ -108,7 +108,7 @@ class InvalidBlockRequestTest(ComparisonTestFramework):
         block3.rehash()
         block3.solve()
 
-        yield TestInstance([[block3, False]])
+        yield TestInstance([[block3, RejectResult(16,'bad-cb-amount')]])
 
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/invalidtxrequest.py
+++ b/qa/rpc-tests/invalidtxrequest.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python2
+#
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+
+from test_framework.test_framework import ComparisonTestFramework
+from test_framework.util import *
+from test_framework.comptool import TestManager, TestInstance, RejectResult
+from test_framework.mininode import *
+from test_framework.blocktools import *
+import logging
+import copy
+import time
+
+
+'''
+In this test we connect to one node over p2p, and test tx requests.
+'''
+
+# Use the ComparisonTestFramework with 1 node: only use --testbinary.
+class InvalidTxRequestTest(ComparisonTestFramework):
+
+    ''' Can either run this test as 1 node with expected answers, or two and compare them.
+        Change the "outcome" variable from each TestInstance object to only do the comparison. '''
+    def __init__(self):
+        self.num_nodes = 1
+
+    def run_test(self):
+        test = TestManager(self, self.options.tmpdir)
+        test.add_all_connections(self.nodes)
+        self.tip = None
+        self.block_time = None
+        NetworkThread().start() # Start up network handling in another thread
+        test.run()
+
+    def get_tests(self):
+        if self.tip is None:
+            self.tip = int ("0x" + self.nodes[0].getbestblockhash() + "L", 0)
+        self.block_time = int(time.time())+1
+
+        '''
+        Create a new block with an anyone-can-spend coinbase
+        '''
+        height = 1
+        block = create_block(self.tip, create_coinbase(height), self.block_time)
+        self.block_time += 1
+        block.solve()
+        # Save the coinbase for later
+        self.block1 = block
+        self.tip = block.sha256
+        height += 1
+        yield TestInstance([[block, True]])
+
+        '''
+        Now we need that block to mature so we can spend the coinbase.
+        '''
+        test = TestInstance(sync_every_block=False)
+        for i in xrange(100):
+            block = create_block(self.tip, create_coinbase(height), self.block_time)
+            block.solve()
+            self.tip = block.sha256
+            self.block_time += 1
+            test.blocks_and_transactions.append([block, True])
+            height += 1
+        yield test
+
+        # chr(100) is OP_NOTIF
+        # Transaction will be rejected with code 16 (REJECT_INVALID)
+        tx1 = create_transaction(self.block1.vtx[0], 0, chr(100), 50*100000000)
+        yield TestInstance([[tx1, RejectResult(16, 'mandatory-script-verify-flag-failed')]])
+
+        # TODO: test further transactions...
+
+if __name__ == '__main__':
+    InvalidTxRequestTest().main()

--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -27,6 +27,20 @@ generator that returns TestInstance objects.  See below for definition.
 
 global mininode_lock
 
+def wait_until(predicate, attempts=float('inf'), timeout=float('inf')):
+    attempt = 0
+    elapsed = 0
+
+    while attempt < attempts and elapsed < timeout:
+        with mininode_lock:
+            if predicate():
+                return True
+        attempt += 1
+        elapsed += 0.05
+        time.sleep(0.05)
+
+    return False
+
 class TestNode(NodeConnCB):
 
     def __init__(self, block_store, tx_store):
@@ -42,6 +56,10 @@ class TestNode(NodeConnCB):
         # a response
         self.pingMap = {}
         self.lastInv = []
+        self.closed = False
+
+    def on_close(self, conn):
+        self.closed = True
 
     def add_connection(self, conn):
         self.conn = conn
@@ -131,6 +149,7 @@ class TestManager(object):
     def __init__(self, testgen, datadir):
         self.test_generator = testgen
         self.connections    = []
+        self.test_nodes     = []
         self.block_store    = BlockStore(datadir)
         self.tx_store       = TxStore(datadir)
         self.ping_counter   = 1
@@ -138,58 +157,44 @@ class TestManager(object):
     def add_all_connections(self, nodes):
         for i in range(len(nodes)):
             # Create a p2p connection to each node
-            self.connections.append(NodeConn('127.0.0.1', p2p_port(i),
-                        nodes[i], TestNode(self.block_store, self.tx_store)))
+            test_node = TestNode(self.block_store, self.tx_store)
+            self.test_nodes.append(test_node)
+            self.connections.append(NodeConn('127.0.0.1', p2p_port(i), nodes[i], test_node))
             # Make sure the TestNode (callback class) has a reference to its
             # associated NodeConn
-            self.connections[-1].cb.add_connection(self.connections[-1])
+            test_node.add_connection(self.connections[-1])
+
+    def wait_for_disconnections(self):
+        def disconnected():
+            return all(node.closed for node in self.test_nodes)
+        return wait_until(disconnected, timeout=10)
 
     def clear_all_connections(self):
         self.connections    = []
         self.test_nodes     = []
 
     def wait_for_verack(self):
-        sleep_time = 0.05
-        max_tries = 10 / sleep_time  # Wait at most 10 seconds
-        while max_tries > 0:
-            done = True
-            with mininode_lock:
-                for c in self.connections:
-                    if c.cb.verack_received is False:
-                        done = False
-                        break
-            if done:
-                break
-            time.sleep(sleep_time)
+        def veracked():
+            return all(node.verack_received for node in self.test_nodes)
+        return wait_until(veracked, timeout=10)
 
     def wait_for_pings(self, counter):
-        received_pongs = False
-        while received_pongs is not True:
-            time.sleep(0.05)
-            received_pongs = True
-            with mininode_lock:
-                for c in self.connections:
-                    if c.cb.received_ping_response(counter) is not True:
-                        received_pongs = False
-                        break
+        def received_pongs():
+            return all(node.received_ping_response(counter) for node in self.test_nodes)
+        return wait_until(received_pongs)
 
     # sync_blocks: Wait for all connections to request the blockhash given
     # then send get_headers to find out the tip of each node, and synchronize
     # the response by using a ping (and waiting for pong with same nonce).
     def sync_blocks(self, blockhash, num_blocks):
-        # Wait for nodes to request block (50ms sleep * 20 tries * num_blocks)
-        max_tries = 20*num_blocks
-        while max_tries > 0:
-            with mininode_lock:
-                results = [ blockhash in c.cb.block_request_map and
-                            c.cb.block_request_map[blockhash] for c in self.connections ]
-            if False not in results:
-                break
-            time.sleep(0.05)
-            max_tries -= 1
+        def blocks_requested():
+            return all(
+                blockhash in node.block_request_map and node.block_request_map[blockhash]
+                for node in self.test_nodes
+            )
 
         # --> error if not requested
-        if max_tries == 0:
+        if not wait_until(blocks_requested, attempts=20*num_blocks):
             # print [ c.cb.block_request_map for c in self.connections ]
             raise AssertionError("Not all nodes requested block")
         # --> Answer request (we did this inline!)
@@ -205,18 +210,14 @@ class TestManager(object):
     # Analogous to sync_block (see above)
     def sync_transaction(self, txhash, num_events):
         # Wait for nodes to request transaction (50ms sleep * 20 tries * num_events)
-        max_tries = 20*num_events
-        while max_tries > 0:
-            with mininode_lock:
-                results = [ txhash in c.cb.tx_request_map and
-                            c.cb.tx_request_map[txhash] for c in self.connections ]
-            if False not in results:
-                break
-            time.sleep(0.05)
-            max_tries -= 1
+        def transaction_requested():
+            return all(
+                txhash in node.tx_request_map and node.tx_request_map[txhash]
+                for node in self.test_nodes
+            )
 
         # --> error if not requested
-        if max_tries == 0:
+        if not wait_until(transaction_requested, attempts=20*num_events):
             # print [ c.cb.tx_request_map for c in self.connections ]
             raise AssertionError("Not all nodes requested transaction")
         # --> Answer request (we did this inline!)
@@ -339,6 +340,7 @@ class TestManager(object):
             print "Test %d: PASS" % test_number, [ c.rpc.getblockcount() for c in self.connections ]
             test_number += 1
 
+        [ c.disconnect_node() for c in self.connections ]
+        self.wait_for_disconnections()
         self.block_store.close()
         self.tx_store.close()
-        [ c.disconnect_node() for c in self.connections ]

--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -41,6 +41,20 @@ def wait_until(predicate, attempts=float('inf'), timeout=float('inf')):
 
     return False
 
+class RejectResult(object):
+    '''
+    Outcome that expects rejection of a transaction or block.
+    '''
+    def __init__(self, code, reason=''):
+        self.code = code
+        self.reason = reason
+    def match(self, other):
+        if self.code != other.code:
+            return False
+        return other.reason.startswith(self.reason)
+    def __repr__(self):
+        return '%i:%s' % (self.code,self.reason or '*')
+
 class TestNode(NodeConnCB):
 
     def __init__(self, block_store, tx_store):
@@ -51,6 +65,8 @@ class TestNode(NodeConnCB):
         self.block_request_map = {}
         self.tx_store = tx_store
         self.tx_request_map = {}
+        self.block_reject_map = {}
+        self.tx_reject_map = {}
 
         # When the pingmap is non-empty we're waiting for
         # a response
@@ -93,6 +109,12 @@ class TestNode(NodeConnCB):
             del self.pingMap[message.nonce]
         except KeyError:
             raise AssertionError("Got pong for unknown ping [%s]" % repr(message))
+
+    def on_reject(self, conn, message):
+        if message.message == 'tx':
+            self.tx_reject_map[message.data] = RejectResult(message.code, message.reason)
+        if message.message == 'block':
+            self.block_reject_map[message.data] = RejectResult(message.code, message.reason)
 
     def send_inv(self, obj):
         mtype = 2 if isinstance(obj, CBlock) else 1
@@ -242,6 +264,15 @@ class TestManager(object):
                 if outcome is None:
                     if c.cb.bestblockhash != self.connections[0].cb.bestblockhash:
                         return False
+                elif isinstance(outcome, RejectResult): # Check that block was rejected w/ code
+                    if c.cb.bestblockhash == blockhash:
+                        return False
+                    if blockhash not in c.cb.block_reject_map:
+                        print 'Block not in reject map: %064x' % (blockhash)
+                        return False
+                    if not outcome.match(c.cb.block_reject_map[blockhash]):
+                        print 'Block rejected with %s instead of expected %s: %064x' % (c.cb.block_reject_map[blockhash], outcome, blockhash)
+                        return False
                 elif ((c.cb.bestblockhash == blockhash) != outcome):
                     # print c.cb.bestblockhash, blockhash, outcome
                     return False
@@ -260,6 +291,15 @@ class TestManager(object):
                     # Make sure the mempools agree with each other
                     if c.cb.lastInv != self.connections[0].cb.lastInv:
                         # print c.rpc.getrawmempool()
+                        return False
+                elif isinstance(outcome, RejectResult): # Check that tx was rejected w/ code
+                    if txhash in c.cb.lastInv:
+                        return False
+                    if txhash not in c.cb.tx_reject_map:
+                        print 'Tx not in reject map: %064x' % (txhash)
+                        return False
+                    if not outcome.match(c.cb.tx_reject_map[txhash]):
+                        print 'Tx rejected with %s instead of expected %s: %064x' % (c.cb.tx_reject_map[txhash], outcome, txhash)
                         return False
                 elif ((txhash in c.cb.lastInv) != outcome):
                     # print c.rpc.getrawmempool(), c.cb.lastInv

--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -121,8 +121,8 @@ class TestNode(NodeConnCB):
 #    or false, then only the last tx is tested against outcome.)
 
 class TestInstance(object):
-    def __init__(self, objects=[], sync_every_block=True, sync_every_tx=False):
-        self.blocks_and_transactions = objects
+    def __init__(self, objects=None, sync_every_block=True, sync_every_tx=False):
+        self.blocks_and_transactions = objects if objects else []
         self.sync_every_block = sync_every_block
         self.sync_every_tx = sync_every_tx
 


### PR DESCRIPTION
I cherry-picked this to get the class comptool.RejectResult, which is a prerequisite for a rpc test I'm porting for Bitcoin ABC.

As a bonus this also contains a couple of bug fixes and a new rpc test, invalidtxrequest.py.

Contains commits from:
https://github.com/bitcoin/bitcoin/pull/6465 - Don't share objects between TestInstances
https://github.com/bitcoin/bitcoin/pull/6509 - Fix race condition on test node shutdown
https://github.com/bitcoin/bitcoin/pull/7179 - net: Fix sent reject messages for blocks and transactions

