### PR TITLE
keypool test bump + detach wallet from miner

### DIFF
--- a/qa/rpc-tests/getblocktemplate_longpoll.py
+++ b/qa/rpc-tests/getblocktemplate_longpoll.py
@@ -6,28 +6,6 @@
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
-
-def check_array_result(object_array, to_match, expected):
-    """
-    Pass in array of JSON objects, a dictionary with key/value pairs
-    to match against, and another dictionary with expected key/value
-    pairs.
-    """
-    num_matched = 0
-    for item in object_array:
-        all_match = True
-        for key,value in to_match.items():
-            if item[key] != value:
-                all_match = False
-        if not all_match:
-            continue
-        for key,value in expected.items():
-            if item[key] != value:
-                raise AssertionError("%s : expected %s=%s"%(str(item), str(key), str(value)))
-            num_matched = num_matched+1
-    if num_matched == 0:
-        raise AssertionError("No objects matched %s"%(str(to_match)))
-
 import threading
 
 class LongpollThread(threading.Thread):

--- a/qa/rpc-tests/getblocktemplate_proposals.py
+++ b/qa/rpc-tests/getblocktemplate_proposals.py
@@ -10,28 +10,6 @@ from binascii import a2b_hex, b2a_hex
 from hashlib import sha256
 from struct import pack
 
-
-def check_array_result(object_array, to_match, expected):
-    """
-    Pass in array of JSON objects, a dictionary with key/value pairs
-    to match against, and another dictionary with expected key/value
-    pairs.
-    """
-    num_matched = 0
-    for item in object_array:
-        all_match = True
-        for key,value in to_match.items():
-            if item[key] != value:
-                all_match = False
-        if not all_match:
-            continue
-        for key,value in expected.items():
-            if item[key] != value:
-                raise AssertionError("%s : expected %s=%s"%(str(item), str(key), str(value)))
-            num_matched = num_matched+1
-    if num_matched == 0:
-        raise AssertionError("No objects matched %s"%(str(to_match)))
-
 def b2x(b):
     return b2a_hex(b).decode('ascii')
 

--- a/qa/rpc-tests/keypool.py
+++ b/qa/rpc-tests/keypool.py
@@ -10,28 +10,6 @@
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
-
-def check_array_result(object_array, to_match, expected):
-    """
-    Pass in array of JSON objects, a dictionary with key/value pairs
-    to match against, and another dictionary with expected key/value
-    pairs.
-    """
-    num_matched = 0
-    for item in object_array:
-        all_match = True
-        for key,value in to_match.items():
-            if item[key] != value:
-                all_match = False
-        if not all_match:
-            continue
-        for key,value in expected.items():
-            if item[key] != value:
-                raise AssertionError("%s : expected %s=%s"%(str(item), str(key), str(value)))
-            num_matched = num_matched+1
-    if num_matched == 0:
-        raise AssertionError("No objects matched %s"%(str(to_match)))
-
 class KeyPoolTest(BitcoinTestFramework):
 
     def run_test(self):

--- a/qa/rpc-tests/keypool.py
+++ b/qa/rpc-tests/keypool.py
@@ -6,15 +6,8 @@
 # Exercise the wallet keypool, and interaction with wallet encryption/locking
 
 # Add python-bitcoinrpc to module search path:
-import os
-import sys
 
-import json
-import shutil
-import subprocess
-import tempfile
-import traceback
-
+from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
 
@@ -39,12 +32,15 @@ def check_array_result(object_array, to_match, expected):
     if num_matched == 0:
         raise AssertionError("No objects matched %s"%(str(to_match)))
 
-    def run_test(nodes, tmpdir):
+class KeyPoolTest(BitcoinTestFramework):
+
+    def run_test(self):
+        nodes = self.nodes
         # Encrypt wallet and wait to terminate
         nodes[0].encryptwallet('test')
         bitcoind_processes[0].wait()
         # Restart node 0
-        nodes[0] = start_node(0, tmpdir)
+        nodes[0] = start_node(0, self.options.tmpdir)
         # Keep creating keys
         addr = nodes[0].getnewaddress()
         try:
@@ -89,57 +85,12 @@ def check_array_result(object_array, to_match, expected):
         except JSONRPCException as e:
             assert(e.error['code']==-12)
 
-    def main():
-        import optparse
+    def setup_chain(self):
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain(self.options.tmpdir)
 
-        parser = optparse.OptionParser(usage="%prog [options]")
-        parser.add_option("--nocleanup", dest="nocleanup", default=False, action="store_true",
-                          help="Leave bitcoinds and test.* datadir on exit or error")
-        parser.add_option("--srcdir", dest="srcdir", default="../../src",
-                          help="Source directory containing bitcoind/bitcoin-cli (default: %default%)")
-        parser.add_option("--tmpdir", dest="tmpdir", default=tempfile.mkdtemp(prefix="test"),
-                          help="Root directory for datadirs")
-        (options, args) = parser.parse_args()
-
-        os.environ['PATH'] = options.srcdir+":"+os.environ['PATH']
-
-        check_json_precision()
-
-        success = False
-        nodes = []
-        try:
-            print("Initializing test directory "+options.tmpdir)
-            if not os.path.isdir(options.tmpdir):
-                os.makedirs(options.tmpdir)
-            initialize_chain(options.tmpdir)
-
-            nodes = start_nodes(1, options.tmpdir)
-
-            run_test(nodes, options.tmpdir)
-
-            success = True
-
-        except AssertionError as e:
-            print("Assertion failed: "+e.message)
-        except JSONRPCException as e:
-            print("JSONRPC error: "+e.error['message'])
-            traceback.print_tb(sys.exc_info()[2])
-        except Exception as e:
-            print("Unexpected exception caught during testing: "+str(sys.exc_info()[0]))
-            traceback.print_tb(sys.exc_info()[2])
-
-        if not options.nocleanup:
-            print("Cleaning up")
-            stop_nodes(nodes)
-            wait_bitcoinds()
-            shutil.rmtree(options.tmpdir)
-
-        if success:
-            print("Tests successful")
-            sys.exit(0)
-        else:
-            print("Failed")
-            sys.exit(1)
+    def setup_network(self):
+        self.nodes = start_nodes(1, self.options.tmpdir)
 
 if __name__ == '__main__':
-    main()
+    KeyPoolTest().main()

--- a/qa/rpc-tests/keypool.py
+++ b/qa/rpc-tests/keypool.py
@@ -39,107 +39,107 @@ def check_array_result(object_array, to_match, expected):
     if num_matched == 0:
         raise AssertionError("No objects matched %s"%(str(to_match)))
 
