### PR TITLE
Direct fetch in order

### DIFF
--- a/src/blockheaderprocessor.h
+++ b/src/blockheaderprocessor.h
@@ -45,10 +45,10 @@ class DefaultHeaderProcessor : public BlockHeaderProcessor {
          CBlockIndex* acceptHeaders(
                 const std::vector<CBlockHeader>& headers);
 
+         // private, but protected for unittest
+         virtual std::vector<CBlockIndex*> findMissingBlocks(CBlockIndex* last);
+
     private:
-
-        std::vector<CBlockIndex*> findMissingBlocks(CBlockIndex* last);
-
         bool hasEqualOrMoreWork(CBlockIndex* last);
         void suggestDownload(
                 const std::vector<CBlockIndex*>& toFetch, CBlockIndex* last);

--- a/src/test/blockheaderprocessor_tests.cpp
+++ b/src/test/blockheaderprocessor_tests.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include <boost/test/unit_test.hpp>
 #include "blockheaderprocessor.h"
-#include "test/thinblockutil.h" // DummyNode
+#include "test/thinblockutil.h"
 #include "test/testutil.h"
 
 BOOST_AUTO_TEST_SUITE(blockheaderprocessor_tests);
@@ -42,6 +42,102 @@ BOOST_AUTO_TEST_CASE(test_connect_chain_req) {
     BOOST_CHECK(!p.requestConnectHeaders(header, from));
     BOOST_CHECK_EQUAL(0, from.messages.size());
     BOOST_CHECK_EQUAL(1 /* no change */, NodeStatePtr(from.id)->unconnectingHeaders);
+}
+
+namespace {
+    class DummyHeaderProcessor : public DefaultHeaderProcessor {
+        public:
+        DummyHeaderProcessor(std::unique_ptr<ThinBlockManager> mg) :
+            DefaultHeaderProcessor(&node, inFlight, *mg, markAsInFlight, [](){}),
+            thinmg(std::move(mg))
+        {
+        }
+
+        std::vector<CBlockIndex*> findMissingBlocks(CBlockIndex* last) override {
+            return DefaultHeaderProcessor::findMissingBlocks(last);
+        }
+        private:
+            DummyNode node;
+            InFlightIndex inFlight;
+            DummyMarkAsInFlight markAsInFlight;
+            std::unique_ptr<ThinBlockManager> thinmg;
+    };
+
+}
+
+BOOST_AUTO_TEST_CASE(test_find_missing_blocks) {
+
+    uint256 dummyhash = uint256S("0xF00D");
+
+    CBlockIndex prev1;
+    prev1.nStatus = BLOCK_HAVE_DATA;
+    prev1.phashBlock = &dummyhash;
+
+    CBlockIndex tip;
+    tip.nStatus = 0;
+    tip.pprev = &prev1;
+    tip.phashBlock = &dummyhash;
+
+    DummyHeaderProcessor p(GetDummyThinBlockMg());
+    std::vector<CBlockIndex*> missing = p.findMissingBlocks(&tip);
+
+    // we have data for prev1, so only tip should be returned.
+    BOOST_CHECK_EQUAL(1, missing.size());
+    BOOST_CHECK_EQUAL(&tip, missing[0]);
+
+    // we don't have data for prev1, both should be returned.
+    prev1.nStatus = 0;
+    missing = p.findMissingBlocks(&tip);
+    BOOST_CHECK_EQUAL(2, missing.size());
+    BOOST_CHECK_EQUAL(&tip, missing[0]);
+    BOOST_CHECK_EQUAL(&prev1, missing[1]);
+}
+
+BOOST_AUTO_TEST_CASE(test_find_missing_blocks_trim) {
+    // Function should not return more than MAX_BLOCKS_IN_TRANSIT_PER_PEER,
+    // skipping the newest blocks.
+    uint256 dummyhash = uint256S("0xF00D");
+
+    CBlockIndex* prev = nullptr;
+    std::vector<CBlockIndex> blocks;
+    blocks.resize(1 + MAX_BLOCKS_IN_TRANSIT_PER_PEER);
+    for (size_t i = 0; i < blocks.size(); ++i) {
+        CBlockIndex newTip;
+        newTip.nStatus = 0;
+        newTip.pprev = prev;
+        newTip.phashBlock = &dummyhash;
+        blocks[i] = newTip;
+        prev = &blocks[i];
+    }
+
+    DummyHeaderProcessor p(GetDummyThinBlockMg());
+    std::vector<CBlockIndex*> missing = p.findMissingBlocks(&blocks.back());
+
+    // blocks.back() should be trimmed off.
+    BOOST_CHECK_EQUAL(MAX_BLOCKS_IN_TRANSIT_PER_PEER, missing.size());
+    BOOST_CHECK_EQUAL(&blocks[blocks.size() - 2], missing.front());
+    BOOST_CHECK_EQUAL(&blocks.front(), missing.back());
+}
+
+BOOST_AUTO_TEST_CASE(test_find_missing_blocks_toofarbehind) {
+
+    const int WALK_LIMIT = 144; // one day
+    uint256 dummyhash = uint256S("0xF00D");
+    CBlockIndex* prev = nullptr;
+    std::vector<CBlockIndex> blocks;
+    blocks.resize(1 + WALK_LIMIT);
+    for (size_t i = 0; i < blocks.size(); ++i) {
+        CBlockIndex newTip;
+        newTip.nStatus = 0;
+        newTip.pprev = prev;
+        newTip.phashBlock = &dummyhash;
+        blocks[i] = newTip;
+        prev = &blocks[i];
+    }
+    DummyHeaderProcessor p(GetDummyThinBlockMg());
+    std::vector<CBlockIndex*> missing = p.findMissingBlocks(&blocks.back());
+
+    BOOST_CHECK_EQUAL(0, missing.size());
 }
 
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
Fetch the oldest blocks missing when direct fetching during a header
announcement. Added unittests.

This is a workaround for rpc-test issue described here: https://github.com/bitcoinxt/bitcoinxt/pull/243#issuecomment-322727048

`bip9-softforks` does not randomly fail after this fix.