### PR TITLE
Take a copy of blocks in stopAllWork

### DIFF
--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -156,7 +156,8 @@ void ThinBlockWorker::stopWork(const uint256& block) {
 }
 
 void ThinBlockWorker::stopAllWork() {
-    for (auto b : blocks)
+    std::set<uint256> blocksCpy = blocks;
+    for (const uint256& b : blocksCpy)
         stopWork(b);
 }
 


### PR DESCRIPTION
Make it safe to modify the blocks set during iteration.