-def run_test(nodes, tmpdir):
-    # Encrypt wallet and wait to terminate
-    nodes[0].encryptwallet('test')
-    bitcoind_processes[0].wait()
-    # Restart node 0
-    nodes[0] = start_node(0, tmpdir)
-    # Keep creating keys
-    addr = nodes[0].getnewaddress()
-    try:
+    def run_test(nodes, tmpdir):
+        # Encrypt wallet and wait to terminate
+        nodes[0].encryptwallet('test')
+        bitcoind_processes[0].wait()
+        # Restart node 0
+        nodes[0] = start_node(0, tmpdir)
+        # Keep creating keys
         addr = nodes[0].getnewaddress()
-        raise AssertionError('Keypool should be exhausted after one address')
-    except JSONRPCException as e:
-        assert(e.error['code']==-12)
+        try:
+            addr = nodes[0].getnewaddress()
+            raise AssertionError('Keypool should be exhausted after one address')
+        except JSONRPCException as e:
+            assert(e.error['code']==-12)
 
-    # put three new keys in the keypool
-    nodes[0].walletpassphrase('test', 12000)
-    nodes[0].keypoolrefill(3)
-    nodes[0].walletlock()
+        # put three new keys in the keypool
+        nodes[0].walletpassphrase('test', 12000)
+        nodes[0].keypoolrefill(3)
+        nodes[0].walletlock()
 
-    # drain the keys
-    addr = set()
-    addr.add(nodes[0].getrawchangeaddress())
-    addr.add(nodes[0].getrawchangeaddress())
-    addr.add(nodes[0].getrawchangeaddress())
-    addr.add(nodes[0].getrawchangeaddress())
-    # assert that four unique addresses were returned
-    assert(len(addr) == 4)
-    # the next one should fail
-    try:
-        addr = nodes[0].getrawchangeaddress()
-        raise AssertionError('Keypool should be exhausted after three addresses')
-    except JSONRPCException as e:
-        assert(e.error['code']==-12)
+        # drain the keys
+        addr = set()
+        addr.add(nodes[0].getrawchangeaddress())
+        addr.add(nodes[0].getrawchangeaddress())
+        addr.add(nodes[0].getrawchangeaddress())
+        addr.add(nodes[0].getrawchangeaddress())
+        # assert that four unique addresses were returned
+        assert(len(addr) == 4)
+        # the next one should fail
+        try:
+            addr = nodes[0].getrawchangeaddress()
+            raise AssertionError('Keypool should be exhausted after three addresses')
+        except JSONRPCException as e:
+            assert(e.error['code']==-12)
 
-    # refill keypool with three new addresses
-    nodes[0].walletpassphrase('test', 12000)
-    nodes[0].keypoolrefill(3)
-    nodes[0].walletlock()
+        # refill keypool with three new addresses
+        nodes[0].walletpassphrase('test', 12000)
+        nodes[0].keypoolrefill(3)
+        nodes[0].walletlock()
 
-    # drain them by mining
-    nodes[0].generate(1)
-    nodes[0].generate(1)
-    nodes[0].generate(1)
-    nodes[0].generate(1)
-    try:
+        # drain them by mining
         nodes[0].generate(1)
-        raise AssertionError('Keypool should be exhausted after three addesses')
-    except JSONRPCException,e:
-        assert(e.error['code']==-12)
+        nodes[0].generate(1)
+        nodes[0].generate(1)
+        nodes[0].generate(1)
+        try:
+            nodes[0].generate(1)
+            raise AssertionError('Keypool should be exhausted after three addesses')
+        except JSONRPCException as e:
+            assert(e.error['code']==-12)
 
-def main():
-    import optparse
+    def main():
+        import optparse
 
-    parser = optparse.OptionParser(usage="%prog [options]")
-    parser.add_option("--nocleanup", dest="nocleanup", default=False, action="store_true",
-                      help="Leave bitcoinds and test.* datadir on exit or error")
-    parser.add_option("--srcdir", dest="srcdir", default="../../src",
-                      help="Source directory containing bitcoind/bitcoin-cli (default: %default%)")
-    parser.add_option("--tmpdir", dest="tmpdir", default=tempfile.mkdtemp(prefix="test"),
-                      help="Root directory for datadirs")
-    (options, args) = parser.parse_args()
+        parser = optparse.OptionParser(usage="%prog [options]")
+        parser.add_option("--nocleanup", dest="nocleanup", default=False, action="store_true",
+                          help="Leave bitcoinds and test.* datadir on exit or error")
+        parser.add_option("--srcdir", dest="srcdir", default="../../src",
+                          help="Source directory containing bitcoind/bitcoin-cli (default: %default%)")
+        parser.add_option("--tmpdir", dest="tmpdir", default=tempfile.mkdtemp(prefix="test"),
+                          help="Root directory for datadirs")
+        (options, args) = parser.parse_args()
 
-    os.environ['PATH'] = options.srcdir+":"+os.environ['PATH']
+        os.environ['PATH'] = options.srcdir+":"+os.environ['PATH']
 
-    check_json_precision()
+        check_json_precision()
 
-    success = False
-    nodes = []
-    try:
-        print("Initializing test directory "+options.tmpdir)
-        if not os.path.isdir(options.tmpdir):
-            os.makedirs(options.tmpdir)
-        initialize_chain(options.tmpdir)
+        success = False
+        nodes = []
+        try:
+            print("Initializing test directory "+options.tmpdir)
+            if not os.path.isdir(options.tmpdir):
+                os.makedirs(options.tmpdir)
+            initialize_chain(options.tmpdir)
 
-        nodes = start_nodes(1, options.tmpdir)
+            nodes = start_nodes(1, options.tmpdir)
 
-        run_test(nodes, options.tmpdir)
+            run_test(nodes, options.tmpdir)
 
-        success = True
+            success = True
 
-    except AssertionError as e:
-        print("Assertion failed: "+e.message)
-    except JSONRPCException as e:
-        print("JSONRPC error: "+e.error['message'])
-        traceback.print_tb(sys.exc_info()[2])
-    except Exception as e:
-        print("Unexpected exception caught during testing: "+str(sys.exc_info()[0]))
-        traceback.print_tb(sys.exc_info()[2])
+        except AssertionError as e:
+            print("Assertion failed: "+e.message)
+        except JSONRPCException as e:
+            print("JSONRPC error: "+e.error['message'])
+            traceback.print_tb(sys.exc_info()[2])
+        except Exception as e:
+            print("Unexpected exception caught during testing: "+str(sys.exc_info()[0]))
+            traceback.print_tb(sys.exc_info()[2])
 
-    if not options.nocleanup:
-        print("Cleaning up")
-        stop_nodes(nodes)
-        wait_bitcoinds()
-        shutil.rmtree(options.tmpdir)
+        if not options.nocleanup:
+            print("Cleaning up")
+            stop_nodes(nodes)
+            wait_bitcoinds()
+            shutil.rmtree(options.tmpdir)
 
