### PR TITLE
BIP100 cleanup for regtest, theoretical fork

### DIFF
--- a/src/maxblocksize.cpp
+++ b/src/maxblocksize.cpp
@@ -21,7 +21,7 @@ uint64_t GetNextMaxBlockSize(const CBlockIndex* pindexLast, const Consensus::Par
         return MAX_BLOCK_SIZE;
 
     // Bump to 8MB at UAHF fork
-    if (pindexLast->pprev && IsUAHFActivatingBlock(pindexLast->GetMedianTimePast(), pindexLast->pprev))
+    if (IsUAHFActivatingBlock(pindexLast->GetMedianTimePast(), pindexLast->pprev))
         return UAHF_INITIAL_MAX_BLOCK_SIZE;
 
     uint64_t nMaxBlockSize = pindexLast->nMaxBlockSize;
@@ -35,7 +35,7 @@ uint64_t GetNextMaxBlockSize(const CBlockIndex* pindexLast, const Consensus::Par
     const CBlockIndex *pindexWalk = pindexLast;
     for (int64_t i = 0; i < params.DifficultyAdjustmentInterval(); i++) {
         assert(pindexWalk);
-        votes.push_back(pindexWalk->nMaxBlockSizeVote ? pindexWalk->nMaxBlockSizeVote : pindexWalk->nMaxBlockSize);
+        votes.push_back(pindexWalk->nMaxBlockSizeVote ? pindexWalk->nMaxBlockSizeVote : nMaxBlockSize);
         pindexWalk = pindexWalk->pprev;
     }
 

--- a/src/test/maxblocksize_tests.cpp
+++ b/src/test/maxblocksize_tests.cpp
@@ -16,7 +16,7 @@ void fillBlockIndex(
         bool addVotes, int64_t currMax) {
 
     int height = 0;
-    int64_t blocktime = UAHF_DEFAULT_ACTIVATION_TIME;
+    int64_t blocktime = Opt().UAHFTime();
 
     CBlockIndex* prev = nullptr;
     for (CBlockIndex& index : blockIndexes)
@@ -35,7 +35,7 @@ void fillBlockIndex(
 };
 
 BOOST_AUTO_TEST_CASE(get_next_max_blocksize) {
-    auto params = Params(CBaseChainParams::MAIN).GetConsensus();
+    auto params = Params(CBaseChainParams::REGTEST).GetConsensus();
     BOOST_CHECK_EQUAL(1512, params.nMaxBlockSizeChangePosition);
 
     // Genesis block, legacy block size
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(get_next_max_blocksize) {
     // Not at a difficulty adjustment interval,
     // should not change max block size.
     {
-        uint64_t currMax = 42 * 1000000;
+        uint64_t currMax = UAHF_INITIAL_MAX_BLOCK_SIZE;
         std::vector<CBlockIndex> blockInterval(interval);
         fillBlockIndex(params, blockInterval, true, currMax);
         CBlockIndex index;


### PR DESCRIPTION
Two changes to the bip100 implementation.

1 - Remove null check on pIndexLast->pprev in GetNextMaxBlockSize().  This is part of the job of IsUAHFActivatingBlock() which handles the regtest case, that activates at genesis.

2 - The default max block size vote should be the end-of-interval value, not the value as of the voting block. This can make a difference if some rare event like the UAHF modifies the max block size within the interval.

In the actual UAHF, it did not matter, because the fork occurred with fewer than 75% voting (by default) for a size different than the end-of-interval size (8M).
