### PR TITLE
Use Bitcoin Cash network magic

### DIFF
--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -1498,9 +1498,9 @@ class NodeConn(asyncore.dispatcher):
         b"blocktxn": msg_blocktxn
     }
     MAGIC_BYTES = {
-        "mainnet": b"\xf9\xbe\xb4\xd9",   # mainnet
-        "testnet3": b"\x0b\x11\x09\x07",  # testnet3
-        "regtest": b"\xfa\xbf\xb5\xda"    # regtest
+        "mainnet": b"\xe3\xe1\xf3\xe8",
+        "testnet3": b"\xf4\xe5\xf3\xf4",
+        "regtest": b"\xda\xb5\xbf\xfa",
     }
 
     def __init__(self, dstaddr, dstport, rpc, callback, net="regtest", services=1):

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -45,6 +45,7 @@ BITCOIN_TESTS =\
   test/blocksender_tests.cpp \
   test/blockencodings_tests.cpp \
   test/bloom_tests.cpp \
+  test/chainparams_tests.cpp \
   test/checkblock_tests.cpp \
   test/Checkpoints_tests.cpp \
   test/clientversion_tests.cpp \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -14,6 +14,7 @@
 #include <boost/assign/list_of.hpp>
 
 #include "chainparamsseeds.h"
+#include "options.h"
 
 static CBlock CreateGenesisBlock(const char* pszTimestamp, const CScript& genesisOutputScript, uint32_t nTime, uint32_t nNonce, uint32_t nBits, int32_t nVersion, const CAmount& genesisReward)
 {
@@ -52,6 +53,17 @@ static CBlock CreateGenesisBlock(uint32_t nTime, uint32_t nNonce, uint32_t nBits
     const char* pszTimestamp = "The Times 03/Jan/2009 Chancellor on brink of second bailout for banks";
     const CScript genesisOutputScript = CScript() << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f") << OP_CHECKSIG;
     return CreateGenesisBlock(pszTimestamp, genesisOutputScript, nTime, nNonce, nBits, nVersion, genesisReward);
+}
+
+const CMessageHeader::MessageStartChars& CChainParams::NetworkMagic() const {
+    return Opt().UAHFTime() == 0
+        ? pchMessageStart
+        : pchCashMessageStart;
+}
+
+const CMessageHeader::MessageStartChars& CChainParams::DBMagic() const {
+    // Always use BTC bytes for backward compatability.
+    return pchMessageStart;
 }
 
 /**
@@ -104,6 +116,10 @@ public:
         pchMessageStart[1] = 0xbe;
         pchMessageStart[2] = 0xb4;
         pchMessageStart[3] = 0xd9;
+        pchCashMessageStart[0] = 0xe3;
+        pchCashMessageStart[1] = 0xe1;
+        pchCashMessageStart[2] = 0xf3;
+        pchCashMessageStart[3] = 0xe8;
         nDefaultPort = 8333;
         nPruneAfterHeight = 100000;
         nMinBlockfileBlocks = 128;
@@ -195,6 +211,10 @@ public:
         pchMessageStart[1] = 0x11;
         pchMessageStart[2] = 0x09;
         pchMessageStart[3] = 0x07;
+        pchCashMessageStart[0] = 0xf4;
+        pchCashMessageStart[1] = 0xe5;
+        pchCashMessageStart[2] = 0xf3;
+        pchCashMessageStart[3] = 0xf4;
         nDefaultPort = 18333;
         nPruneAfterHeight = 1000;
         nMinBlockfileBlocks = 128;
@@ -298,6 +318,10 @@ public:
         pchMessageStart[1] = 0xbf;
         pchMessageStart[2] = 0xb5;
         pchMessageStart[3] = 0xda;
+        pchCashMessageStart[0] = 0xda;
+        pchCashMessageStart[1] = 0xb5;
+        pchCashMessageStart[2] = 0xbf;
+        pchCashMessageStart[3] = 0xfa;
         nDefaultPort = 18444;
         nPruneAfterHeight = 1000;
         nMinBlockfileBlocks = 16;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -53,7 +53,10 @@ public:
     };
 
     const Consensus::Params& GetConsensus() const { return consensus; }
-    const CMessageHeader::MessageStartChars& MessageStart() const { return pchMessageStart; }
+    /** Magic bytes in network messages */
+    const CMessageHeader::MessageStartChars& NetworkMagic() const;
+    /** Magic bytes used to separate items in database */
+    const CMessageHeader::MessageStartChars& DBMagic() const;
     int GetDefaultPort() const { return nDefaultPort; }
 
     const CBlock& GenesisBlock() const { return genesis; }
@@ -81,6 +84,7 @@ protected:
 
     Consensus::Params consensus;
     CMessageHeader::MessageStartChars pchMessageStart;
+    CMessageHeader::MessageStartChars pchCashMessageStart;
     int nDefaultPort;
     uint64_t nPruneAfterHeight;
     uint64_t nMinBlockfileBlocks;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -563,7 +563,7 @@ bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes)
         // get current incomplete message, or create a new one
         if (vRecvMsg.empty() ||
             vRecvMsg.back().complete())
-            vRecvMsg.push_back(CNetMessage(Params().MessageStart(), SER_NETWORK, nRecvVersion));
+            vRecvMsg.push_back(CNetMessage(Params().NetworkMagic(), SER_NETWORK, nRecvVersion));
 
         CNetMessage& msg = vRecvMsg.back();
 
@@ -1367,9 +1367,9 @@ void ThreadOpenConnections()
         //  * Increase the number of connectable addresses in the tried table.
         //
         // Method:
