### PR TITLE
Ensure backupwallet fails if pathDest is set to pathSource

### DIFF
--- a/qa/rpc-tests/walletbackup.py
+++ b/qa/rpc-tests/walletbackup.py
@@ -199,6 +199,16 @@ class WalletBackupTest(BitcoinTestFramework):
         assert_equal(self.nodes[1].getbalance(), balance1)
         assert_equal(self.nodes[2].getbalance(), balance2)
 
+        # Backup to source wallet file must fail
+        sourcePaths = [
+            tmpdir + "/node0/regtest/wallet.dat",
+            tmpdir + "/node0/./regtest/wallet.dat",
+            tmpdir + "/node0/regtest/",
+            tmpdir + "/node0/regtest"]
+
+        for sourcePath in sourcePaths:
+            assert_raises(JSONRPCException, self.nodes[0].backupwallet, sourcePath)
+
 
 if __name__ == '__main__':
     WalletBackupTest().main()

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -879,6 +879,10 @@ bool BackupWallet(const CWallet& wallet, const string& strDest)
                     pathDest /= wallet.strWalletFile;
 
                 try {
+                    if (boost::filesystem::equivalent(pathSrc, pathDest)) {
+                        LogPrintf("cannot backup to wallet source file %s\n", pathDest.string());
+                        return false;
+                    }
 #if BOOST_VERSION >= 104000
                     boost::filesystem::copy_file(pathSrc, pathDest, boost::filesystem::copy_option::overwrite_if_exists);
 #else


### PR DESCRIPTION
From https://github.com/bitcoin/bitcoin/pull/11376

Previous behaviour was to destroy the wallet (to zero-length)