### PR TITLE
Test framework improvements

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -222,9 +222,10 @@ class RPCTestHandler:
             # Add tests
             self.num_running += 1
             t = self.test_list.pop(0)
+            port_seed = ["--portseed=%s" % len(self.test_list)]
             self.jobs.append((t,
                               time.time(),
-                              subprocess.Popen((RPC_TESTS_DIR + t).split() + self.flags,
+                              subprocess.Popen((RPC_TESTS_DIR + t).split() + self.flags + port_seed,
                                                universal_newlines=True,
                                                stdout=subprocess.PIPE,
                                                stderr=subprocess.PIPE)))

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -152,8 +152,7 @@ def runtests():
                 test_list.append(t)
 
     if print_help:
-        # Help should be the same for all scripts, so just
-        # call the first and exit
+        # Only print help of the first script and exit
         subprocess.check_call(RPC_TESTS_DIR + test_list[0] + ' -h', shell=True)
         sys.exit(0)
 

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -51,10 +51,12 @@ ENABLE_COVERAGE=0
 
 #Create a set to store arguments and create the passon string
 opts = set()
-passon_args = ""
+passon_args = []
 PASSON_REGEX = re.compile("^--")
+PARALLEL_REGEX = re.compile('^-parallel=')
 
 print_help = False
+run_parallel = 4
 
 for arg in sys.argv[1:]:
     if arg == "--help" or arg == "-h" or arg == "-?":
@@ -63,7 +65,9 @@ for arg in sys.argv[1:]:
     if arg == '--coverage':
         ENABLE_COVERAGE = 1
     elif PASSON_REGEX.match(arg):
-        passon_args += " " + arg
+        passon_args.append(arg)
+    elif PARALLEL_REGEX.match(arg):
+        run_parallel = int(arg.split(sep='=', maxsplit=1)[1])
     else:
         opts.add(arg)
 
@@ -85,6 +89,7 @@ if not (ENABLE_WALLET == 1 and ENABLE_UTILS == 1 and ENABLE_BITCOIND == 1):
 
 #Tests
 testScripts = [
+    'walletbackup.py',
     'bip68-112-113-p2p.py',
     'spv.py',
     'wallet.py',
@@ -103,7 +108,6 @@ testScripts = [
     'proxy_test.py',
     'merkle_blocks.py',
     'signrawtransactions.py',
-    'walletbackup.py',
     'p2p-versionbits-warning.py',
     'decodescript.py',
     'sendheaders.py',
@@ -140,6 +144,7 @@ testScriptsExt = [
     'mempool_packages.py'
 ]
 
+
 def runtests():
     test_list = []
     if '-extended' in opts:
@@ -153,7 +158,7 @@ def runtests():
 
     if print_help:
         # Only print help of the first script and exit
-        subprocess.check_call(RPC_TESTS_DIR + test_list[0] + ' -h', shell=True)
+        subprocess.check_call((RPC_TESTS_DIR + test_list[0]).split() + ['-h'])
         sys.exit(0)
 
     coverage = None
@@ -161,21 +166,82 @@ def runtests():
     if ENABLE_COVERAGE:
         coverage = RPCCoverage()
         print("Initializing coverage directory at %s\n" % coverage.dir)
-    flags = " --srcdir %s/src %s %s" % (BUILDDIR, coverage.flag if coverage else '', passon_args)
+    flags = ["--srcdir=%s/src" % BUILDDIR] + passon_args
+    if coverage:
+        flags.append(coverage.flag)
+
+    if len(test_list) > 1:
+        # Populate cache
+        subprocess.check_output([RPC_TESTS_DIR + 'create_cache.py'] + flags)
 
     #Run Tests
-    for t in test_list:
-            print("Running testscript %s%s%s ..." % (BOLD[1], t, BOLD[0]))
-            time0 = time.time()
-            subprocess.check_call(
-                RPC_TESTS_DIR + t + flags, shell=True)
-            print("Duration: %s s\n" % (int(time.time() - time0)))
+    max_len_name = len(max(test_list, key=len))
+    time_sum = 0
+    time0 = time.time()
+    job_queue = RPCTestHandler(run_parallel, test_list, flags)
+    results = BOLD[1] + "%s | %s | %s\n\n" % ("TEST".ljust(max_len_name), "PASSED", "DURATION") + BOLD[0]
+    all_passed = True
+    for _ in range(len(test_list)):
+        (name, stdout, stderr, passed, duration) = job_queue.get_next()
+        all_passed = all_passed and passed
+        time_sum += duration
+
+        print('\n' + BOLD[1] + name + BOLD[0] + ":")
+        print(stdout)
+        print('stderr:\n' if not stderr == '' else '', stderr)
+        results += "%s | %s | %s s\n" % (name.ljust(max_len_name), str(passed).ljust(6), duration)
+        print("Pass: %s%s%s, Duration: %s s\n" % (BOLD[1], passed, BOLD[0], duration))
+    results += BOLD[1] + "\n%s | %s | %s s (accumulated)" % ("ALL".ljust(max_len_name), str(all_passed).ljust(6), time_sum) + BOLD[0]
+    print(results)
+    print("\nRuntime: %s s" % (int(time.time() - time0)))
 
     if coverage:
         coverage.report_rpc_coverage()
 
         print("Cleaning up coverage data")
         coverage.cleanup()
+
+    sys.exit(not all_passed)
+
+
+class RPCTestHandler:
+    """
+    Trigger the testscrips passed in via the list.
+    """
+
+    def __init__(self, num_tests_parallel, test_list=None, flags=None):
+        assert(num_tests_parallel >= 1)
+        self.num_jobs = num_tests_parallel
+        self.test_list = test_list
+        self.flags = flags
+        self.num_running = 0
+        self.jobs = []
+
+    def get_next(self):
+        while self.num_running < self.num_jobs and self.test_list:
+            # Add tests
+            self.num_running += 1
+            t = self.test_list.pop(0)
+            self.jobs.append((t,
+                              time.time(),
+                              subprocess.Popen((RPC_TESTS_DIR + t).split() + self.flags,
+                                               universal_newlines=True,
+                                               stdout=subprocess.PIPE,
+                                               stderr=subprocess.PIPE)))
+        if not self.jobs:
+            raise IndexError('%s from empty list' % __name__)
+        while True:
+            # Return first proc that finishes
+            time.sleep(.5)
+            for j in self.jobs:
+                (name, time0, proc) = j
+                if proc.poll() is not None:
+                    (stdout, stderr) = proc.communicate(timeout=3)
+                    passed = stderr == "" and proc.returncode == 0
+                    self.num_running -= 1
+                    self.jobs.remove(j)
+                    return name, stdout, stderr, passed, int(time.time() - time0)
+            print('.', end='', flush=True)
 
 
 class RPCCoverage(object):
@@ -195,7 +261,7 @@ class RPCCoverage(object):
     """
     def __init__(self):
         self.dir = tempfile.mkdtemp(prefix="coverage")
-        self.flag = '--coveragedir %s' % self.dir
+        self.flag = '--coveragedir=%s' % self.dir
 
     def report_rpc_coverage(self):
         """

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -31,6 +31,14 @@ import re
 
 from tests_config import *
 
+BOLD = ("","")
+if os.name == 'posix':
+    # primitive formatting on supported
+    # terminal via ANSI escape sequences:
+    BOLD = ('\033[0m', '\033[1m')
+
+RPC_TESTS_DIR = BUILDDIR + '/qa/rpc-tests/'
+
 #If imported values are not defined then set to zero (or disabled)
 if 'ENABLE_WALLET' not in vars():
     ENABLE_WALLET=0
@@ -41,29 +49,29 @@ if 'ENABLE_UTILS' not in vars():
 
 ENABLE_COVERAGE=0
 
-#Create a set to store arguments and create the passOn string
+#Create a set to store arguments and create the passon string
 opts = set()
-passOn = ""
-p = re.compile("^--")
+passon_args = ""
+PASSON_REGEX = re.compile("^--")
 
-bold = ("","")
-if (os.name == 'posix'):
-    bold = ('\033[0m', '\033[1m')
+print_help = False
 
 for arg in sys.argv[1:]:
+    if arg == "--help" or arg == "-h" or arg == "-?":
+        print_help = True
+        break
     if arg == '--coverage':
         ENABLE_COVERAGE = 1
-    elif (p.match(arg) or arg == "-h"):
-        passOn += " " + arg
+    elif PASSON_REGEX.match(arg):
+        passon_args += " " + arg
     else:
         opts.add(arg)
 
 #Set env vars
-buildDir = BUILDDIR
 if "BITCOIND" not in os.environ:
-    os.environ["BITCOIND"] = buildDir + '/src/bitcoind' + EXEEXT
+    os.environ["BITCOIND"] = BUILDDIR + '/src/bitcoind' + EXEEXT
 if "BITCOINCLI" not in os.environ:
-    os.environ["BITCOINCLI"] = buildDir + '/src/bitcoin-cli' + EXEEXT
+    os.environ["BITCOINCLI"] = BUILDDIR + '/src/bitcoin-cli' + EXEEXT
 
 if EXEEXT == ".exe" and "-win" not in opts:
     # https://github.com/bitcoin/bitcoin/commit/d52802551752140cf41f0d9a225a43e84404d3e9
@@ -133,48 +141,35 @@ testScriptsExt = [
 ]
 
 def runtests():
+    test_list = []
+    if '-extended' in opts:
+        test_list = testScripts + testScriptsExt
+    elif len(opts) == 0 or (len(opts) == 1 and "-win" in opts):
+        test_list = testScripts
+    else:
+        for t in testScripts + testScriptsExt:
+            if t in opts or re.sub(".py$", "", t) in opts:
+                test_list.append(t)
+
+    if print_help:
+        # Help should be the same for all scripts, so just
+        # call the first and exit
+        subprocess.check_call(RPC_TESTS_DIR + test_list[0] + ' -h', shell=True)
+        sys.exit(0)
+
     coverage = None
 
     if ENABLE_COVERAGE:
         coverage = RPCCoverage()
         print("Initializing coverage directory at %s\n" % coverage.dir)
-
-    rpcTestDir = buildDir + '/qa/rpc-tests/'
-    run_extended = '-extended' in opts
-    cov_flag = coverage.flag if coverage else ''
-    flags = " --srcdir %s/src %s %s" % (buildDir, cov_flag, passOn)
+    flags = " --srcdir %s/src %s %s" % (BUILDDIR, coverage.flag if coverage else '', passon_args)
 
     #Run Tests
-    for i in range(len(testScripts)):
-        if (len(opts) == 0
-                or (len(opts) == 1 and "-win" in opts )
-                or run_extended
-                or testScripts[i] in opts
-                or re.sub(".py$", "", testScripts[i]) in opts ):
-
-            print("Running testscript %s%s%s ..." % (bold[1], testScripts[i], bold[0]))
+    for t in test_list:
+            print("Running testscript %s%s%s ..." % (BOLD[1], t, BOLD[0]))
             time0 = time.time()
             subprocess.check_call(
-                rpcTestDir + testScripts[i] + flags, shell=True)
-            print("Duration: %s s\n" % (int(time.time() - time0)))
-
-            # exit if help is called so we print just one set of
-            # instructions
-            p = re.compile(" -h| --help")
-            if p.match(passOn):
-                sys.exit(0)
-
-    # Run Extended Tests
-    for i in range(len(testScriptsExt)):
-        if (run_extended or testScriptsExt[i] in opts
-                or re.sub(".py$", "", testScriptsExt[i]) in opts):
-
-            print(
-                "Running 2nd level testscript "
-                + "%s%s%s ..." % (bold[1], testScriptsExt[i], bold[0]))
-            time0 = time.time()
-            subprocess.check_call(
-                rpcTestDir + testScriptsExt[i] + flags, shell=True)
+                RPC_TESTS_DIR + t + flags, shell=True)
             print("Duration: %s s\n" % (int(time.time() - time0)))
 
     if coverage:

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -67,6 +67,7 @@ if "BITCOINCLI" not in os.environ:
 
 if EXEEXT == ".exe" and "-win" not in opts:
     # https://github.com/bitcoin/bitcoin/commit/d52802551752140cf41f0d9a225a43e84404d3e9
+    # https://github.com/bitcoin/bitcoin/pull/5677#issuecomment-136646964
     print("Win tests currently disabled by default.  Use -win option to enable")
     sys.exit(0)
 

--- a/qa/rpc-tests/bip65-cltv-p2p.py
+++ b/qa/rpc-tests/bip65-cltv-p2p.py
@@ -37,11 +37,12 @@ Mine 1 old version block, see that the node rejects.
 class BIP65Test(ComparisonTestFramework):
 
     def __init__(self):
+        super().__init__()
         self.num_nodes = 1
 
     def setup_network(self):
         # Must set the blockversion for this test
-        self.nodes = start_nodes(1, self.options.tmpdir,
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
                                  extra_args=[['-debug', '-whitelist=127.0.0.1', '-blockversion=3']],
                                  binary=[self.options.testbinary])
 

--- a/qa/rpc-tests/bip65-cltv.py
+++ b/qa/rpc-tests/bip65-cltv.py
@@ -13,6 +13,10 @@ import os
 import shutil
 
 class BIP65Test(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 3
+        self.setup_clean_chain = False
 
     def __init__(self):
         self.num_nodes = 3

--- a/qa/rpc-tests/bip68-112-113-p2p.py
+++ b/qa/rpc-tests/bip68-112-113-p2p.py
@@ -94,11 +94,12 @@ def all_rlt_txs(txarray):
 
 class BIP68_112_113Test(ComparisonTestFramework):
     def __init__(self):
+        super().__init__()
         self.num_nodes = 1
 
     def setup_network(self):
         # Must set the blockversion for this test
-        self.nodes = start_nodes(1, self.options.tmpdir,
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
                                  extra_args=[['-debug', '-whitelist=127.0.0.1', '-blockversion=4']],
                                  binary=[self.options.testbinary])
 

--- a/qa/rpc-tests/bip68-sequence.py
+++ b/qa/rpc-tests/bip68-sequence.py
@@ -23,6 +23,10 @@ SEQUENCE_LOCKTIME_MASK = 0x0000ffff
 NOT_FINAL_ERROR = "64: non-BIP68-final"
 
 class BIP68Test(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 2
+        self.setup_clean_chain = False
 
     def setup_network(self):
         self.nodes = []

--- a/qa/rpc-tests/bip9-softforks.py
+++ b/qa/rpc-tests/bip9-softforks.py
@@ -32,10 +32,11 @@ test that enforcement has triggered
 class BIP9SoftForksTest(ComparisonTestFramework):
 
     def __init__(self):
+        super().__init__()
         self.num_nodes = 1
 
     def setup_network(self):
-        self.nodes = start_nodes(1, self.options.tmpdir,
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
                                  extra_args=[['-debug', '-whitelist=127.0.0.1']],
                                  binary=[self.options.testbinary])
 

--- a/qa/rpc-tests/bipdersig-p2p.py
+++ b/qa/rpc-tests/bipdersig-p2p.py
@@ -45,11 +45,12 @@ Mine 1 old version block, see that the node rejects.
 class BIP66Test(ComparisonTestFramework):
 
     def __init__(self):
+        super().__init__()
         self.num_nodes = 1
 
     def setup_network(self):
         # Must set the blockversion for this test
-        self.nodes = start_nodes(1, self.options.tmpdir,
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
                                  extra_args=[['-debug', '-whitelist=127.0.0.1', '-blockversion=2']],
                                  binary=[self.options.testbinary])
 

--- a/qa/rpc-tests/create_cache.py
+++ b/qa/rpc-tests/create_cache.py
@@ -12,9 +12,15 @@ from test_framework.test_framework import BitcoinTestFramework
 
 class CreateCache(BitcoinTestFramework):
 
+    def __init__(self):
+        super().__init__()
+
+        # Test network and test nodes are not required:
+        self.num_nodes = 0
+        self.nodes = []
+
     def setup_network(self):
-        # Don't setup any test nodes
-        self.options.noshutdown = True
+        pass
 
     def run_test(self):
         pass

--- a/qa/rpc-tests/create_cache.py
+++ b/qa/rpc-tests/create_cache.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# Copyright (c) 2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Helper script to create the cache
+# (see BitcoinTestFramework.setup_chain)
+#
+
+from test_framework.test_framework import BitcoinTestFramework
+
+class CreateCache(BitcoinTestFramework):
+
+    def setup_network(self):
+        # Don't setup any test nodes
+        self.options.noshutdown = True
+
+    def run_test(self):
+        pass
+
+if __name__ == '__main__':
+    CreateCache().main()

--- a/qa/rpc-tests/decodescript.py
+++ b/qa/rpc-tests/decodescript.py
@@ -11,12 +11,13 @@ from io import BytesIO
 class DecodeScriptTest(BitcoinTestFramework):
     """Tests decoding scripts via RPC command "decodescript"."""
 
-    def setup_chain(self):
-        print('Initializing test directory ' + self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 1)
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(1, self.options.tmpdir)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
         self.is_network_split = False
 
     def decodescript_script_sig(self):

--- a/qa/rpc-tests/forknotify.py
+++ b/qa/rpc-tests/forknotify.py
@@ -14,6 +14,11 @@ import shutil
 
 class ForkNotifyTest(BitcoinTestFramework):
 
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 2
+        self.setup_clean_chain = False
+
     alert_filename = None  # Set by setup_network
 
     def __init__(self):

--- a/qa/rpc-tests/getblocktemplate_longpoll.py
+++ b/qa/rpc-tests/getblocktemplate_longpoll.py
@@ -26,6 +26,11 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
     Test longpolling with getblocktemplate.
     '''
 
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 4
+        self.setup_clean_chain = False
+
     def run_test(self):
         print("Warning: this test will take about 70 seconds in the best case. Be patient.")
         self.nodes[0].generate(10)

--- a/qa/rpc-tests/getblocktemplate_proposals.py
+++ b/qa/rpc-tests/getblocktemplate_proposals.py
@@ -70,6 +70,15 @@ class GetBlockTemplateProposalTest(BitcoinTestFramework):
     Test block proposals with getblocktemplate.
     '''
 
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 2
+        self.setup_clean_chain = False
+
+    def setup_network(self):
+        self.nodes = self.setup_nodes()
+        connect_nodes_bi(self.nodes, 0, 1)
+
     def run_test(self):
         node = self.nodes[0]
         node.generate(1) # Mine a block to leave initial block download

--- a/qa/rpc-tests/getchaintips.py
+++ b/qa/rpc-tests/getchaintips.py
@@ -11,9 +11,12 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 
 class GetChainTipsTest (BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 4
+        self.setup_clean_chain = False
 
     def run_test (self):
-        BitcoinTestFramework.run_test (self)
 
         tips = self.nodes[0].getchaintips ()
         assert_equal (len (tips), 1)

--- a/qa/rpc-tests/httpbasics.py
+++ b/qa/rpc-tests/httpbasics.py
@@ -14,8 +14,13 @@ import http.client
 import urllib.parse
 
 class HTTPBasicsTest (BitcoinTestFramework):
-    def setup_nodes(self):
-        return start_nodes(4, self.options.tmpdir)
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 3
+        self.setup_clean_chain = False
+
+    def setup_network(self):
+        self.nodes = self.setup_nodes()
 
     def run_test(self):
 

--- a/qa/rpc-tests/invalidateblock.py
+++ b/qa/rpc-tests/invalidateblock.py
@@ -13,9 +13,10 @@ from test_framework.util import *
 class InvalidateTest(BitcoinTestFramework):
 
 
-    def setup_chain(self):
-        print("Initializing test directory "+self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 3)
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 3
 
     def setup_network(self):
         self.nodes = []

--- a/qa/rpc-tests/invalidblockrequest.py
+++ b/qa/rpc-tests/invalidblockrequest.py
@@ -27,6 +27,7 @@ class InvalidBlockRequestTest(ComparisonTestFramework):
     ''' Can either run this test as 1 node with expected answers, or two and compare them.
         Change the "outcome" variable from each TestInstance object to only do the comparison. '''
     def __init__(self):
+        super().__init__()
         self.num_nodes = 1
 
     def run_test(self):

--- a/qa/rpc-tests/invalidtxrequest.py
+++ b/qa/rpc-tests/invalidtxrequest.py
@@ -23,6 +23,7 @@ class InvalidTxRequestTest(ComparisonTestFramework):
     ''' Can either run this test as 1 node with expected answers, or two and compare them.
         Change the "outcome" variable from each TestInstance object to only do the comparison. '''
     def __init__(self):
+        super().__init__()
         self.num_nodes = 1
 
     def run_test(self):

--- a/qa/rpc-tests/keypool.py
+++ b/qa/rpc-tests/keypool.py
@@ -5,8 +5,6 @@
 
 # Exercise the wallet keypool, and interaction with wallet encryption/locking
 
-# Add python-bitcoinrpc to module search path:
-
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
@@ -63,12 +61,13 @@ class KeyPoolTest(BitcoinTestFramework):
         except JSONRPCException as e:
             assert(e.error['code']==-12)
 
-    def setup_chain(self):
-        print("Initializing test directory "+self.options.tmpdir)
-        initialize_chain(self.options.tmpdir)
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = False
+        self.num_nodes = 1
 
     def setup_network(self):
-        self.nodes = start_nodes(1, self.options.tmpdir)
+        self.nodes = self.setup_nodes()
 
 if __name__ == '__main__':
     KeyPoolTest().main()

--- a/qa/rpc-tests/listtransactions.py
+++ b/qa/rpc-tests/listtransactions.py
@@ -17,11 +17,15 @@ def txFromHex(hexstring):
     return tx
 
 class ListTransactionsTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 4
+        self.setup_clean_chain = False
 
     def setup_nodes(self):
         #This test requires mocktime
         enable_mocktime()
-        return start_nodes(4, self.options.tmpdir)
+        return start_nodes(self.num_nodes, self.options.tmpdir)
 
     def run_test(self):
         # Simple send, 0 to 1:

--- a/qa/rpc-tests/maxblocksinflight.py
+++ b/qa/rpc-tests/maxblocksinflight.py
@@ -80,12 +80,13 @@ class MaxBlocksInFlightTest(BitcoinTestFramework):
                           default=os.getenv("BITCOIND", "bitcoind"),
                           help="Binary to test max block requests behavior")
 
-    def setup_chain(self):
-        print("Initializing test directory "+self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 1)
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
 
     def setup_network(self):
-        self.nodes = start_nodes(1, self.options.tmpdir,
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
                                  extra_args=[['-debug', '-whitelist=127.0.0.1']],
                                  binary=[self.options.testbinary])
 

--- a/qa/rpc-tests/mempool_limit.py
+++ b/qa/rpc-tests/mempool_limit.py
@@ -14,6 +14,9 @@ class MempoolLimitTest(BitcoinTestFramework):
         return  Decimal(amount).quantize(Decimal('0.00000001'), rounding=ROUND_DOWN)
 
     def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 2
         # Some pre-processing to create a bunch of OP_RETURN txouts to insert into transactions we create
         # So we have big transactions (and therefore can't fit very many into each block)
         # create one script_pubkey
@@ -88,10 +91,6 @@ class MempoolLimitTest(BitcoinTestFramework):
         self.is_network_split = False
         self.sync_all()
         self.relayfee = self.nodes[0].getnetworkinfo()['relayfee']
-
-    def setup_chain(self):
-        print("Initializing test directory "+self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 2)
 
     def run_test(self):
         txids = []

--- a/qa/rpc-tests/mempool_packages.py
+++ b/qa/rpc-tests/mempool_packages.py
@@ -15,6 +15,10 @@ MAX_ANCESTORS = 25
 MAX_DESCENDANTS = 25
 
 class MempoolPackagesTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 2
+        self.setup_clean_chain = False
 
     def setup_network(self):
         self.nodes = []

--- a/qa/rpc-tests/mempool_reorg.py
+++ b/qa/rpc-tests/mempool_reorg.py
@@ -15,6 +15,10 @@ import shutil
 
 # Create one-input, one-output, no-fee transaction:
 class MempoolCoinbaseTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 2
+        self.setup_clean_chain = False
 
     alert_filename = None  # Set by setup_network
 

--- a/qa/rpc-tests/mempool_resurrect_test.py
+++ b/qa/rpc-tests/mempool_resurrect_test.py
@@ -16,6 +16,11 @@ import shutil
 # Create one-input, one-output, no-fee transaction:
 class MempoolCoinbaseTest(BitcoinTestFramework):
 
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 1
+        self.setup_clean_chain = False
+
     def setup_network(self):
         # Just need one node for this test
         args = ["-checkmempool", "-debug=mempool", "-relaypriority=0"]

--- a/qa/rpc-tests/mempool_spendcoinbase.py
+++ b/qa/rpc-tests/mempool_spendcoinbase.py
@@ -21,6 +21,11 @@ import shutil
 # Create one-input, one-output, no-fee transaction:
 class MempoolSpendCoinbaseTest(BitcoinTestFramework):
 
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 1
+        self.setup_clean_chain = False
+
     def setup_network(self):
         # Just need one node for this test
         args = ["-checkmempool", "-debug=mempool", "-relaypriority=0"]

--- a/qa/rpc-tests/merkle_blocks.py
+++ b/qa/rpc-tests/merkle_blocks.py
@@ -14,9 +14,10 @@ import shutil
 
 class MerkleBlockTest(BitcoinTestFramework):
 
-    def setup_chain(self):
-        print("Initializing test directory "+self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 4)
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 4
 
     def setup_network(self):
         self.nodes = []

--- a/qa/rpc-tests/p2p-acceptblock.py
+++ b/qa/rpc-tests/p2p-acceptblock.py
@@ -111,8 +111,10 @@ class AcceptBlockTest(BitcoinTestFramework):
                           default=os.getenv("BITCOIND", "bitcoind"),
                           help="bitcoind binary to test")
 
-    def setup_chain(self):
-        initialize_chain_clean(self.options.tmpdir, 2)
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 2
 
     def setup_network(self):
         # Node0 will be used to test behavior of processing unrequested blocks

--- a/qa/rpc-tests/p2p-fullblocktest.py
+++ b/qa/rpc-tests/p2p-fullblocktest.py
@@ -33,6 +33,7 @@ class FullBlockTest(ComparisonTestFramework):
     ''' Can either run this test as 1 node with expected answers, or two and compare them.
         Change the "outcome" variable from each TestInstance object to only do the comparison. '''
     def __init__(self):
+        super().__init__()
         self.num_nodes = 1
         self.block_heights = {}
         self.coinbase_key = CECKey()

--- a/qa/rpc-tests/p2p-versionbits-warning.py
+++ b/qa/rpc-tests/p2p-versionbits-warning.py
@@ -59,8 +59,10 @@ class TestNode(NodeConnCB):
 
 
 class VersionBitsWarningTest(BitcoinTestFramework):
-    def setup_chain(self):
-        initialize_chain_clean(self.options.tmpdir, 1)
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
 
     def setup_network(self):
         self.nodes = []

--- a/qa/rpc-tests/proxy_test.py
+++ b/qa/rpc-tests/proxy_test.py
@@ -37,7 +37,10 @@ addnode connect to generic DNS name
 
 class ProxyTest(BitcoinTestFramework):
     def __init__(self):
-        super(ProxyTest, self).__init__()
+        super().__init__()
+        self.num_nodes = 4
+        self.setup_clean_chain = False
+
         # Create two proxies on different ports
         # ... one unauthenticated
         self.conf1 = Socks5Configuration()
@@ -66,7 +69,7 @@ class ProxyTest(BitcoinTestFramework):
     def setup_nodes(self):
         # Note: proxies are not used to connect to local nodes
         # this is because the proxy to use is based on CService.GetNetwork(), which return NET_UNROUTABLE for localhost
-        return start_nodes(4, self.options.tmpdir, extra_args=[
+        return start_nodes(self.num_nodes, self.options.tmpdir, extra_args=[
             ['-listen', '-debug=net', '-debug=proxy', '-proxy=%s:%i' % (self.conf1.addr),'-proxyrandomize=1'],
             ['-listen', '-debug=net', '-debug=proxy', '-proxy=%s:%i' % (self.conf1.addr),'-onion=%s:%i' % (self.conf2.addr),'-proxyrandomize=0'],
             ['-listen', '-debug=net', '-debug=proxy', '-proxy=%s:%i' % (self.conf2.addr),'-proxyrandomize=1'],

--- a/qa/rpc-tests/pruning.py
+++ b/qa/rpc-tests/pruning.py
@@ -21,6 +21,10 @@ def calc_usage(blockdir):
 class PruneTest(BitcoinTestFramework):
 
     def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 3
+
         self.utxo = []
         self.address = ["",""]
 
@@ -41,10 +45,6 @@ class PruneTest(BitcoinTestFramework):
             # add script_pubkey
             self.txouts = self.txouts + script_pubkey
 
-
-    def setup_chain(self):
-        print("Initializing test directory "+self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 3)
 
     def setup_network(self):
         self.nodes = []

--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -16,12 +16,13 @@ from time import sleep
 # Create one-input, one-output, no-fee transaction:
 class RawTransactionsTest(BitcoinTestFramework):
 
-    def setup_chain(self):
-        print("Initializing test directory "+self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 3)
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 3
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(3, self.options.tmpdir)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
 
         #connect to a local machine for debugging
         #url = "http://bitcoinrpc:DP6DvqZtqXarpeNWyN3LZTFchCCyCUuHwNF7E8pX99x1@%s:%d" % ('127.0.0.1', 18332)

--- a/qa/rpc-tests/receivedby.py
+++ b/qa/rpc-tests/receivedby.py
@@ -27,10 +27,15 @@ def get_sub_array_from_array(object_array, to_match):
 
 class ReceivedByTest(BitcoinTestFramework):
 
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 4
+        self.setup_clean_chain = False
+
     def setup_nodes(self):
         #This test requires mocktime
         enable_mocktime()
-        return start_nodes(4, self.options.tmpdir)
+        return start_nodes(self.num_nodes, self.options.tmpdir)
 
     def run_test(self):
         '''

--- a/qa/rpc-tests/reindex.py
+++ b/qa/rpc-tests/reindex.py
@@ -13,9 +13,10 @@ import time
 
 class ReindexTest(BitcoinTestFramework):
 
-    def setup_chain(self):
-        print("Initializing test directory "+self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 1)
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
 
     def setup_network(self):
         self.nodes = []

--- a/qa/rpc-tests/rest.py
+++ b/qa/rpc-tests/rest.py
@@ -50,12 +50,13 @@ def http_post_call(host, port, path, requestdata = '', response_object = 0):
 class RESTTest (BitcoinTestFramework):
     FORMAT_SEPARATOR = "."
 
-    def setup_chain(self):
-        print("Initializing test directory "+self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 3)
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 3
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(3, self.options.tmpdir)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)

--- a/qa/rpc-tests/rpcbind_test.py
+++ b/qa/rpc-tests/rpcbind_test.py
@@ -5,147 +5,107 @@
 
 # Test for -rpcbind, as well as -rpcallowip and -rpcconnect
 
-# Add python-bitcoinrpc to module search path:
-import os
 import sys
 
-import json
-import shutil
-import subprocess
-import tempfile
-import traceback
-
+from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 from test_framework.netutil import *
 
-def run_bind_test(tmpdir, allow_ips, connect_to, addresses, expected):
-    '''
-    Start a node with requested rpcallowip and rpcbind parameters,
-    then try to connect, and check if the set of bound addresses
-    matches the expected set.
-    '''
-    expected = [(addr_to_hex(addr), port) for (addr, port) in expected]
-    base_args = ['-disablewallet', '-nolisten']
-    if allow_ips:
-        base_args += ['-rpcallowip=' + x for x in allow_ips]
-    binds = ['-rpcbind='+addr for addr in addresses]
-    nodes = start_nodes(self.num_nodes, tmpdir, [base_args + binds], connect_to)
-    try:
-        pid = bitcoind_processes[0].pid
-        assert_equal(set(get_bind_addrs(pid)), set(expected))
-    finally:
-        stop_nodes(nodes)
-        wait_bitcoinds()
+class RPCBindTest(BitcoinTestFramework):
 
-def run_allowip_test(tmpdir, allow_ips, rpchost, rpcport):
-    '''
-    Start a node with rpcwallow IP, and request getinfo
-    at a non-localhost IP.
-    '''
-    base_args = ['-disablewallet', '-nolisten'] + ['-rpcallowip='+x for x in allow_ips]
-    nodes = start_nodes(self.num_nodes, tmpdir, [base_args])
-    try:
-        # connect to node through non-loopback interface
-        node = get_rpc_proxy(rpc_url(0, "%s:%d" % (rpchost, rpcport)), 0)
-        node.getinfo()
-    finally:
-        node = None # make sure connection will be garbage collected and closed
-        stop_nodes(nodes)
-        wait_bitcoinds()
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
 
-
-def run_test(tmpdir):
-    assert(sys.platform.startswith('linux')) # due to OS-specific network stats queries, this test works only on Linux
-    # find the first non-loopback interface for testing
-    non_loopback_ip = None
-    for name,ip in all_interfaces():
-        if ip != '127.0.0.1':
-            non_loopback_ip = ip
-            break
-    if non_loopback_ip is None:
-        assert(not 'This test requires at least one non-loopback IPv4 interface')
-    print("Using interface %s for testing" % non_loopback_ip)
-
-    defaultport = rpc_port(0)
-
-    # check default without rpcallowip (IPv4 and IPv6 localhost)
-    run_bind_test(tmpdir, None, '127.0.0.1', [],
-        [('127.0.0.1', defaultport), ('::1', defaultport)])
-    # check default with rpcallowip (IPv6 any)
-    run_bind_test(tmpdir, ['127.0.0.1'], '127.0.0.1', [],
-        [('::0', defaultport)])
-    # check only IPv4 localhost (explicit)
-    run_bind_test(tmpdir, ['127.0.0.1'], '127.0.0.1', ['127.0.0.1'],
-        [('127.0.0.1', defaultport)])
-    # check only IPv4 localhost (explicit) with alternative port
-    run_bind_test(tmpdir, ['127.0.0.1'], '127.0.0.1:32171', ['127.0.0.1:32171'],
-        [('127.0.0.1', 32171)])
-    # check only IPv4 localhost (explicit) with multiple alternative ports on same host
-    run_bind_test(tmpdir, ['127.0.0.1'], '127.0.0.1:32171', ['127.0.0.1:32171', '127.0.0.1:32172'],
-        [('127.0.0.1', 32171), ('127.0.0.1', 32172)])
-    # check only IPv6 localhost (explicit)
-    run_bind_test(tmpdir, ['[::1]'], '[::1]', ['[::1]'],
-        [('::1', defaultport)])
-    # check both IPv4 and IPv6 localhost (explicit)
-    run_bind_test(tmpdir, ['127.0.0.1'], '127.0.0.1', ['127.0.0.1', '[::1]'],
-        [('127.0.0.1', defaultport), ('::1', defaultport)])
-    # check only non-loopback interface
-    run_bind_test(tmpdir, [non_loopback_ip], non_loopback_ip, [non_loopback_ip],
-        [(non_loopback_ip, defaultport)])
-
-    # Check that with invalid rpcallowip, we are denied
-    run_allowip_test(tmpdir, [non_loopback_ip], non_loopback_ip, defaultport)
-    try:
-        run_allowip_test(tmpdir, ['1.1.1.1'], non_loopback_ip, defaultport)
-        assert(not 'Connection not denied by rpcallowip as expected')
-    except ValueError:
+    def setup_network(self):
         pass
 
-def main():
-    import optparse
+    def setup_nodes(self):
+        pass
 
-    parser = optparse.OptionParser(usage="%prog [options]")
-    parser.add_option("--nocleanup", dest="nocleanup", default=False, action="store_true",
-                      help="Leave bitcoinds and test.* datadir on exit or error")
-    parser.add_option("--srcdir", dest="srcdir", default="../../src",
-                      help="Source directory containing bitcoind/bitcoin-cli (default: %default%)")
-    parser.add_option("--tmpdir", dest="tmpdir", default=tempfile.mkdtemp(prefix="test"),
-                      help="Root directory for datadirs")
-    (options, args) = parser.parse_args()
+    def run_bind_test(self, allow_ips, connect_to, addresses, expected):
+        '''
+        Start a node with requested rpcallowip and rpcbind parameters,
+        then try to connect, and check if the set of bound addresses
+        matches the expected set.
+        '''
+        expected = [(addr_to_hex(addr), port) for (addr, port) in expected]
+        base_args = ['-disablewallet', '-nolisten']
+        if allow_ips:
+            base_args += ['-rpcallowip=' + x for x in allow_ips]
+        binds = ['-rpcbind='+addr for addr in addresses]
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [base_args + binds], connect_to)
+        try:
+            pid = bitcoind_processes[0].pid
+            assert_equal(set(get_bind_addrs(pid)), set(expected))
+        finally:
+            stop_nodes(self.nodes)
+            wait_bitcoinds()
 
-    os.environ['PATH'] = options.srcdir+":"+os.environ['PATH']
+    def run_allowip_test(self, allow_ips, rpchost, rpcport):
+        '''
+        Start a node with rpcwallow IP, and request getinfo
+        at a non-localhost IP.
+        '''
+        base_args = ['-disablewallet', '-nolisten'] + ['-rpcallowip='+x for x in allow_ips]
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [base_args])
+        try:
+            # connect to node through non-loopback interface
+            node = get_rpc_proxy(rpc_url(0, "%s:%d" % (rpchost, rpcport)), 0)
+            node.getinfo()
+        finally:
+            node = None # make sure connection will be garbage collected and closed
+            stop_nodes(self.nodes)
+            wait_bitcoinds()
 
-    check_json_precision()
+    def run_test(self):
+        # due to OS-specific network stats queries, this test works only on Linux
+        assert(sys.platform.startswith('linux'))
+        # find the first non-loopback interface for testing
+        non_loopback_ip = None
+        for name,ip in all_interfaces():
+            if ip != '127.0.0.1':
+                non_loopback_ip = ip
+                break
+        if non_loopback_ip is None:
+            assert(not 'This test requires at least one non-loopback IPv4 interface')
+        print("Using interface %s for testing" % non_loopback_ip)
 
-    success = False
-    nodes = []
-    try:
-        print("Initializing test directory "+options.tmpdir)
-        if not os.path.isdir(options.tmpdir):
-            os.makedirs(options.tmpdir)
-        initialize_chain(options.tmpdir)
+        defaultport = rpc_port(0)
 
-        run_test(options.tmpdir)
+        # check default without rpcallowip (IPv4 and IPv6 localhost)
+        self.run_bind_test(None, '127.0.0.1', [],
+            [('127.0.0.1', defaultport), ('::1', defaultport)])
+        # check default with rpcallowip (IPv6 any)
+        self.run_bind_test(['127.0.0.1'], '127.0.0.1', [],
+            [('::0', defaultport)])
+        # check only IPv4 localhost (explicit)
+        self.run_bind_test(['127.0.0.1'], '127.0.0.1', ['127.0.0.1'],
+            [('127.0.0.1', defaultport)])
+        # check only IPv4 localhost (explicit) with alternative port
+        self.run_bind_test(['127.0.0.1'], '127.0.0.1:32171', ['127.0.0.1:32171'],
+            [('127.0.0.1', 32171)])
+        # check only IPv4 localhost (explicit) with multiple alternative ports on same host
+        self.run_bind_test(['127.0.0.1'], '127.0.0.1:32171', ['127.0.0.1:32171', '127.0.0.1:32172'],
+            [('127.0.0.1', 32171), ('127.0.0.1', 32172)])
+        # check only IPv6 localhost (explicit)
+        self.run_bind_test(['[::1]'], '[::1]', ['[::1]'],
+            [('::1', defaultport)])
+        # check both IPv4 and IPv6 localhost (explicit)
+        self.run_bind_test(['127.0.0.1'], '127.0.0.1', ['127.0.0.1', '[::1]'],
+            [('127.0.0.1', defaultport), ('::1', defaultport)])
+        # check only non-loopback interface
+        self.run_bind_test([non_loopback_ip], non_loopback_ip, [non_loopback_ip],
+            [(non_loopback_ip, defaultport)])
 
-        success = True
-
-    except AssertionError as e:
-        print("Assertion failed: "+e.message)
-    except Exception as e:
-        print("Unexpected exception caught during testing: "+str(e))
-        traceback.print_tb(sys.exc_info()[2])
-
-    if not options.nocleanup:
-        print("Cleaning up")
-        wait_bitcoinds()
-        shutil.rmtree(options.tmpdir)
-
-    if success:
-        print("Tests successful")
-        sys.exit(0)
-    else:
-        print("Failed")
-        sys.exit(1)
+        # Check that with invalid rpcallowip, we are denied
+        self.run_allowip_test([non_loopback_ip], non_loopback_ip, defaultport)
+        try:
+            self.run_allowip_test(['1.1.1.1'], non_loopback_ip, defaultport)
+            assert(not 'Connection not denied by rpcallowip as expected')
+        except JSONRPCException:
+            pass
 
 if __name__ == '__main__':
-    main()
+    RPCBindTest ().main ()

--- a/qa/rpc-tests/rpcbind_test.py
+++ b/qa/rpc-tests/rpcbind_test.py
@@ -29,7 +29,7 @@ def run_bind_test(tmpdir, allow_ips, connect_to, addresses, expected):
     if allow_ips:
         base_args += ['-rpcallowip=' + x for x in allow_ips]
     binds = ['-rpcbind='+addr for addr in addresses]
-    nodes = start_nodes(1, tmpdir, [base_args + binds], connect_to)
+    nodes = start_nodes(self.num_nodes, tmpdir, [base_args + binds], connect_to)
     try:
         pid = bitcoind_processes[0].pid
         assert_equal(set(get_bind_addrs(pid)), set(expected))
@@ -43,7 +43,7 @@ def run_allowip_test(tmpdir, allow_ips, rpchost, rpcport):
     at a non-localhost IP.
     '''
     base_args = ['-disablewallet', '-nolisten'] + ['-rpcallowip='+x for x in allow_ips]
-    nodes = start_nodes(1, tmpdir, [base_args])
+    nodes = start_nodes(self.num_nodes, tmpdir, [base_args])
     try:
         # connect to node through non-loopback interface
         node = get_rpc_proxy(rpc_url(0, "%s:%d" % (rpchost, rpcport)), 0)

--- a/qa/rpc-tests/sendheaders.py
+++ b/qa/rpc-tests/sendheaders.py
@@ -255,12 +255,14 @@ class TestNode(BaseNode):
         BaseNode.__init__(self)
 
 class SendHeadersTest(BitcoinTestFramework):
-    def setup_chain(self):
-        initialize_chain_clean(self.options.tmpdir, 2)
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 2
 
     def setup_network(self):
         self.nodes = []
-        self.nodes = start_nodes(2, self.options.tmpdir, [["-debug", "-logtimemicros=1"]]*2)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [["-debug", "-logtimemicros=1"]]*2)
         connect_nodes(self.nodes[0], 1)
 
     # mine count blocks and return the new tip

--- a/qa/rpc-tests/signrawtransactions.py
+++ b/qa/rpc-tests/signrawtransactions.py
@@ -10,12 +10,13 @@ from test_framework.util import *
 class SignRawTransactionsTest(BitcoinTestFramework):
     """Tests transaction signing via RPC command "signrawtransaction"."""
 
-    def setup_chain(self):
-        print('Initializing test directory ' + self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 1)
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(1, self.options.tmpdir)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
         self.is_network_split = False
 
     def successful_signing_test(self):

--- a/qa/rpc-tests/smartfees.py
+++ b/qa/rpc-tests/smartfees.py
@@ -138,6 +138,11 @@ def check_estimates(node, fees_seen, max_invalid, print_estimates = True):
 
 class EstimateFeeTest(BitcoinTestFramework):
 
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 3
+        self.setup_clean_chain = False
+
     def setup_network(self):
         '''
         We'll setup the network to have 3 nodes that all mine with different parameters.

--- a/qa/rpc-tests/test_framework/authproxy.py
+++ b/qa/rpc-tests/test_framework/authproxy.py
@@ -160,6 +160,11 @@ class AuthServiceProxy(object):
             raise JSONRPCException({
                 'code': -342, 'message': 'missing HTTP response from server'})
 
+        content_type = http_response.getheader('Content-Type')
+        if content_type != 'application/json':
+            raise JSONRPCException({
+                'code': -342, 'message': 'non-JSON HTTP response with \'%i %s\' from server' % (http_response.status, http_response.reason)})
+
         responsedata = http_response.read().decode('utf8')
         response = json.loads(responsedata, parse_float=decimal.Decimal)
         if "error" in response and response["error"] is None:

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -124,7 +124,7 @@ class BitcoinTestFramework(object):
 
         if self.options.trace_rpc:
             import logging
-            logging.basicConfig(level=logging.DEBUG)
+            logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
 
         if self.options.coveragedir:
             enable_coverage(self.options.coveragedir)
@@ -154,6 +154,8 @@ class BitcoinTestFramework(object):
         except Exception as e:
             print("Unexpected exception caught during testing: "+str(e))
             traceback.print_tb(sys.exc_info()[2])
+        except KeyboardInterrupt as e:
+            print("Exiting after " + repr(e))
 
         if not self.options.noshutdown:
             print("Stopping nodes")

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -5,10 +5,10 @@
 
 # Base class for RPC testing
 
-# Add python-bitcoinrpc to module search path:
+import logging
+import optparse
 import os
 import sys
-
 import shutil
 import tempfile
 import traceback
@@ -24,8 +24,9 @@ from .util import (
     enable_coverage,
     check_json_precision,
     initialize_chain_clean,
+    PortSeed,
 )
-from .authproxy import AuthServiceProxy, JSONRPCException
+from .authproxy import JSONRPCException
 
 
 class BitcoinTestFramework(object):
@@ -101,7 +102,6 @@ class BitcoinTestFramework(object):
         self.setup_network(False)
 
     def main(self):
-        import optparse
 
         parser = optparse.OptionParser(usage="%prog [options]")
         parser.add_option("--nocleanup", dest="nocleanup", default=False, action="store_true",
@@ -114,17 +114,20 @@ class BitcoinTestFramework(object):
                           help="Root directory for datadirs")
         parser.add_option("--tracerpc", dest="trace_rpc", default=False, action="store_true",
                           help="Print out all RPC calls as they are made")
+        parser.add_option("--portseed", dest="port_seed", default=os.getpid(), type='int',
+                          help="The seed to use for assigning port numbers (default: current process id)")
         parser.add_option("--coveragedir", dest="coveragedir",
                           help="Write tested RPC commands into this directory")
         self.add_options(parser)
         (self.options, self.args) = parser.parse_args()
 
         if self.options.trace_rpc:
-            import logging
             logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
 
         if self.options.coveragedir:
             enable_coverage(self.options.coveragedir)
+
+        PortSeed.n = self.options.port_seed
 
         os.environ['PATH'] = self.options.srcdir+":"+os.environ['PATH']
 

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -15,7 +15,6 @@ import traceback
 
 from .util import (
     initialize_chain,
-    assert_equal,
     start_nodes,
     connect_nodes_bi,
     sync_blocks,
@@ -32,14 +31,12 @@ from .authproxy import AuthServiceProxy, JSONRPCException
 class BitcoinTestFramework(object):
 
     def __init__(self):
-        self.setup_clean_chain = False
         self.num_nodes = 4
+        self.setup_clean_chain = False
+        self.nodes = None
 
-    # These may be over-ridden by subclasses:
     def run_test(self):
-        for node in self.nodes:
-            assert_equal(node.getblockcount(), 200)
-            assert_equal(node.getbalance(), 25*50)
+        raise NotImplementedError
 
     def add_options(self, parser):
         pass
@@ -51,10 +48,10 @@ class BitcoinTestFramework(object):
         if self.setup_clean_chain:
             initialize_chain_clean(self.options.tmpdir, self.num_nodes)
         else:
-            initialize_chain(self.options.tmpdir)
+            initialize_chain(self.options.tmpdir, self.num_nodes)
 
     def setup_nodes(self):
-        return start_nodes(4, self.options.tmpdir)
+        return start_nodes(self.num_nodes, self.options.tmpdir)
 
     def setup_network(self, split = False):
         self.nodes = self.setup_nodes()
@@ -184,9 +181,8 @@ class BitcoinTestFramework(object):
 
 class ComparisonTestFramework(BitcoinTestFramework):
 
-    # Can override the num_nodes variable to indicate how many nodes to run.
     def __init__(self):
-        super(ComparisonTestFramework, self).__init__()
+        super().__init__()
         self.num_nodes = 2
         self.setup_clean_chain = True
 
@@ -197,10 +193,6 @@ class ComparisonTestFramework(BitcoinTestFramework):
         parser.add_option("--refbinary", dest="refbinary",
                           default=os.getenv("BITCOIND", "bitcoind"),
                           help="bitcoind binary to use for reference nodes (if any)")
-
-    def setup_chain(self):
-        print("Initializing test directory "+self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, self.num_nodes)
 
     def setup_network(self):
         self.nodes = start_nodes(

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -8,7 +8,6 @@
 # Helpful routines for regression testing
 #
 
-# Add python-bitcoinrpc to module search path:
 import os
 import sys
 
@@ -35,6 +34,11 @@ MAX_NODES = 8
 PORT_MIN = 11000
 # The number of ports to "reserve" for p2p and rpc, each
 PORT_RANGE = 5000
+
+
+class PortSeed:
+    # Must be initialized with a unique integer for each process
+    n = None
 
 #Set Mocktime default to OFF.
 #MOCKTIME is only needed for scripts that use the
@@ -91,10 +95,10 @@ def get_rpc_proxy(url, node_number, timeout=None):
 
 def p2p_port(n):
     assert(n <= MAX_NODES)
-    return PORT_MIN + n + (MAX_NODES * os.getpid()) % (PORT_RANGE - 1 - MAX_NODES)
+    return PORT_MIN + n + (MAX_NODES * PortSeed.n) % (PORT_RANGE - 1 - MAX_NODES)
 
 def rpc_port(n):
-    return PORT_MIN + PORT_RANGE + n + (MAX_NODES * os.getpid()) % (PORT_RANGE -1 - MAX_NODES)
+    return PORT_MIN + PORT_RANGE + n + (MAX_NODES * PortSeed.n) % (PORT_RANGE - 1 - MAX_NODES)
 
 def check_json_precision():
     """Make sure json library being used does not lose precision converting BTC values"""

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -28,6 +28,13 @@ from .authproxy import AuthServiceProxy, JSONRPCException
 
 COVERAGE_DIR = None
 
+# The maximum number of nodes a single test can spawn
+MAX_NODES = 8
+# Don't assign rpc or p2p ports lower than this
+PORT_MIN = 11000
+# The number of ports to "reserve" for p2p and rpc, each
+PORT_RANGE = 5000
+
 #Set Mocktime default to OFF.
 #MOCKTIME is only needed for scripts that use the
 #cached version of the blockchain.  If the cached
@@ -82,9 +89,11 @@ def get_rpc_proxy(url, node_number, timeout=None):
 
 
 def p2p_port(n):
-    return 11000 + n + os.getpid()%999
+    assert(n <= MAX_NODES)
+    return PORT_MIN + n + (MAX_NODES * os.getpid()) % (PORT_RANGE - 1 - MAX_NODES)
+
 def rpc_port(n):
-    return 12000 + n + os.getpid()%999
+    return PORT_MIN + PORT_RANGE + n + (MAX_NODES * os.getpid()) % (PORT_RANGE -1 - MAX_NODES)
 
 def check_json_precision():
     """Make sure json library being used does not lose precision converting BTC values"""
@@ -308,8 +317,8 @@ def start_nodes(num_nodes, dirname, extra_args=None, rpchost=None, binary=None):
     """
     Start multiple bitcoinds, return RPC connections to them
     """
-    if extra_args is None: extra_args = [ None for i in range(num_nodes) ]
-    if binary is None: binary = [ None for i in range(num_nodes) ]
+    if extra_args is None: extra_args = [ None for _ in range(num_nodes) ]
+    if binary is None: binary = [ None for _ in range(num_nodes) ]
     rpcs = []
     try:
         for i in range(num_nodes):

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -16,6 +16,7 @@ from binascii import hexlify, unhexlify
 from base64 import b64encode
 from decimal import Decimal, ROUND_DOWN
 import json
+import http.client
 import random
 import shutil
 import subprocess
@@ -332,13 +333,19 @@ def log_filename(dirname, n_node, logname):
     return os.path.join(dirname, "node"+str(n_node), "regtest", logname)
 
 def stop_node(node, i):
-    node.stop()
+    try:
+        node.stop()
+    except http.client.CannotSendRequest as e:
+        print("WARN: Unable to stop node: " + repr(e))
     bitcoind_processes[i].wait()
     del bitcoind_processes[i]
 
 def stop_nodes(nodes):
     for node in nodes:
-        node.stop()
+        try:
+            node.stop()
+        except http.client.CannotSendRequest as e:
+            print("WARN: Unable to stop node: " + repr(e))
     del nodes[:] # Emptying array closes connections as a side effect
 
 def set_node_times(nodes, t):

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -194,24 +194,28 @@ def wait_for_bitcoind_start(process, url, i):
                 raise # unkown JSON RPC exception
         time.sleep(0.25)
 
-def initialize_chain(test_dir):
+def initialize_chain(test_dir, num_nodes):
     """
-    Create (or copy from cache) a 200-block-long chain and
-    4 wallets.
+    Create a cache of a 200-block-long chain (with wallet) for MAX_NODES
+    Afterward, create num_nodes copies from the cache
     """
 
-    if (not os.path.isdir(os.path.join("cache","node0"))
-        or not os.path.isdir(os.path.join("cache","node1"))
-        or not os.path.isdir(os.path.join("cache","node2"))
-        or not os.path.isdir(os.path.join("cache","node3"))):
+    assert num_nodes <= MAX_NODES
+    create_cache = False
+    for i in range(MAX_NODES):
+        if not os.path.isdir(os.path.join('cache', 'node'+str(i))):
+            create_cache = True
+            break
+
+    if create_cache:
 
         #find and delete old cache directories if any exist
-        for i in range(4):
+        for i in range(MAX_NODES):
             if os.path.isdir(os.path.join("cache","node"+str(i))):
                 shutil.rmtree(os.path.join("cache","node"+str(i)))
 
         # Create cache directories, run bitcoinds:
-        for i in range(4):
+        for i in range(MAX_NODES):
             datadir=initialize_datadir("cache", i)
             args = [ os.getenv("BITCOIND", "bitcoind"), "-keypool=1", "-datadir="+datadir, "-discover=0" ]
             if i > 0:
@@ -224,15 +228,18 @@ def initialize_chain(test_dir):
                 print("initialize_chain: RPC succesfully started")
 
         rpcs = []
-        for i in range(4):
+        for i in range(MAX_NODES):
             try:
                 rpcs.append(get_rpc_proxy(rpc_url(i), i))
             except:
                 sys.stderr.write("Error connecting to "+url+"\n")
                 sys.exit(1)
 
-        # Create a 200-block-long chain; each of the 4 nodes
+        # Create a 200-block-long chain; each of the 4 first nodes
         # gets 25 mature blocks and 25 immature.
+        # Note: To preserve compatibility with older versions of
+        # initialize_chain, only 4 nodes will generate coins.
+        #
         # blocks are created with timestamps 10 minutes apart
         # starting from 2010 minutes in the past
         enable_mocktime()
@@ -250,13 +257,13 @@ def initialize_chain(test_dir):
         stop_nodes(rpcs)
         wait_bitcoinds()
         disable_mocktime()
-        for i in range(4):
+        for i in range(MAX_NODES):
             os.remove(log_filename("cache", i, "debug.log"))
             os.remove(log_filename("cache", i, "db.log"))
             os.remove(log_filename("cache", i, "peers.dat"))
             os.remove(log_filename("cache", i, "fee_estimates.dat"))
 
-    for i in range(4):
+    for i in range(num_nodes):
         from_dir = os.path.join("cache", "node"+str(i))
         to_dir = os.path.join(test_dir,  "node"+str(i))
         shutil.copytree(from_dir, to_dir)

--- a/qa/rpc-tests/txn_clone.py
+++ b/qa/rpc-tests/txn_clone.py
@@ -15,6 +15,11 @@ import shutil
 
 class TxnMallTest(BitcoinTestFramework):
 
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 4
+        self.setup_clean_chain = False
+
     def add_options(self, parser):
         parser.add_option("--mineblock", dest="mine_block", default=False, action="store_true",
                           help="Test double-spend of 1-confirmed transaction")

--- a/qa/rpc-tests/txn_doublespend.py
+++ b/qa/rpc-tests/txn_doublespend.py
@@ -15,6 +15,11 @@ import shutil
 
 class TxnMallTest(BitcoinTestFramework):
 
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 4
+        self.setup_clean_chain = False
+
     def add_options(self, parser):
         parser.add_option("--mineblock", dest="mine_block", default=False, action="store_true",
                           help="Test double-spend of 1-confirmed transaction")

--- a/qa/rpc-tests/txn_doublespendrelay.py
+++ b/qa/rpc-tests/txn_doublespendrelay.py
@@ -25,6 +25,11 @@ def wait_for(criteria):
 
 class DoubleSpendRelay(BitcoinTestFramework):
 
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 4
+        self.setup_clean_chain = False
+
     #
     # Create a 4-node network; roles for the nodes are:
     # [0] : transaction creator

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -35,9 +35,10 @@ class WalletTest (BitcoinTestFramework):
             raise AssertionError("Fee of %s BTC too high! (Should be %s BTC)"%(str(fee), str(target_fee)))
         return curr_balance
 
-    def setup_chain(self):
-        print("Initializing test directory "+self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 4)
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 4
 
     def setup_network(self, split=False):
         self.nodes = start_nodes(3, self.options.tmpdir, [["-relaypriority=0"],]*3)

--- a/qa/rpc-tests/walletbackup.py
+++ b/qa/rpc-tests/walletbackup.py
@@ -37,7 +37,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 from random import randint
 import logging
-logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
+logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO, stream=sys.stdout)
 
 class WalletBackupTest(BitcoinTestFramework):
 

--- a/qa/rpc-tests/walletbackup.py
+++ b/qa/rpc-tests/walletbackup.py
@@ -41,9 +41,10 @@ logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO, str
 
 class WalletBackupTest(BitcoinTestFramework):
 
-    def setup_chain(self):
-        logging.info("Initializing test directory "+self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 4)
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 4
 
     # This mirrors how the network was setup in the bash test
     def setup_network(self, split=False):

--- a/qa/rpc-tests/zapwallettxes.py
+++ b/qa/rpc-tests/zapwallettxes.py
@@ -9,12 +9,13 @@ from test_framework.util import *
 
 class ZapWalletTXesTest (BitcoinTestFramework):
 
-    def setup_chain(self):
-        print("Initializing test directory "+self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 3)
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 3
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(3, self.options.tmpdir)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)


### PR DESCRIPTION
Builds on top of #258 

Great improvements for the qa test framework. Includes:

https://github.com/bitcoin/bitcoin/pull/7851/ - [qa] pull-tester: Don't mute zmq ImportError
https://github.com/bitcoin/bitcoin/pull/7971/ - [qa] Refactor test_framework and pull tester
https://github.com/bitcoin/bitcoin/pull/8056/ - [qa] Remove hardcoded "4 nodes" from test_framework
https://github.com/bitcoin/bitcoin/pull/7972 - [qa] pull-tester: Run rpc test in parallel
https://github.com/bitcoin/bitcoin/pull/8713 - [qa] create_cache: Delete temp dir when done