-        //  * Choose a random address from new and attempt to connect to it if we can connect 
+        //  * Choose a random address from new and attempt to connect to it if we can connect
         //    successfully it is added to tried.
-        //  * Start attempting feeler connections only after node finishes making outbound 
+        //  * Start attempting feeler connections only after node finishes making outbound
         //    connections.
         //  * Only make a feeler connection once every few minutes.
         //
@@ -2002,7 +2002,7 @@ bool CAddrDB::Write(const CAddrMan& addr)
 
     // serialize addresses, checksum data up to that point, then append csum
     CDataStream ssPeers(SER_DISK, CLIENT_VERSION);
-    ssPeers << FLATDATA(Params().MessageStart());
+    ssPeers << FLATDATA(Params().DBMagic());
     ssPeers << addr;
     uint256 hash = Hash(ssPeers.begin(), ssPeers.end());
     ssPeers << hash;
@@ -2077,7 +2077,7 @@ bool CAddrDB::Read(CAddrMan& addr, CDataStream& ssPeers)
         ssPeers >> FLATDATA(pchMsgTmp);
 
         // ... verify the network matches ours
-        if (memcmp(pchMsgTmp, Params().MessageStart(), sizeof(pchMsgTmp)))
+        if (memcmp(pchMsgTmp, Params().DBMagic(), sizeof(pchMsgTmp)))
             return error("%s: Invalid network magic number", __func__);
 
         // de-serialize address data into one CAddrMan object
@@ -2206,7 +2206,7 @@ void CNode::BeginMessage(const char* pszCommand) EXCLUSIVE_LOCK_FUNCTION(cs_vSen
 {
     ENTER_CRITICAL_SECTION(cs_vSend);
     assert(ssSend.size() == 0);
-    ssSend << CMessageHeader(Params().MessageStart(), pszCommand, 0);
+    ssSend << CMessageHeader(Params().NetworkMagic(), pszCommand, 0);
     LogPrint("net", "sending: %s ", SanitizeString(pszCommand));
 }
 

--- a/src/test/ReceiveMsgBytes_tests.cpp
+++ b/src/test/ReceiveMsgBytes_tests.cpp
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(FullMessages)
     testNode.nVersion = 1;
 
     CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
-    s << CMessageHeader(Params().MessageStart(), "ping", 0);
+    s << CMessageHeader(Params().NetworkMagic(), "ping", 0);
     s << (uint64_t)11; // ping nonce
     CNetMessage::FinalizeHeader(s);
 
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(TooLargeBlock)
     testNode.nVersion = 1;
 
     CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
-    s << CMessageHeader(Params().MessageStart(), "block", 0);
+    s << CMessageHeader(Params().NetworkMagic(), "block", 0);
     size_t headerLen = s.size();
     s << block;
 
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(TooLargeVerack)
     testNode.nVersion = 1;
 
     CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
-    s << CMessageHeader(Params().MessageStart(), "verack", 0);
+    s << CMessageHeader(Params().NetworkMagic(), "verack", 0);
     size_t headerLen = s.size();
 
     CNetMessage::FinalizeHeader(s);
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(TooLargePing)
     testNode.nVersion = 1;
 
     CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
-    s << CMessageHeader(Params().MessageStart(), "ping", 0);
+    s << CMessageHeader(Params().NetworkMagic(), "ping", 0);
     s << (uint64_t)11; // 8-byte nonce
 
     CNetMessage::FinalizeHeader(s);

--- a/src/test/chainparams_tests.cpp
+++ b/src/test/chainparams_tests.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <boost/test/unit_test.hpp>
+#include "chainparams.h"
+#include "options.h"
+
+namespace {
+
+class OptDummy : public ArgGetter {
+    public:
+        OptDummy() : uahftime(0) { }
+        int64_t GetArg(const std::string& arg, int64_t def) override {
+            return arg == "-uahftime" ? uahftime : def;
+        }
+
+        bool GetBool(const std::string&, bool def) override
+        { return def; }
+
+        std::vector<std::string> GetMultiArgs(const std::string&) override
+        { return { }; }
+
+        int64_t uahftime;
+};
+
+} // anon ns
+
+BOOST_AUTO_TEST_SUITE(chainparams_tests);
+
+BOOST_AUTO_TEST_CASE(check_network_magic) {
+    auto cfg = new OptDummy();
+    auto raii = SetDummyArgGetter(std::unique_ptr<ArgGetter>(cfg));
+
+    // Should return BTC magic.
+    cfg->uahftime = 0;
+    auto magic = Params(CBaseChainParams::MAIN).NetworkMagic();
+    BOOST_CHECK_EQUAL(0xf9, magic[0]);
+
+    // Should return BCH magic.
+    cfg->uahftime = 42;
+    magic = Params(CBaseChainParams::MAIN).NetworkMagic();
+    BOOST_CHECK_EQUAL(0xe3, magic[0]);
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -61,7 +61,7 @@ public:
 CDataStream AddrmanToStream(CAddrManSerializationMock& addrman)
 {
     CDataStream ssPeersIn(SER_DISK, CLIENT_VERSION);
-    ssPeersIn << FLATDATA(Params().MessageStart());
+    ssPeersIn << FLATDATA(Params().DBMagic());
     ssPeersIn << addrman;
     std::string str = ssPeersIn.str();
     vector<unsigned char> vchData(str.begin(), str.end());


### PR DESCRIPTION
This changes the network magic bytes when the node runs on the Bitcoin Cash network.

These bytes were also used in the database. For backward compatibility, we still use the old byte values for database.

This change is not backward compatible with older nodes. This is fine, since we're doing a hard fork in a few days.