-    if success:
-        print("Tests successful")
-        sys.exit(0)
-    else:
-        print("Failed")
-        sys.exit(1)
+        if success:
+            print("Tests successful")
+            sys.exit(0)
+        else:
+            print("Failed")
+            sys.exit(1)
 
 if __name__ == '__main__':
     main()

--- a/qa/rpc-tests/keypool.py
+++ b/qa/rpc-tests/keypool.py
@@ -73,6 +73,21 @@ def run_test(nodes, tmpdir):
     except JSONRPCException as e:
         assert(e.error['code']==-12)
 
+    # refill keypool with three new addresses
+    nodes[0].walletpassphrase('test', 12000)
+    nodes[0].keypoolrefill(3)
+    nodes[0].walletlock()
+
+    # drain them by mining
+    nodes[0].generate(1)
+    nodes[0].generate(1)
+    nodes[0].generate(1)
+    nodes[0].generate(1)
+    try:
+        nodes[0].generate(1)
+        raise AssertionError('Keypool should be exhausted after three addesses')
+    except JSONRPCException,e:
+        assert(e.error['code']==-12)
 
 def main():
     import optparse

--- a/qa/rpc-tests/listtransactions.py
+++ b/qa/rpc-tests/listtransactions.py
@@ -16,27 +16,6 @@ def txFromHex(hexstring):
     tx.deserialize(f)
     return tx
 
-def check_array_result(object_array, to_match, expected):
-    """
-    Pass in array of JSON objects, a dictionary with key/value pairs
-    to match against, and another dictionary with expected key/value
-    pairs.
-    """
-    num_matched = 0
-    for item in object_array:
-        all_match = True
-        for key,value in to_match.items():
-            if item[key] != value:
-                all_match = False
-        if not all_match:
-            continue
-        for key,value in expected.items():
-            if item[key] != value:
-                raise AssertionError("%s : expected %s=%s"%(str(item), str(key), str(value)))
-            num_matched = num_matched+1
-    if num_matched == 0:
-        raise AssertionError("No objects matched %s"%(str(to_match)))
-
 class ListTransactionsTest(BitcoinTestFramework):
 
     def setup_nodes(self):
@@ -48,28 +27,28 @@ class ListTransactionsTest(BitcoinTestFramework):
         # Simple send, 0 to 1:
         txid = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.1)
         self.sync_all()
