### PR TITLE
[Test] Update bip100-sizelimit.py for uahf

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -120,8 +120,7 @@ testScripts = [
 ]
 
 testScriptsExt = [
-# Needs update for BCC.
-#    'bip100-sizelimit.py',
+    'bip100-sizelimit.py',
     'bip9-softforks.py',
     'bip65-cltv-p2p.py',
     'bip65-cltv.py',

--- a/qa/rpc-tests/bip100-sizelimit.py
+++ b/qa/rpc-tests/bip100-sizelimit.py
@@ -8,12 +8,19 @@
 #
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
+from test_framework.mininode import MAX_BLOCK_SIZE
 
 from decimal import Decimal
-
 CACHE_DIR = "cache_bigblock"
 
 class BigBlockTest(BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 4
+        self.setup_clean_chain = None
+        # Use predictable timestamps on subsequent runs from cache
+        enable_mocktime()
 
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)
@@ -24,16 +31,16 @@ class BigBlockTest(BitcoinTestFramework):
             for i in range(4):
                 initialize_datadir(CACHE_DIR, i) # Overwrite port/rpcport in bitcoin.conf
 
-            # Node 0 creates 8MB blocks that vote for increase to 8MB
-            # Node 1 creates empty blocks that vote for 8MB
-            # Node 2 creates empty blocks that vote for 2MB
-            # Node 3 creates empty blocks that do not vote for increase
+            # Node 0 creates 10MB blocks that vote for increase to 10MB
+            # Node 1 creates empty blocks that vote for 10MB
+            # Node 2 creates empty blocks that do not vote for increase
+            # Node 3 creates empty blocks that vote for 9MB
             self.nodes = []
             # Use node0 to mine blocks for input splitting
-            self.nodes.append(start_node(0, CACHE_DIR, ["-blockmaxsize=8000000", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"]))
-            self.nodes.append(start_node(1, CACHE_DIR, ["-blockmaxsize=1000", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"]))
-            self.nodes.append(start_node(2, CACHE_DIR, ["-blockmaxsize=1000", "-maxblocksizevote=1", "-limitancestorsize=2000", "-limitdescendantsize=2000"]))
-            self.nodes.append(start_node(3, CACHE_DIR, ["-blockmaxsize=1000", "-maxblocksizevote=2", "-limitancestorsize=2000", "-limitdescendantsize=2000"]))
+            self.nodes.append(start_node(0, CACHE_DIR, ["-blockmaxsize=10000000", "-maxblocksizevote=10", "-limitancestorsize=2000", "-limitdescendantsize=2000"]))
+            self.nodes.append(start_node(1, CACHE_DIR, ["-blockmaxsize=1000", "-maxblocksizevote=10", "-limitancestorsize=2000", "-limitdescendantsize=2000"]))
+            self.nodes.append(start_node(2, CACHE_DIR, ["-blockmaxsize=1000", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"]))
+            self.nodes.append(start_node(3, CACHE_DIR, ["-blockmaxsize=99999", "-maxblocksizevote=9", "-limitancestorsize=2000", "-limitdescendantsize=2000"]))
 
             connect_nodes_bi(self.nodes, 0, 1)
             connect_nodes_bi(self.nodes, 1, 2)
@@ -44,42 +51,24 @@ class BigBlockTest(BitcoinTestFramework):
 
             # Create a 2012-block chain in a 75% ratio for increase (genesis block votes for 1MB)
             # Make sure they are not already sorted correctly
-            blocks = []
-            blocks.append(self.nodes[1].generate(503))
+            self.nodes[1].generate(503)
             assert(self.sync_blocks(self.nodes[1:3]))
-            blocks.append(self.nodes[2].generate(502)) # <--- genesis is 503rd vote for 1MB
+            self.nodes[2].generate(502) # <--- genesis is 503rd vote for no increase
             assert(self.sync_blocks(self.nodes[2:4]))
-            blocks.append(self.nodes[3].generate(503))
+
+            relayfee = self.nodes[3].getnetworkinfo()['relayfee']
+            utxos = create_confirmed_utxos(relayfee, self.nodes[3], 128)
+
+            # 166 node 3 blocks were already mined to create utxos
+            self.nodes[3].generate(503 - 166)
             assert(self.sync_blocks(self.nodes[1:4]))
-            blocks.append(self.nodes[1].generate(503))
+            self.nodes[1].generate(503)
             assert(self.sync_blocks(self.nodes))
 
-            tx_file = open(os.path.join(CACHE_DIR, "txdata"), "w")
-
-            # Create a lot of tansaction data ready to be mined
-            fee = Decimal('.00005')
-            used = set()
             print("Creating transaction data")
-            for i in range(0,25):
-                inputs = []
-                outputs = {}
-                limit = 0
-                utxos = self.nodes[3].listunspent(0)
-                for utxo in utxos:
-                    if not utxo["txid"]+str(utxo["vout"]) in used:
-                        raw_input = {}
-                        raw_input["txid"] = utxo["txid"]
-                        raw_input["vout"] = utxo["vout"]
-                        inputs.append(raw_input)
-                        outputs[self.nodes[3].getnewaddress()] = utxo["amount"] - fee
-                        used.add(utxo["txid"]+str(utxo["vout"]))
-                        limit = limit + 1
-                        if (limit >= 250):
-                            break
-                rawtx = self.nodes[3].createrawtransaction(inputs, outputs)
-                txdata = self.nodes[3].signrawtransaction(rawtx)["hex"]
-                self.nodes[3].sendrawtransaction(txdata)
-                tx_file.write(txdata+"\n")
+            txouts = gen_return_txouts()
+            tx_file = open(os.path.join(CACHE_DIR, "txdata"), "w")
+            create_lots_of_big_transactions(self.nodes[3], txouts, utxos, 128, relayfee * 1000, tx_file)
             tx_file.close()
 
             stop_nodes(self.nodes)
@@ -110,9 +99,9 @@ class BigBlockTest(BitcoinTestFramework):
     def setup_network(self):
         self.nodes = []
 
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-blockmaxsize=8000000", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"], timewait=60))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-blockmaxsize=1000", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"], timewait=60))
-        self.nodes.append(start_node(2, self.options.tmpdir, ["-blockmaxsize=1000", "-maxblocksizevote=1", "-limitancestorsize=2000", "-limitdescendantsize=2000"], timewait=60))
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-blockmaxsize=10000000", "-maxblocksizevote=10", "-limitancestorsize=2000", "-limitdescendantsize=2000"], timewait=60))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-blockmaxsize=1000", "-maxblocksizevote=10", "-limitancestorsize=2000", "-limitdescendantsize=2000"], timewait=60))
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-blockmaxsize=1000", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"], timewait=60))
         # (We don't restart the node with the huge wallet
         connect_nodes_bi(self.nodes, 0, 1)
         connect_nodes_bi(self.nodes, 1, 2)
