### PR TITLE
[debian] Add configuration step to select network

### DIFF
--- a/contrib/gitian-debian/postinst
+++ b/contrib/gitian-debian/postinst
@@ -36,3 +36,14 @@ if [ -x "/bin/systemctl" ]; then
 else
     echo "The file '/bin/systemctl' is not executable or found, bitcoinxtd service not automatically enabled or started" 
 fi
+
+# ask which network to connect to
+db_input high bitcoinxt/select_network || true
+db_go || true
+db_get bitcoinxt/select_network
+if [ "$RET" = "Bitcoin (BTC)" ]; then
+    echo "uahftime=0" >> /etc/bitcoinxt/bitcoin.conf
+    echo "BTC Network: uahftime=0 added to /etc/bitcoinxt/bitcoin.conf"
+else
+    echo "BCC Network: Default settings kept."
+fi

--- a/contrib/gitian-debian/postinst
+++ b/contrib/gitian-debian/postinst
@@ -3,8 +3,13 @@
 # Source debconf library.
 . /usr/share/debconf/confmodule
 
-# add random rpc password to bitcoin.conf
-echo "rpcpassword=$(xxd -l 16 -p /dev/urandom)" >> /etc/bitcoinxt/bitcoin.conf 
+export BITCOIN_CONF="/etc/bitcoinxt/bitcoin.conf"
+
+# add random rpc password to bitcoin.conf, if there isn't one.
+if ! grep -q '^rpcpassword=' $BITCOIN_CONF; then
+    echo "Adding a random rcp password to $BITCOIN_CONF"
+    echo "rpcpassword=$(xxd -l 17 -p /dev/urandom)" >> $BITCOIN_CONF
+fi
 
 # add users
 adduser --system --group --quiet bitcoin
@@ -42,8 +47,18 @@ db_input high bitcoinxt/select_network || true
 db_go || true
 db_get bitcoinxt/select_network
 if [ "$RET" = "Bitcoin (BTC)" ]; then
-    echo "uahftime=0" >> /etc/bitcoinxt/bitcoin.conf
-    echo "BTC Network: uahftime=0 added to /etc/bitcoinxt/bitcoin.conf"
+    if grep -q '^uahftime' $BITCOIN_CONF; then
+        sed -i 's/^uahftime.*/uahftime=0/' $BITCOIN_CONF
+        echo "BTC selected: Setting uahftime=0 in $BITCOIN_CONF"
+    else
+        echo "uahftime=0" >> $BITCOIN_CONF
+        echo "BTC selected: Adding uahftime=0 to $BITCOIN_CONF"
+    fi;
 else
-    echo "BCC Network: Default settings kept."
+    if grep -q '^uahftime' $BITCOIN_CONF; then
+        sed -i 's/^uahftime.*//' $BITCOIN_CONF
+        echo "BCC selected: Removing uahftime from $BITCOIN_CONF"
+    else
+        echo "BCC selected: No configuration change needed."
+    fi;
 fi

--- a/contrib/gitian-debian/templates
+++ b/contrib/gitian-debian/templates
@@ -2,3 +2,15 @@ Template: bitcoinxt/start_service
 Type: boolean
 Default: true
 Description: Automatically enable and start systemd bitcoinxtd.service?
+
+Template: bitcoinxt/select_network
+Type: select
+Default: Bitcoin Cash (BCC)
+Choices: Bitcoin Cash (BCC), Bitcoin (BTC)
+Description: Which network shall Bitcoin XT connect to?
+  Bitcoin XT is configured to use the BCC network by default.
+  BTC is selected by adding uahftime=0 to /etc/bitcoinxt/bitcoin.conf.
+  If your bitcoin.conf is located at a different location, you must edit it yourself.
+  -
+  Make sure you are on the correct network.
+  Configuring to use the wrong network will result in sending the wrong coins.


### PR DESCRIPTION
User is asked to select which network (BCC or BTC) to connect to when
installing the debian package.

![screenshot from 2017-08-26 00-18-03](https://user-images.githubusercontent.com/92707/29734789-7cd15680-89f4-11e7-84b9-8bf56f9281c9.png)