-        check_array_result(self.nodes[0].listtransactions(),
+        assert_array_result(self.nodes[0].listtransactions(),
                            {"txid":txid},
                            {"category":"send","account":"","amount":Decimal("-0.1"),"confirmations":0})
-        check_array_result(self.nodes[1].listtransactions(),
+        assert_array_result(self.nodes[1].listtransactions(),
                            {"txid":txid},
                            {"category":"receive","account":"","amount":Decimal("0.1"),"confirmations":0})
         # mine a block, confirmations should change:
         self.nodes[0].generate(1)
         self.sync_all()
-        check_array_result(self.nodes[0].listtransactions(),
+        assert_array_result(self.nodes[0].listtransactions(),
                            {"txid":txid},
                            {"category":"send","account":"","amount":Decimal("-0.1"),"confirmations":1})
-        check_array_result(self.nodes[1].listtransactions(),
+        assert_array_result(self.nodes[1].listtransactions(),
                            {"txid":txid},
                            {"category":"receive","account":"","amount":Decimal("0.1"),"confirmations":1})
 
         # send-to-self:
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 0.2)
-        check_array_result(self.nodes[0].listtransactions(),
+        assert_array_result(self.nodes[0].listtransactions(),
                            {"txid":txid, "category":"send"},
                            {"amount":Decimal("-0.2")})
-        check_array_result(self.nodes[0].listtransactions(),
+        assert_array_result(self.nodes[0].listtransactions(),
                            {"txid":txid, "category":"receive"},
                            {"amount":Decimal("0.2")})
 
@@ -80,28 +59,28 @@ class ListTransactionsTest(BitcoinTestFramework):
                     self.nodes[1].getaccountaddress("toself") : 0.44 }
         txid = self.nodes[1].sendmany("", send_to)
         self.sync_all()
-        check_array_result(self.nodes[1].listtransactions(),
+        assert_array_result(self.nodes[1].listtransactions(),
                            {"category":"send","amount":Decimal("-0.11")},
                            {"txid":txid} )
-        check_array_result(self.nodes[0].listtransactions(),
+        assert_array_result(self.nodes[0].listtransactions(),
                            {"category":"receive","amount":Decimal("0.11")},
                            {"txid":txid} )
-        check_array_result(self.nodes[1].listtransactions(),
+        assert_array_result(self.nodes[1].listtransactions(),
                            {"category":"send","amount":Decimal("-0.22")},
                            {"txid":txid} )
-        check_array_result(self.nodes[1].listtransactions(),
+        assert_array_result(self.nodes[1].listtransactions(),
                            {"category":"receive","amount":Decimal("0.22")},
                            {"txid":txid} )
-        check_array_result(self.nodes[1].listtransactions(),
+        assert_array_result(self.nodes[1].listtransactions(),
                            {"category":"send","amount":Decimal("-0.33")},
                            {"txid":txid} )
-        check_array_result(self.nodes[0].listtransactions(),
+        assert_array_result(self.nodes[0].listtransactions(),
                            {"category":"receive","amount":Decimal("0.33")},
                            {"txid":txid, "account" : "from1"} )
-        check_array_result(self.nodes[1].listtransactions(),
+        assert_array_result(self.nodes[1].listtransactions(),
                            {"category":"send","amount":Decimal("-0.44")},
                            {"txid":txid, "account" : ""} )
-        check_array_result(self.nodes[1].listtransactions(),
+        assert_array_result(self.nodes[1].listtransactions(),
                            {"category":"receive","amount":Decimal("0.44")},
                            {"txid":txid, "account" : "toself"} )
 

--- a/qa/rpc-tests/receivedby.py
+++ b/qa/rpc-tests/receivedby.py
@@ -25,32 +25,6 @@ def get_sub_array_from_array(object_array, to_match):
         return item
     return []
 
-def check_array_result(object_array, to_match, expected, should_not_find = False):
-    """
-        Pass in array of JSON objects, a dictionary with key/value pairs
-        to match against, and another dictionary with expected key/value
-        pairs.
-        If the should_not_find flag is true, to_match should not be found in object_array
-        """
-    if should_not_find == True:
-        expected = { }
-    num_matched = 0
-    for item in object_array:
-        all_match = True
-        for key,value in to_match.items():
-            if item[key] != value:
-                all_match = False
-        if not all_match:
-            continue
-        for key,value in expected.items():
-            if item[key] != value:
-                raise AssertionError("%s : expected %s=%s"%(str(item), str(key), str(value)))
-            num_matched = num_matched+1
-    if num_matched == 0 and should_not_find != True:
-        raise AssertionError("No objects matched %s"%(str(to_match)))
-    if num_matched > 0 and should_not_find == True:
-        raise AssertionError("Objects was matched %s"%(str(to_match)))
-
 class ReceivedByTest(BitcoinTestFramework):
 
     def setup_nodes(self):
@@ -68,26 +42,26 @@ class ReceivedByTest(BitcoinTestFramework):
         self.sync_all()
 
         #Check not listed in listreceivedbyaddress because has 0 confirmations
-        check_array_result(self.nodes[1].listreceivedbyaddress(),
+        assert_array_result(self.nodes[1].listreceivedbyaddress(),
                            {"address":addr},
                            { },
                            True)
         #Bury Tx under 10 block so it will be returned by listreceivedbyaddress
         self.nodes[1].generate(10)
         self.sync_all()
-        check_array_result(self.nodes[1].listreceivedbyaddress(),
+        assert_array_result(self.nodes[1].listreceivedbyaddress(),
                            {"address":addr},
                            {"address":addr, "account":"", "amount":Decimal("0.1"), "confirmations":10, "txids":[txid,]})
         #With min confidence < 10
-        check_array_result(self.nodes[1].listreceivedbyaddress(5),
+        assert_array_result(self.nodes[1].listreceivedbyaddress(5),
                            {"address":addr},
                            {"address":addr, "account":"", "amount":Decimal("0.1"), "confirmations":10, "txids":[txid,]})
         #With min confidence > 10, should not find Tx
-        check_array_result(self.nodes[1].listreceivedbyaddress(11),{"address":addr},{ },True)
+        assert_array_result(self.nodes[1].listreceivedbyaddress(11),{"address":addr},{ },True)
 
         #Empty Tx
         addr = self.nodes[1].getnewaddress()
-        check_array_result(self.nodes[1].listreceivedbyaddress(0,True),
+        assert_array_result(self.nodes[1].listreceivedbyaddress(0,True),
                            {"address":addr},
                            {"address":addr, "account":"", "amount":0, "confirmations":0, "txids":[]})
 
@@ -131,7 +105,7 @@ class ReceivedByTest(BitcoinTestFramework):
         self.sync_all()
 
         # listreceivedbyaccount should return received_by_account_json because of 0 confirmations
-        check_array_result(self.nodes[1].listreceivedbyaccount(),
+        assert_array_result(self.nodes[1].listreceivedbyaccount(),
                            {"account":account},
                            received_by_account_json)
 
@@ -143,7 +117,7 @@ class ReceivedByTest(BitcoinTestFramework):
         self.nodes[1].generate(10)
         self.sync_all()
         # listreceivedbyaccount should return updated account balance
-        check_array_result(self.nodes[1].listreceivedbyaccount(),
+        assert_array_result(self.nodes[1].listreceivedbyaccount(),
                            {"account":account},
                            {"account":received_by_account_json["account"], "amount":(received_by_account_json["amount"] + Decimal("0.1"))})
 

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -478,6 +478,35 @@ def assert_raises(exc, fun, *args, **kwds):
     else:
         raise AssertionError("No exception raised")
 
+def assert_array_result(object_array, to_match, expected, should_not_find = False):
+    """
+        Pass in array of JSON objects, a dictionary with key/value pairs
+        to match against, and another dictionary with expected key/value
+        pairs.
+        If the should_not_find flag is true, to_match should not be found
+        in object_array
+        """
+    if should_not_find == True:
+        expected = { }
+    num_matched = 0
+    for item in object_array:
+        all_match = True
+        for key,value in to_match.items():
+            if item[key] != value:
+                all_match = False
+        if not all_match:
+            continue
+        elif should_not_find == True:
+            num_matched = num_matched+1
+        for key,value in expected.items():
+            if item[key] != value:
+                raise AssertionError("%s : expected %s=%s"%(str(item), str(key), str(value)))
+            num_matched = num_matched+1
+    if num_matched == 0 and should_not_find != True:
+        raise AssertionError("No objects matched %s"%(str(to_match)))
+    if num_matched > 0 and should_not_find == True:
+        raise AssertionError("Objects were found %s"%(str(to_match)))
+
 def satoshi_round(amount):
     return Decimal(amount).quantize(Decimal('0.00000001'), rounding=ROUND_DOWN)
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -174,8 +174,8 @@ void Shutdown()
 #ifdef ENABLE_WALLET
     if (pwalletMain)
         pwalletMain->Flush(false);
-    GenerateBitcoins(false, NULL, 0);
 #endif
+    GenerateBitcoins(false, 0, Params());
     StopNode();
     UnregisterNodeSignals(GetNodeSignals());
 
@@ -406,10 +406,8 @@ std::string HelpMessage(HelpMessageMode mode)
         debugCategories += ", qt";
     strUsage += HelpMessageOpt("-debug=<category>", strprintf(_("Output debugging information (default: %u, supplying <category> is optional)"), 0) + ". " +
         _("If <category> is not supplied or if <category> = 1, output all debugging information.") + _("<category> can be:") + " " + debugCategories + ".");
-#ifdef ENABLE_WALLET
     strUsage += HelpMessageOpt("-gen", strprintf(_("Generate coins (default: %u)"), 0));
     strUsage += HelpMessageOpt("-genproclimit=<n>", strprintf(_("Set the number of threads for coin generation if enabled (-1 = all cores, default: %d)"), 1));
-#endif
     strUsage += HelpMessageOpt("-help-debug", _("Show all debugging options (usage: --help -help-debug)"));
     strUsage += HelpMessageOpt("-logips", strprintf(_("Include IP addresses in debug output (default: %u)"), 0));
     strUsage += HelpMessageOpt("-logtimestamps", strprintf(_("Prepend debug output with timestamp (default: %u)"), 1));
@@ -1503,11 +1501,8 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     CBlockIndex *pdummy = NULL;
     scheduler.scheduleEvery(f, PartitionCheck(&IsInitialBlockDownload, boost::ref(cs_main), boost::cref(pdummy), nPowTargetSpacing));
 
-#ifdef ENABLE_WALLET
     // Generate coins in the background
-    if (pwalletMain)
-        GenerateBitcoins(GetBoolArg("-gen", false), pwalletMain, GetArg("-genproclimit", 1));
-#endif
+    GenerateBitcoins(GetBoolArg("-gen", false), GetArg("-genproclimit", 1), Params());
 
     // ********************************************************* Step 11: finished
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -315,7 +315,7 @@ static bool ProcessBlockFound(CBlock* pblock, const CChainParams& chainparams)
     }
 
     // Inform about the new block
-    GetMainSignals().BlockFound(*pblock);
+    GetMainSignals().BlockFound(pblock->GetHash());
 
     // Process this block the same as if we had received it from another node
     CValidationState state;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -337,8 +337,10 @@ void static BitcoinMiner(const CChainParams& chainparams)
     GetMainSignals().ScriptForMining(coinbaseScript);
 
     try {
-        //throw an error if no script was provided
-        if (!coinbaseScript->reserveScript.size())
+        // Throw an error if no script was provided.  This can happen
+        // due to some internal error but also if the keypool is empty.
+        // In the latter case, already the pointer is NULL.
+        if (!coinbaseScript || coinbaseScript->reserveScript.empty())
             throw std::runtime_error("No coinbase script available (mining requires a wallet)");
 
         while (true) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -19,9 +19,7 @@
 #include "util.h"
 #include "utilmoneystr.h"
 #include "options.h"
-#ifdef ENABLE_WALLET
-#include "wallet/wallet.h"
-#endif
+#include "validationinterface.h"
 
 #include <boost/thread.hpp>
 #include <boost/tuple/tuple.hpp>
@@ -266,7 +264,6 @@ void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& 
     pblock->hashMerkleRoot = pblock->BuildMerkleTree();
 }
 
-#ifdef ENABLE_WALLET
 //////////////////////////////////////////////////////////////////////////////
 //
 // Internal miner
@@ -305,17 +302,7 @@ bool static ScanHash(const CBlockHeader *pblock, uint32_t& nNonce, uint256 *phas
     }
 }
 
-CBlockTemplate* CreateNewBlockWithKey(CReserveKey& reservekey)
-{
-    CPubKey pubkey;
-    if (!reservekey.GetReservedKey(pubkey))
-        return NULL;
-
-    CScript scriptPubKey = CScript() << ToByteVector(pubkey) << OP_CHECKSIG;
-    return CreateNewBlock(scriptPubKey);
-}
-
-static bool ProcessBlockFound(CBlock* pblock, CWallet& wallet, CReserveKey& reservekey)
+static bool ProcessBlockFound(CBlock* pblock, const CChainParams& chainparams)
 {
     LogPrintf("%s\n", pblock->ToString());
     LogPrintf("generated %s\n", FormatMoney(pblock->vtx[0].vout[0].nValue));
@@ -327,14 +314,8 @@ static bool ProcessBlockFound(CBlock* pblock, CWallet& wallet, CReserveKey& rese
             return error("BitcoinMiner: generated block is stale");
     }
 
-    // Remove key from key pool
-    reservekey.KeepKey();
-
-    // Track how many getdata requests this block gets
-    {
-        LOCK(wallet.cs_wallet);
-        wallet.mapRequestCount[pblock->GetHash()] = 0;
-    }
+    // Inform about the new block
+    GetMainSignals().BlockFound(*pblock);
 
     // Process this block the same as if we had received it from another node
     CValidationState state;
@@ -344,15 +325,12 @@ static bool ProcessBlockFound(CBlock* pblock, CWallet& wallet, CReserveKey& rese
     return true;
 }
 
-void static BitcoinMiner(CWallet *pwallet)
+void static BitcoinMiner(const CChainParams& chainparams, const CScript& coinbaseScript)
 {
     LogPrintf("BitcoinMiner started\n");
     SetThreadPriority(THREAD_PRIORITY_LOWEST);
     RenameThread("bitcoin-miner");
-    const CChainParams& chainparams = Params();
 
-    // Each thread has its own key and counter
-    CReserveKey reservekey(pwallet);
     unsigned int nExtraNonce = 0;
 
     try {
@@ -378,7 +356,7 @@ void static BitcoinMiner(CWallet *pwallet)
             unsigned int nTransactionsUpdatedLast = mempool.GetTransactionsUpdated();
             CBlockIndex* pindexPrev = chainActive.Tip();
 
-            unique_ptr<CBlockTemplate> pblocktemplate(CreateNewBlockWithKey(reservekey));
+            unique_ptr<CBlockTemplate> pblocktemplate(CreateNewBlock(coinbaseScript));
             if (!pblocktemplate.get())
             {
                 LogPrintf("Error in BitcoinMiner: Keypool ran out, please call keypoolrefill before restarting the mining thread\n");
@@ -411,7 +389,7 @@ void static BitcoinMiner(CWallet *pwallet)
                         SetThreadPriority(THREAD_PRIORITY_NORMAL);
                         LogPrintf("BitcoinMiner:\n");
                         LogPrintf("proof-of-work found  \n  hash: %s  \ntarget: %s\n", hash.GetHex(), hashTarget.GetHex());
-                        ProcessBlockFound(pblock, *pwallet, reservekey);
+                        ProcessBlockFound(pblock, chainparams);
                         SetThreadPriority(THREAD_PRIORITY_LOWEST);
 
                         // In regression test mode, stop mining after a block is found.
@@ -456,7 +434,7 @@ void static BitcoinMiner(CWallet *pwallet)
     }
 }
 
-void GenerateBitcoins(bool fGenerate, CWallet* pwallet, int nThreads)
+void GenerateBitcoins(bool fGenerate, int nThreads, const CChainParams& chainparams)
 {
     static boost::thread_group* minerThreads = NULL;
 
@@ -473,9 +451,14 @@ void GenerateBitcoins(bool fGenerate, CWallet* pwallet, int nThreads)
     if (nThreads == 0 || !fGenerate)
         return;
 
+    CScript coinbaseScript;
+    GetMainSignals().ScriptForMining(coinbaseScript);
+
+    //throw an error if no script was provided
+    if (!coinbaseScript.size())
+        throw std::runtime_error("No coinbase script available (mining requires a wallet)");
+
     minerThreads = new boost::thread_group();
     for (int i = 0; i < nThreads; i++)
-        minerThreads->create_thread(boost::bind(&BitcoinMiner, pwallet));
+        minerThreads->create_thread(boost::bind(&BitcoinMiner, boost::cref(chainparams), coinbaseScript));
 }
-
-#endif // ENABLE_WALLET

--- a/src/miner.h
+++ b/src/miner.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 
 class CBlockIndex;
+class CChainParams;
 class CReserveKey;
 class CScript;
 class CWallet;
@@ -24,10 +25,9 @@ struct CBlockTemplate
 };
 
 /** Run the miner threads */
-void GenerateBitcoins(bool fGenerate, CWallet* pwallet, int nThreads);
+void GenerateBitcoins(bool fGenerate, int nThreads, const CChainParams& chainparams);
 /** Generate a new block, without valid proof-of-work */
 CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn);
-CBlockTemplate* CreateNewBlockWithKey(CReserveKey& reservekey);
 /** Modify the extranonce in a block */
 void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce, uint64_t nMaxBlockSize);
 void UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -17,9 +17,6 @@
 #include "rpcserver.h"
 #include "util.h"
 #include "validationinterface.h"
-#ifdef ENABLE_WALLET
-#include "wallet/wallet.h"
-#endif
 
 #include <stdint.h>
 
@@ -93,7 +90,6 @@ UniValue getnetworkhashps(const UniValue& params, bool fHelp)
     return GetNetworkHashPS(params.size() > 0 ? params[0].get_int() : 120, params.size() > 1 ? params[1].get_int() : -1);
 }
 
-#ifdef ENABLE_WALLET
 UniValue getgenerate(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
@@ -128,8 +124,6 @@ UniValue generate(const UniValue& params, bool fHelp)
             + HelpExampleCli("generate", "11")
         );
 
-    if (pwalletMain == NULL)
-        throw JSONRPCError(RPC_METHOD_NOT_FOUND, "Method not found (disabled)");
     if (!Params().MineBlocksOnDemand())
         throw JSONRPCError(RPC_METHOD_NOT_FOUND, "This method can only be used on regtest");
 
@@ -137,7 +131,13 @@ UniValue generate(const UniValue& params, bool fHelp)
     int nHeightEnd = 0;
     int nHeight = 0;
     int nGenerate = params[0].get_int();
-    CReserveKey reservekey(pwalletMain);
+
+    CScript coinbaseScript;
+    GetMainSignals().ScriptForMining(coinbaseScript);
+
+    //throw an error if no script was provided
+    if (!coinbaseScript.size())
+        throw JSONRPCError(RPC_INTERNAL_ERROR, "No coinbase script available (mining requires a wallet)");
 
     {   // Don't keep cs_main locked
         LOCK(cs_main);
@@ -149,9 +149,9 @@ UniValue generate(const UniValue& params, bool fHelp)
     UniValue blockHashes(UniValue::VARR);
     while (nHeight < nHeightEnd)
     {
-        unique_ptr<CBlockTemplate> pblocktemplate(CreateNewBlockWithKey(reservekey));
+        unique_ptr<CBlockTemplate> pblocktemplate(CreateNewBlock(coinbaseScript));
         if (!pblocktemplate.get())
-            throw JSONRPCError(RPC_INTERNAL_ERROR, "Wallet keypool empty");
+            throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
         CBlock *pblock = &pblocktemplate->block;
         {
             LOCK(cs_main);
@@ -169,10 +169,8 @@ UniValue generate(const UniValue& params, bool fHelp)
         ++nHeight;
         blockHashes.push_back(pblock->GetHash().GetHex());
     }
-    reservekey.KeepKey();
     return blockHashes;
 }
-
 
 UniValue setgenerate(const UniValue& params, bool fHelp)
 {
@@ -196,8 +194,6 @@ UniValue setgenerate(const UniValue& params, bool fHelp)
             + HelpExampleRpc("setgenerate", "true, 1")
         );
 
-    if (pwalletMain == NULL)
-        throw JSONRPCError(RPC_METHOD_NOT_FOUND, "Method not found (disabled)");
     if (Params().MineBlocksOnDemand())
         throw JSONRPCError(RPC_METHOD_NOT_FOUND, "Use the generate method instead of setgenerate on this network");
 
@@ -215,12 +211,10 @@ UniValue setgenerate(const UniValue& params, bool fHelp)
 
     mapArgs["-gen"] = (fGenerate ? "1" : "0");
     mapArgs ["-genproclimit"] = itostr(nGenProcLimit);
-    GenerateBitcoins(fGenerate, pwalletMain, nGenProcLimit);
+    GenerateBitcoins(fGenerate, nGenProcLimit, Params());
 
     return NullUniValue;
 }
-#endif
-
 
 UniValue getmininginfo(const UniValue& params, bool fHelp)
 {
@@ -262,9 +256,7 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("testnet",          Params().TestnetToBeDeprecatedFieldRPC()));
     obj.push_back(Pair("chain",            Params().NetworkIDString()));
     obj.push_back(Pair("sizelimit",        chainActive.Tip()->nMaxBlockSize));
-#ifdef ENABLE_WALLET
     obj.push_back(Pair("generate",         getgenerate(params, false)));
-#endif
     return obj;
 }
 

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -150,7 +150,7 @@ UniValue generate(const UniValue& params, bool fHelp)
     UniValue blockHashes(UniValue::VARR);
     while (nHeight < nHeightEnd)
     {
-        unique_ptrCBlockTemplate> pblocktemplate(CreateNewBlock(coinbaseScript->reserveScript));
+        unique_ptr<CBlockTemplate> pblocktemplate(CreateNewBlock(coinbaseScript->reserveScript));
         if (!pblocktemplate.get())
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
         CBlock *pblock = &pblocktemplate->block;

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -136,8 +136,12 @@ UniValue generate(const UniValue& params, bool fHelp)
     boost::shared_ptr<CReserveScript> coinbaseScript;
     GetMainSignals().ScriptForMining(coinbaseScript);
 
+    // If the keypool is exhausted, no script is returned at all.  Catch this.
+    if (!coinbaseScript)
+        throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Error: Keypool ran out, please call keypoolrefill first");
+
     //throw an error if no script was provided
-    if (!coinbaseScript->reserveScript.size())
+    if (coinbaseScript->reserveScript.empty())
         throw JSONRPCError(RPC_INTERNAL_ERROR, "No coinbase script available (mining requires a wallet)");
 
     {   // Don't keep cs_main locked

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -21,6 +21,7 @@
 #include <stdint.h>
 
 #include <boost/assign/list_of.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include "univalue/univalue.h"
 
@@ -132,11 +133,11 @@ UniValue generate(const UniValue& params, bool fHelp)
     int nHeight = 0;
     int nGenerate = params[0].get_int();
 
-    CScript coinbaseScript;
+    boost::shared_ptr<CReserveScript> coinbaseScript;
     GetMainSignals().ScriptForMining(coinbaseScript);
 
     //throw an error if no script was provided
-    if (!coinbaseScript.size())
+    if (!coinbaseScript->reserveScript.size())
         throw JSONRPCError(RPC_INTERNAL_ERROR, "No coinbase script available (mining requires a wallet)");
 
     {   // Don't keep cs_main locked
@@ -149,7 +150,7 @@ UniValue generate(const UniValue& params, bool fHelp)
     UniValue blockHashes(UniValue::VARR);
     while (nHeight < nHeightEnd)
     {
-        unique_ptr<CBlockTemplate> pblocktemplate(CreateNewBlock(coinbaseScript));
+        unique_ptrCBlockTemplate> pblocktemplate(CreateNewBlock(coinbaseScript->reserveScript));
         if (!pblocktemplate.get())
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
         CBlock *pblock = &pblocktemplate->block;
@@ -168,6 +169,9 @@ UniValue generate(const UniValue& params, bool fHelp)
             throw JSONRPCError(RPC_INTERNAL_ERROR, "ProcessNewBlock, block not accepted");
         ++nHeight;
         blockHashes.push_back(pblock->GetHash().GetHex());
+
+        //mark script as important because it was used at least for one coinbase output
+        coinbaseScript->KeepScript();
     }
     return blockHashes;
 }

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -294,12 +294,10 @@ static const CRPCCommand vRPCCommands[] =
     { "mining",             "prioritisetransaction",  &prioritisetransaction,  true  },
     { "mining",             "submitblock",            &submitblock,            true  },
 
-#ifdef ENABLE_WALLET
     /* Coin generation */
     { "generating",         "getgenerate",            &getgenerate,            true  },
     { "generating",         "setgenerate",            &setgenerate,            true  },
     { "generating",         "generate",               &generate,               true  },
-#endif
 
     /* Raw transactions */
     { "rawtransactions",    "createrawtransaction",   &createrawtransaction,   true  },

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -630,4 +630,13 @@ public:
     }
 };
 
+class CReserveScript
+{
+public:
+    CScript reserveScript;
+    virtual void KeepScript() {}
+    CReserveScript() {}
+    virtual ~CReserveScript() {}
+};
+
 #endif // BITCOIN_SCRIPT_SCRIPT_H

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -21,11 +21,11 @@ void RegisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.Broadcast.connect(boost::bind(&CValidationInterface::ResendWalletTransactions, pwalletIn, _1));
     g_signals.BlockChecked.connect(boost::bind(&CValidationInterface::BlockChecked, pwalletIn, _1, _2));
     g_signals.ScriptForMining.connect(boost::bind(&CValidationInterface::GetScriptForMining, pwalletIn, _1));
-    g_signals.BlockFound.connect(boost::bind(&CValidationInterface::UpdateRequestCount, pwalletIn, _1));
+    g_signals.BlockFound.connect(boost::bind(&CValidationInterface::ResetRequestCount, pwalletIn, _1));
 }
 
 void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
-    g_signals.BlockFound.disconnect(boost::bind(&CValidationInterface::UpdateRequestCount, pwalletIn, _1));
+    g_signals.BlockFound.disconnect(boost::bind(&CValidationInterface::ResetRequestCount, pwalletIn, _1));
     g_signals.ScriptForMining.disconnect(boost::bind(&CValidationInterface::GetScriptForMining, pwalletIn, _1));
     g_signals.BlockChecked.disconnect(boost::bind(&CValidationInterface::BlockChecked, pwalletIn, _1, _2));
     g_signals.Broadcast.disconnect(boost::bind(&CValidationInterface::ResendWalletTransactions, pwalletIn, _1));

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -20,9 +20,13 @@ void RegisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.Inventory.connect(boost::bind(&CValidationInterface::Inventory, pwalletIn, _1));
     g_signals.Broadcast.connect(boost::bind(&CValidationInterface::ResendWalletTransactions, pwalletIn, _1));
     g_signals.BlockChecked.connect(boost::bind(&CValidationInterface::BlockChecked, pwalletIn, _1, _2));
+    g_signals.ScriptForMining.connect(boost::bind(&CValidationInterface::GetScriptForMining, pwalletIn, _1));
+    g_signals.BlockFound.connect(boost::bind(&CValidationInterface::UpdateRequestCount, pwalletIn, _1));
 }
 
 void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
+    g_signals.BlockFound.disconnect(boost::bind(&CValidationInterface::UpdateRequestCount, pwalletIn, _1));
+    g_signals.ScriptForMining.disconnect(boost::bind(&CValidationInterface::GetScriptForMining, pwalletIn, _1));
     g_signals.BlockChecked.disconnect(boost::bind(&CValidationInterface::BlockChecked, pwalletIn, _1, _2));
     g_signals.Broadcast.disconnect(boost::bind(&CValidationInterface::ResendWalletTransactions, pwalletIn, _1));
     g_signals.Inventory.disconnect(boost::bind(&CValidationInterface::Inventory, pwalletIn, _1));
@@ -33,6 +37,8 @@ void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
 }
 
 void UnregisterAllValidationInterfaces() {
+    g_signals.BlockFound.disconnect_all_slots();
+    g_signals.ScriptForMining.disconnect_all_slots();
     g_signals.BlockChecked.disconnect_all_slots();
     g_signals.Broadcast.disconnect_all_slots();
     g_signals.Inventory.disconnect_all_slots();

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -10,6 +10,7 @@
 
 class CBlock;
 struct CBlockLocator;
+class CScript;
 class CTransaction;
 class CValidationInterface;
 class CValidationState;
@@ -35,6 +36,8 @@ protected:
     virtual void Inventory(const uint256 &hash) {}
     virtual void ResendWalletTransactions(int64_t nBestBlockTime) {}
     virtual void BlockChecked(const CBlock&, const CValidationState&) {}
+    virtual void GetScriptForMining(CScript &script) {};
+    virtual void UpdateRequestCount(const CBlock&) {};
     friend void ::RegisterValidationInterface(CValidationInterface*);
     friend void ::UnregisterValidationInterface(CValidationInterface*);
     friend void ::UnregisterAllValidationInterfaces();
@@ -55,6 +58,10 @@ struct CMainSignals {
     boost::signals2::signal<void (int64_t nBestBlockTime)> Broadcast;
     /** Notifies listeners of a block validation result */
     boost::signals2::signal<void (const CBlock&, const CValidationState&)> BlockChecked;
+    /** Notifies listeners that a key for mining is required (coinbase) */
+    boost::signals2::signal<void (CScript &script)> ScriptForMining;
+    /** Notifies listeners that a block has been successfully mined */
+    boost::signals2::signal<void (const CBlock&)> BlockFound;
 };
 
 CMainSignals& GetMainSignals();

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -38,7 +38,7 @@ protected:
     virtual void ResendWalletTransactions(int64_t nBestBlockTime) {}
     virtual void BlockChecked(const CBlock&, const CValidationState&) {}
     virtual void GetScriptForMining(boost::shared_ptr<CReserveScript>&) {};
-    virtual void UpdateRequestCount(const CBlock&) {};
+    virtual void ResetRequestCount(const uint256 &hash) {};
     friend void ::RegisterValidationInterface(CValidationInterface*);
     friend void ::UnregisterValidationInterface(CValidationInterface*);
     friend void ::UnregisterAllValidationInterfaces();
@@ -62,7 +62,7 @@ struct CMainSignals {
     /** Notifies listeners that a key for mining is required (coinbase) */
     boost::signals2::signal<void (boost::shared_ptr<CReserveScript>&)> ScriptForMining;
     /** Notifies listeners that a block has been successfully mined */
-    boost::signals2::signal<void (const CBlock&)> BlockFound;
+    boost::signals2::signal<void (const uint256 &)> BlockFound;
 };
 
 CMainSignals& GetMainSignals();

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -7,10 +7,11 @@
 #define BITCOIN_VALIDATIONINTERFACE_H
 
 #include <boost/signals2/signal.hpp>
+#include <boost/shared_ptr.hpp>
 
 class CBlock;
 struct CBlockLocator;
-class CScript;
+class CReserveScript;
 class CTransaction;
 class CValidationInterface;
 class CValidationState;
@@ -36,7 +37,7 @@ protected:
     virtual void Inventory(const uint256 &hash) {}
     virtual void ResendWalletTransactions(int64_t nBestBlockTime) {}
     virtual void BlockChecked(const CBlock&, const CValidationState&) {}
-    virtual void GetScriptForMining(CScript &script) {};
+    virtual void GetScriptForMining(boost::shared_ptr<CReserveScript>&) {};
     virtual void UpdateRequestCount(const CBlock&) {};
     friend void ::RegisterValidationInterface(CValidationInterface*);
     friend void ::UnregisterValidationInterface(CValidationInterface*);
@@ -59,7 +60,7 @@ struct CMainSignals {
     /** Notifies listeners of a block validation result */
     boost::signals2::signal<void (const CBlock&, const CValidationState&)> BlockChecked;
     /** Notifies listeners that a key for mining is required (coinbase) */
-    boost::signals2::signal<void (CScript &script)> ScriptForMining;
+    boost::signals2::signal<void (boost::shared_ptr<CReserveScript>&)> ScriptForMining;
     /** Notifies listeners that a block has been successfully mined */
     boost::signals2::signal<void (const CBlock&)> BlockFound;
 };

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -362,7 +362,7 @@ bool CWallet::Verify(const string& walletFile, string& warningString, string& er
         } catch (const boost::filesystem::filesystem_error&) {
             // failure is ok (well, not really, but it's not worse than what we started with)
         }
-        
+
         // try again
         if (!bitdb.Open(GetDataDir())) {
             // if it still fails, it probably means we can't even create the database env
@@ -371,14 +371,14 @@ bool CWallet::Verify(const string& walletFile, string& warningString, string& er
             return true;
         }
     }
-    
+
     if (GetBoolArg("-salvagewallet", false))
     {
         // Recover readable keypairs:
         if (!CWalletDB::Recover(bitdb, walletFile, true))
             return false;
     }
-    
+
     if (boost::filesystem::exists(GetDataDir() / walletFile))
     {
         CDBEnv::VerifyResult r = bitdb.Verify(walletFile, CWalletDB::Recover);
@@ -392,7 +392,7 @@ bool CWallet::Verify(const string& walletFile, string& warningString, string& er
         if (r == CDBEnv::RECOVER_FAIL)
             errorString += _("wallet.dat corrupt, salvage failed");
     }
-    
+
     return true;
 }
 
@@ -2195,7 +2195,7 @@ bool CWallet::SetDefaultKey(const CPubKey &vchPubKey)
 
 /**
  * Mark old keypool keys as used,
- * and generate all new keys 
+ * and generate all new keys
  */
 bool CWallet::NewKeyPool()
 {
@@ -2539,6 +2539,17 @@ void CWallet::UpdatedTransaction(const uint256 &hashTx)
         if (mi != mapWallet.end())
             NotifyTransactionChanged(this, hashTx, CT_UPDATED);
     }
+}
+
+void CWallet::GetScriptForMining(CScript &script)
+{
+    CReserveKey reservekey(this);
+    reservekey.KeepKey();
+
+    CPubKey pubkey;
+    if (!reservekey.GetReservedKey(pubkey))
+        return;
+    script = CScript() << ToByteVector(pubkey) << OP_CHECKSIG;
 }
 
 void CWallet::LockCoin(COutPoint& output)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2541,14 +2541,15 @@ void CWallet::UpdatedTransaction(const uint256 &hashTx)
     }
 }
 
-void CWallet::GetScriptForMining(CScript &script)
+void CWallet::GetScriptForMining(boost::shared_ptr<CReserveScript> &script)
 {
-    CReserveKey reservekey(this);
+    boost::shared_ptr<CReserveKey> rKey(new CReserveKey(this));
     CPubKey pubkey;
-    if (!reservekey.GetReservedKey(pubkey))
+    if (!rKey->GetReservedKey(pubkey))
         return;
-    script = CScript() << ToByteVector(pubkey) << OP_CHECKSIG;
-    reservekey.KeepKey();
+
+    script = rKey;
+    script->reserveScript = CScript() << ToByteVector(pubkey) << OP_CHECKSIG;
 }
 
 void CWallet::LockCoin(COutPoint& output)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2544,12 +2544,11 @@ void CWallet::UpdatedTransaction(const uint256 &hashTx)
 void CWallet::GetScriptForMining(CScript &script)
 {
     CReserveKey reservekey(this);
-    reservekey.KeepKey();
-
     CPubKey pubkey;
     if (!reservekey.GetReservedKey(pubkey))
         return;
     script = CScript() << ToByteVector(pubkey) << OP_CHECKSIG;
+    reservekey.KeepKey();
 }
 
 void CWallet::LockCoin(COutPoint& output)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -690,10 +690,10 @@ public:
     }
 
     void GetScriptForMining(boost::shared_ptr<CReserveScript> &script);
-    void UpdateRequestCount(const CBlock& block)
+    void ResetRequestCount(const uint256 &hash)
     {
         LOCK(cs_wallet);
-        mapRequestCount[block.GetHash()] = 0;
+        mapRequestCount[hash] = 0;
     };
     
     unsigned int GetKeyPoolSize()

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -687,6 +687,13 @@ public:
         }
     }
 
+    void GetScriptForMining(CScript &script);
+    void UpdateRequestCount(const CBlock& block)
+    {
+        LOCK(cs_wallet);
+        mapRequestCount[block.GetHash()] = 0;
+    };
+    
     unsigned int GetKeyPoolSize()
     {
         AssertLockHeld(cs_wallet); // setKeyPool

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -28,6 +28,8 @@
 #include <utility>
 #include <vector>
 
+#include <boost/shared_ptr.hpp>
+
 /**
  * Settings
  */
@@ -687,7 +689,7 @@ public:
         }
     }
 
-    void GetScriptForMining(CScript &script);
+    void GetScriptForMining(boost::shared_ptr<CReserveScript> &script);
     void UpdateRequestCount(const CBlock& block)
     {
         LOCK(cs_wallet);
@@ -749,7 +751,7 @@ public:
 };
 
 /** A key allocated from the key pool. */
-class CReserveKey
+class CReserveKey : public CReserveScript
 {
 protected:
     CWallet* pwallet;
@@ -770,6 +772,7 @@ public:
     void ReturnKey();
     bool GetReservedKey(CPubKey &pubkey);
     void KeepKey();
+    void KeepScript() { KeepKey(); }
 };
 
 


### PR DESCRIPTION
Ports of the following:

https://github.com/bitcoin/bitcoin/pull/5994 - detach wallet from miner
https://github.com/bitcoin/bitcoin/pull/6567 - Fix crash when mining with empty keypool.
https://github.com/bitcoin/bitcoin/pull/7027 - [qa] rpc-tests: Properly use test framework
fa942c7 (Move method to check matches within arrays on util.py) from https://github.com/bitcoin/bitcoin/pull/7822/

Builds on top of #257 