@@ -126,13 +115,13 @@ class BigBlockTest(BitcoinTestFramework):
                 node.sendrawtransaction(line.rstrip())
 
     def TestMineBig(self, expect_big):
-        # Test if node0 will mine a block bigger than legacy MAX_BLOCK_SIZE
+        # Test if node0 will mine a block bigger than MAX_BLOCK_SIZE
         b1hash = self.nodes[0].generate(1)[0]
         b1 = self.nodes[0].getblock(b1hash, True)
         assert(self.sync_blocks(self.nodes[0:3]))
 
         if expect_big:
-            assert(b1['size'] > 1000*1000)
+            assert(b1['size'] > MAX_BLOCK_SIZE)
 
             # Have node1 mine on top of the block,
             # to make sure it goes along with the fork
@@ -142,7 +131,7 @@ class BigBlockTest(BitcoinTestFramework):
             assert(self.sync_blocks(self.nodes[0:3]))
 
         else:
-            assert(b1['size'] < 1000*1000)
+            assert(b1['size'] <= MAX_BLOCK_SIZE)
 
         # Reset chain to before b1hash:
         for node in self.nodes[0:3]:
@@ -155,48 +144,48 @@ class BigBlockTest(BitcoinTestFramework):
 
         assert_equal(self.nodes[0].getblockcount(), 2011) # This is a 0-based height
 
-        # Current nMaxBlockSize is still 1MB
-        assert_equal(self.nodes[0].getblocktemplate()["sizelimit"], 1000000)
+        # Current nMaxBlockSize is still 8MB
+        assert_equal(self.nodes[0].getblocktemplate()["sizelimit"], MAX_BLOCK_SIZE)
         self.TestMineBig(False)
 
-        # Create a situation where the 1512th-highest vote is for 2MB
+        # Create a situation where the 1512th-highest vote is for 9MB
         self.nodes[2].generate(1)
         assert(self.sync_blocks(self.nodes[1:3]))
         ahash = self.nodes[1].generate(3)[2]
-        assert_equal(self.nodes[1].getblocktemplate()["sizelimit"], int(1000000 * 1.05))
+        assert_equal(self.nodes[1].getblocktemplate()["sizelimit"], int(MAX_BLOCK_SIZE * 1.05))
         assert(self.sync_blocks(self.nodes[0:2]))
         self.TestMineBig(True)
 
         # Shutdown then restart node[0], it should produce a big block.
         stop_node(self.nodes[0], 0)
-        self.nodes[0] = start_node(0, self.options.tmpdir, ["-blockmaxsize=8000000", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"], timewait=60)
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-blockmaxsize=10000000", "-maxblocksizevote=10", "-limitancestorsize=2000", "-limitdescendantsize=2000"], timewait=60)
         self.load_mempool(self.nodes[0])
         connect_nodes_bi(self.nodes, 0, 1)
         connect_nodes_bi(self.nodes, 0, 2)
-        assert_equal(self.nodes[0].getblocktemplate()["sizelimit"], int(1000000 * 1.05))
+        assert_equal(self.nodes[0].getblocktemplate()["sizelimit"], int(MAX_BLOCK_SIZE * 1.05))
         self.TestMineBig(True)
 
         # Test re-orgs past the sizechange block
         stop_node(self.nodes[0], 0)
         self.nodes[2].invalidateblock(ahash)
-        assert_equal(self.nodes[2].getblocktemplate()["sizelimit"], 1000000)
+        assert_equal(self.nodes[2].getblocktemplate()["sizelimit"], MAX_BLOCK_SIZE)
         self.nodes[2].generate(2)
-        assert_equal(self.nodes[2].getblocktemplate()["sizelimit"], 1000000)
+        assert_equal(self.nodes[2].getblocktemplate()["sizelimit"], MAX_BLOCK_SIZE)
         assert(self.sync_blocks(self.nodes[1:3]))
 
         # Restart node0, it should re-org onto longer chain,
         # and refuse to mine a big block:
-        self.nodes[0] = start_node(0, self.options.tmpdir, ["-blockmaxsize=8000000", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"], timewait=60)
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-blockmaxsize=10000000", "-maxblocksizevote=10", "-limitancestorsize=2000", "-limitdescendantsize=2000"], timewait=60)
         self.load_mempool(self.nodes[0])
         connect_nodes_bi(self.nodes, 0, 1)
         connect_nodes_bi(self.nodes, 0, 2)
         assert(self.sync_blocks(self.nodes[0:3]))
-        assert_equal(self.nodes[0].getblocktemplate()["sizelimit"], 1000000)
+        assert_equal(self.nodes[0].getblocktemplate()["sizelimit"], MAX_BLOCK_SIZE)
         self.TestMineBig(False)
 
-        # Mine 4 blocks voting for 8MB. Bigger block NOT ok, we are in the next voting period
+        # Mine 4 blocks voting for 10MB. Bigger block NOT ok, we are in the next voting period
         self.nodes[1].generate(4)
-        assert_equal(self.nodes[1].getblocktemplate()["sizelimit"], 1000000)
+        assert_equal(self.nodes[1].getblocktemplate()["sizelimit"], MAX_BLOCK_SIZE)
         assert(self.sync_blocks(self.nodes[0:3]))
         self.TestMineBig(False)
 

--- a/qa/rpc-tests/mempool_limit.py
+++ b/qa/rpc-tests/mempool_limit.py
@@ -10,9 +10,6 @@ from test_framework.util import *
 
 class MempoolLimitTest(BitcoinTestFramework):
 
-    def satoshi_round(self, amount):
-        return  Decimal(amount).quantize(Decimal('0.00000001'), rounding=ROUND_DOWN)
-
     def __init__(self):
         super().__init__()
         self.setup_clean_chain = True
@@ -33,56 +30,6 @@ class MempoolLimitTest(BitcoinTestFramework):
             # add script_pubkey
             self.txouts = self.txouts + script_pubkey
 
-    def create_confirmed_utxos(self, count):
-        self.nodes[0].generate(int(0.5*count)+102)
-        sync_blocks(self.nodes[:2])
-        utxos = self.nodes[0].listunspent()
-        iterations = count - len(utxos)
-        addr1 = self.nodes[0].getnewaddress()
-        addr2 = self.nodes[0].getnewaddress()
-        if iterations <= 0:
-            return utxos
-        for i in range(iterations):
-            t = utxos.pop()
-            fee = self.relayfee
-            inputs = []
-            inputs.append({ "txid" : t["txid"], "vout" : t["vout"]})
-            outputs = {}
-            send_value = t['amount'] - fee
-            outputs[addr1] = self.satoshi_round(send_value/2)
-            outputs[addr2] = self.satoshi_round(send_value/2)
-            raw_tx = self.nodes[0].createrawtransaction(inputs, outputs)
-            signed_tx = self.nodes[0].signrawtransaction(raw_tx, None, None, "NONE|FORKID")["hex"]
-            txid = self.nodes[0].sendrawtransaction(signed_tx)
-
-        while (self.nodes[0].getmempoolinfo()['size'] > 0):
-            self.nodes[0].generate(1)
-
-        sync_blocks(self.nodes[:2])
-
-        utxos = self.nodes[0].listunspent()
-        assert(len(utxos) >= count)
-        return utxos
-
-    def create_lots_of_big_transactions(self, utxos, fee):
-        addr = self.nodes[0].getnewaddress()
-        txids = []
-        for i in range(len(utxos)):
-            t = utxos.pop()
-            inputs = []
-            inputs.append({ "txid" : t["txid"], "vout" : t["vout"]})
-            outputs = {}
-            send_value = t['amount'] - fee
-            outputs[addr] = self.satoshi_round(send_value)
-            rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
-            newtx = rawtx[0:92]
-            newtx = newtx + self.txouts
-            newtx = newtx + rawtx[94:]
-            signresult = self.nodes[0].signrawtransaction(newtx, None, None, "NONE|FORKID")
-            txid = self.nodes[0].sendrawtransaction(signresult["hex"], True)
-            txids.append(txid)
-        return txids
-
     def setup_network(self):
         self.nodes = []
         self.nodes.append(start_node(0, self.options.tmpdir, ["-spendzeroconfchange=0", "-debug"]))
@@ -94,7 +41,7 @@ class MempoolLimitTest(BitcoinTestFramework):
 
     def run_test(self):
         txids = []
-        utxos = self.create_confirmed_utxos(130)
+        utxos = create_confirmed_utxos(self.relayfee, self.nodes[0], 130, 102)
 
         #create a mempool tx that will be evicted by node 1
         us0 = utxos.pop()
@@ -104,6 +51,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         txFS = self.nodes[0].signrawtransaction(tx, None, None, "NONE|FORKID")
         txid0 = self.nodes[0].sendrawtransaction(txFS['hex'])
         self.nodes[0].lockunspent(True, [us0])
+        time.sleep(3)
 
         #create a mempool tx that will NOT be evicted by node 1 (because submitted there)
         us1 = utxos.pop()
@@ -114,13 +62,11 @@ class MempoolLimitTest(BitcoinTestFramework):
         txid1 = self.nodes[1].sendrawtransaction(txFS['hex'])
         self.nodes[0].lockunspent(True, [us1])
 
-        sync_mempools(self.nodes[:2])
-
         #and now for the spam
         base_fee = self.relayfee*1000
         for i in range (4):
             txids.append([])
-            txids[i] = self.create_lots_of_big_transactions(utxos[30*i:30*i+30], (i+1)*base_fee)
+            txids[i] = create_lots_of_big_transactions(self.nodes[0], self.txouts, utxos[30*i:30*i+30], 30, (i+1)*base_fee)
 
         time.sleep(3)
         # txid0 should have been evicted by node 1, but txid1 should have been protected

--- a/qa/rpc-tests/mempool_limit.py
+++ b/qa/rpc-tests/mempool_limit.py
@@ -14,21 +14,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         super().__init__()
         self.setup_clean_chain = True
         self.num_nodes = 2
-        # Some pre-processing to create a bunch of OP_RETURN txouts to insert into transactions we create
-        # So we have big transactions (and therefore can't fit very many into each block)
-        # create one script_pubkey
-        script_pubkey = "6a4d0200" #OP_RETURN OP_PUSH2 512 bytes
-        for i in range (512):
-            script_pubkey = script_pubkey + "01"
-        # concatenate 128 txouts of above script_pubkey which we'll insert before the txout for change
-        self.txouts = "81"
-        for k in range(128):
-            # add txout value
-            self.txouts = self.txouts + "0000000000000000"
-            # add length of script_pubkey
-            self.txouts = self.txouts + "fd0402"
-            # add script_pubkey
-            self.txouts = self.txouts + script_pubkey
+        self.txouts = gen_return_txouts()
 
     def setup_network(self):
         self.nodes = []

--- a/qa/rpc-tests/pruning.py
+++ b/qa/rpc-tests/pruning.py
@@ -27,24 +27,7 @@ class PruneTest(BitcoinTestFramework):
 
         self.utxo = []
         self.address = ["",""]
-
-        # Some pre-processing to create a bunch of OP_RETURN txouts to insert into transactions we create
-        # So we have big transactions and full blocks to fill up our block files
-
-        # create one script_pubkey
-        script_pubkey = "6a4d0200" #OP_RETURN OP_PUSH2 512 bytes
-        for i in range (512):
-            script_pubkey = script_pubkey + "01"
-        # concatenate 128 txouts of above script_pubkey which we'll insert before the txout for change
-        self.txouts = "81"
-        for k in range(128):
-            # add txout value
-            self.txouts = self.txouts + "0000000000000000"
-            # add length of script_pubkey
-            self.txouts = self.txouts + "fd0402"
-            # add script_pubkey
-            self.txouts = self.txouts + script_pubkey
-
+        self.txouts = gen_return_txouts()
 
     def setup_network(self):
         self.nodes = []

--- a/qa/rpc-tests/pruning.py
+++ b/qa/rpc-tests/pruning.py
@@ -25,10 +25,6 @@ class PruneTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 3
 
-        self.utxo = []
-        self.address = ["",""]
-        self.txouts = gen_return_txouts()
-
     def setup_network(self):
         self.nodes = []
         self.is_network_split = False
@@ -40,9 +36,6 @@ class PruneTest(BitcoinTestFramework):
         # Create node 2 to test pruning
         self.nodes.append(start_node(2, self.options.tmpdir, ["-debug","-maxreceivebuffer=20000","-prune=550"], timewait=900))
         self.prunedir = self.options.tmpdir+"/node2/regtest/blocks/"
-
-        self.address[0] = self.nodes[0].getnewaddress()
-        self.address[1] = self.nodes[1].getnewaddress()
 
         connect_nodes(self.nodes[0], 1)
         connect_nodes(self.nodes[1], 2)
@@ -56,7 +49,7 @@ class PruneTest(BitcoinTestFramework):
         self.nodes[0].generate(150)
         # Then mine enough full blocks to create more than 550MiB of data
         for i in range(645):
-            self.mine_full_block(self.nodes[0], self.address[0])
+            mine_large_block(self.nodes[0])
 
         sync_blocks(self.nodes[0:3])
 
@@ -68,7 +61,7 @@ class PruneTest(BitcoinTestFramework):
         print("Mining 25 more blocks should cause the first block file to be pruned")
         # Pruning doesn't run until we're allocating another chunk, 20 full blocks past the height cutoff will ensure this
         for i in range(25):
-            self.mine_full_block(self.nodes[0],self.address[0])
+            mine_large_block(self.nodes[0])
 
         waitstart = time.time()
         while os.path.isfile(self.prunedir+"blk00000.dat"):
@@ -93,17 +86,15 @@ class PruneTest(BitcoinTestFramework):
             stop_node(self.nodes[0],0)
             self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug","-maxreceivebuffer=20000","-blockmaxsize=999000", "-checkblocks=5"], timewait=900)
             # Mine 24 blocks in node 1
-            self.utxo = self.nodes[1].listunspent()
             for i in range(24):
                 if j == 0:
-                    self.mine_full_block(self.nodes[1],self.address[1])
+                    mine_large_block(self.nodes[1])
                 else:
                     self.nodes[1].generate(1) #tx's already in mempool from previous disconnects
 
             # Reorg back with 25 block chain from node 0
-            self.utxo = self.nodes[0].listunspent()
             for i in range(25):
-                self.mine_full_block(self.nodes[0],self.address[0])
+                mine_large_block(self.nodes[0])
 
             # Create connections in the order so both nodes can see the reorg at the same time
             connect_nodes(self.nodes[1], 0)
@@ -214,32 +205,6 @@ class PruneTest(BitcoinTestFramework):
         assert(self.nodes[2].getbestblockhash() == goalbesthash)
         # Verify we can now have the data for a block previously pruned
         assert(self.nodes[2].getblock(self.forkhash)["height"] == self.forkheight)
-
-    def mine_full_block(self, node, address):
-        # Want to create a full block
-        # We'll generate a 66k transaction below, and 14 of them is close to the 1MB block limit
-        for j in range(14):
-            if len(self.utxo) < 14:
-                self.utxo = node.listunspent()
-            inputs=[]
-            outputs = {}
-            t = self.utxo.pop()
-            inputs.append({ "txid" : t["txid"], "vout" : t["vout"]})
-            remchange = t["amount"] - Decimal("0.001000")
-            outputs[address]=remchange
-            # Create a basic transaction that will send change back to ourself after account for a fee
-            # And then insert the 128 generated transaction outs in the middle rawtx[92] is where the #
-            # of txouts is stored and is the only thing we overwrite from the original transaction
-            rawtx = node.createrawtransaction(inputs, outputs)
-            newtx = rawtx[0:92]
-            newtx = newtx + self.txouts
-            newtx = newtx + rawtx[94:]
-            # Appears to be ever so slightly faster to sign with SIGHASH_NONE
-            signresult = node.signrawtransaction(newtx,None,None,"NONE|FORKID")
-            txid = node.sendrawtransaction(signresult["hex"], True)
-        # Mine a full sized block which will be these transactions we just created
-        node.generate(1)
-
 
     def run_test(self):
         print("Warning! This test requires 4GB of disk space and takes over 30 mins (up to 2 hours)")

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -607,3 +607,12 @@ def create_lots_of_big_transactions(node, txouts, utxos, num, fee):
         txid = node.sendrawtransaction(signresult["hex"], True)
         txids.append(txid)
     return txids
+
+def mine_large_block(node):
+    # generate a 66k transaction,
+    # and 14 of them is close to the 1MB block limit
+    txouts = gen_return_txouts()
+    utxos = node.listunspent()[:14]
+    fee = 100 * node.getnetworkinfo()["relayfee"]
+    create_lots_of_big_transactions(node, txouts, utxos, 14, fee=fee)
+    node.generate(1)

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -572,6 +572,24 @@ def create_confirmed_utxos(fee, node, count, age=101):
     assert(len(utxos) >= count)
     return utxos
 
+def gen_return_txouts():
+    # Some pre-processing to create a bunch of OP_RETURN txouts to insert into transactions we create
+    # So we have big transactions (and therefore can't fit very many into each block)
+    # create one script_pubkey
+    script_pubkey = "6a4d0200" #OP_RETURN OP_PUSH2 512 bytes
+    for i in range (512):
+        script_pubkey = script_pubkey + "01"
+    # concatenate 128 txouts of above script_pubkey which we'll insert before the txout for change
+    txouts = "81"
+    for k in range(128):
+        # add txout value
+        txouts = txouts + "0000000000000000"
+        # add length of script_pubkey
+        txouts = txouts + "fd0402"
+        # add script_pubkey
+        txouts = txouts + script_pubkey
+    return txouts
+
 def create_lots_of_big_transactions(node, txouts, utxos, num, fee):
     addr = node.getnewaddress()
     txids = []

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -590,7 +590,7 @@ def gen_return_txouts():
         txouts = txouts + script_pubkey
     return txouts
 
-def create_lots_of_big_transactions(node, txouts, utxos, num, fee):
+def create_lots_of_big_transactions(node, txouts, utxos, num, fee, tx_file=None):
     addr = node.getnewaddress()
     txids = []
     for _ in range(num):
@@ -606,6 +606,8 @@ def create_lots_of_big_transactions(node, txouts, utxos, num, fee):
         signresult = node.signrawtransaction(newtx, None, None, "NONE|FORKID")
         txid = node.sendrawtransaction(signresult["hex"], True)
         txids.append(txid)
+        if (tx_file):
+            tx_file.write(signresult["hex"] + "\n")
     return txids
 
 def mine_large_block(node):


### PR DESCRIPTION
Update bip100-sizelimit.py to run in the post-uahf (Bitcoin Cash fork) regtest environment.  Include cherry-picks that factor out standard big block and transaction routines, and use those routines.