### PR TITLE
Framework for handling double spends

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -137,6 +137,11 @@ BITCOIN_CORE_H = \
   protocol.h \
   pubkey.h \
   random.h \
+  respend/respendaction.h \
+  respend/respendlogger.h \
+  respend/respendrelayer.h \
+  respend/respenddetector.h \
+  respend/walletnotifier.h \
   rpcclient.h \
   rpcprotocol.h \
   rpcserver.h \
@@ -227,6 +232,10 @@ libbitcoin_server_a_SOURCES = \
   pow.cpp \
   process_xthinblock.cpp \
   rest.cpp \
+  respend/respendlogger.cpp \
+  respend/respendrelayer.cpp \
+  respend/respenddetector.cpp \
+  respend/walletnotifier.cpp \
   rpcblockchain.cpp \
   rpcmining.cpp \
   rpcmisc.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -33,6 +33,9 @@ RAW_TEST_FILES =
 GENERATED_TEST_FILES = $(JSON_TEST_FILES:.json=.json.h) $(RAW_TEST_FILES:.raw=.raw.h)
 
 BITCOIN_TESTS =\
+  respend/test/respendrelayer_tests.cpp \
+  respend/test/respenddetector_tests.cpp \
+  respend/test/walletnotifier_tests.cpp \
   test/arith_uint256_tests.cpp \
   test/bignum.h \
   test/addrman_tests.cpp \

--- a/src/blockannounce.h
+++ b/src/blockannounce.h
@@ -22,6 +22,7 @@ class BlockAnnounceReceiver {
             block(block), from(from), thinmg(thinmg), blocksInFlight(inFlightIndex)
         {
         }
+	virtual ~BlockAnnounceReceiver() { }
 
         bool onBlockAnnounced(std::vector<CInv>& toFetch);
 

--- a/src/bloom.h
+++ b/src/bloom.h
@@ -38,9 +38,9 @@ static const unsigned char BLOOM_ANCESTOR_UPDATE_BIT = 4;
 /**
  * BloomFilter is a probabilistic filter which SPV clients provide
  * so that we can filter the transactions we send them.
- * 
+ *
  * This allows for significantly more efficient transaction and block downloads.
- * 
+ *
  * Because bloom filters are probabilistic, a SPV node can increase the false-
  * positive rate, making us send it transactions which aren't actually its,
  * allowing clients to trade more bandwidth for more privacy by obfuscating which
@@ -133,9 +133,11 @@ public:
     CRollingBloomFilter(const unsigned int nElements, const double nFPRate);
 
     void insert(const std::vector<unsigned char>& vKey);
+    void insert(const COutPoint& outpoint);
     void insert(const uint256& hash);
     bool contains(const std::vector<unsigned char>& vKey) const;
     bool contains(const uint256& hash) const;
+    bool contains(const COutPoint& outpoint) const;
 
     void reset();
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1493,7 +1493,6 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     LogPrintf("mapAddressBook.size() = %u\n",  pwalletMain ? pwalletMain->mapAddressBook.size() : 0);
 #endif
 
-    InitRespendFilter();
     StartNode(threadGroup, scheduler);
 
     // Monitor the chain, and alert if we get blocks much quicker or slower than expected

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -86,6 +86,10 @@ int Opt::UAHFProtectSunset() {
     return Args->GetArg("-uahfprotectsunset", UAHF_DEFAULT_PROTECT_THIS_SUNSET);
 }
 
+int64_t Opt::RespendRelayLimit() const {
+    return Args->GetArg("-limitrespendrelay", 100);
+}
+
 bool Opt::UsingThinBlocks() {
     if (IsStealthMode())
         return false;
@@ -114,4 +118,3 @@ std::unique_ptr<ArgReset> SetDummyArgGetter(std::unique_ptr<ArgGetter> getter) {
 ArgReset::~ArgReset() {
     Args.reset(new DefaultGetter());
 }
-

--- a/src/options.h
+++ b/src/options.h
@@ -17,6 +17,7 @@ struct Opt {
     uint64_t MaxBlockSizeVote();
     int64_t UAHFTime();
     int UAHFProtectSunset();
+    int64_t RespendRelayLimit() const;
 
     // Thin block options
     bool UsingThinBlocks();

--- a/src/respend/respendaction.h
+++ b/src/respend/respendaction.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2018 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_RESPEND_RESPENDACTION_H
+#define BITCOIN_RESPEND_RESPENDACTION_H
+
+#include <memory>
+class COutPoint;
+class CTransaction;
+
+namespace respend {
+
+// A "respend action" is incrementally provided with information about a
+// respending transaction. After, it will be triggered, allowing it to perform
+// an action based on the information it gathered.
+class RespendAction {
+    public:
+
+        virtual ~RespendAction() = 0;
+        virtual bool AddOutpointConflict(
+                // conflicting outpoint
+                const COutPoint& out,
+                // TX in our mempool. Pointer is owned by mempool, use to
+                // extract info or take a copy.
+                const CTransaction* originalTx,
+                // Current TX that is respending
+                const CTransaction& respendTx,
+                // If we've seen a valid tx respending this output before
+                bool seenBefore,
+                // If original and respend tx only differ in script
+                bool isEquivalent) = 0;
+
+        // If this respend is interesting enough to this action to trigger full
+        // tx validation.
+        virtual bool IsInteresting() const = 0;
+        // Called after tx is validated and only if it's validated.
+        virtual void SetValid(bool) = 0;
+        // Action should do its thing now.
+        virtual void Trigger() = 0;
+};
+inline RespendAction::~RespendAction() { }
+
+// shared_ptr, instead of unique_ptr, for unit testing
+typedef std::shared_ptr<RespendAction> RespendActionPtr;
+
+} // ns respend
+
+#endif

--- a/src/respend/respenddetector.cpp
+++ b/src/respend/respenddetector.cpp
@@ -1,0 +1,120 @@
+// Copyright (c) 2018 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "respend/respenddetector.h"
+#include "bloom.h"
+#include "options.h"
+#include "respend/respendaction.h"
+#include "respend/respendlogger.h"
+#include "respend/respendrelayer.h"
+#include "respend/walletnotifier.h"
+#include "txmempool.h"
+#include "util.h"
+
+#include <algorithm>
+
+namespace respend {
+
+static const unsigned int MAX_RESPEND_BLOOM = 100000;
+std::unique_ptr<CRollingBloomFilter> RespendDetector::respentBefore;
+std::mutex RespendDetector::respentBeforeMutex;
+
+std::vector<RespendActionPtr> CreateDefaultActions() {
+    std::vector<RespendActionPtr> actions;
+
+    if (!Opt().IsStealthMode()) {
+        actions.push_back(RespendActionPtr(new RespendRelayer{}));
+    }
+    if (LogAcceptCategory("respend")) {
+        actions.push_back(RespendActionPtr(new RespendLogger{}));
+    }
+#ifdef ENABLE_WALLET
+    actions.push_back(RespendActionPtr(new WalletNotifier{}));
+#endif
+    return actions;
+}
+
+RespendDetector::RespendDetector(
+        const CTxMemPool& pool, const CTransaction& tx,
+        std::vector<RespendActionPtr> actions) : actions(actions)
+{
+    {
+        std::lock_guard<std::mutex> lock(respentBeforeMutex);
+        if (!bool(respentBefore)) {
+            respentBefore.reset(new CRollingBloomFilter(MAX_RESPEND_BLOOM, 0.01));
+        }
+    }
+    CheckForRespend(pool, tx);
+}
+
+RespendDetector::~RespendDetector() {
+    // Time for actions to perform their task using the (limited)
+    // information they've gathered.
+    for (auto& a : actions) {
+        try {
+            a->Trigger();
+        }
+        catch (const std::exception& e) {
+            LogPrint("respend: ERROR - respend action threw: %s\n", e.what());
+        }
+   }
+}
+
+void RespendDetector::CheckForRespend(
+        const CTxMemPool& pool, const CTransaction& tx) {
+
+    LOCK(pool.cs); // protect pool.mapNextTx
+
+    for (const CTxIn& in : tx.vin)
+    {
+        const COutPoint outpoint = in.prevout;
+
+        // Any conflicting inputs?
+        if (!pool.mapNextTx.count(outpoint))
+            continue;
+
+        conflictingOutpoints.push_back(outpoint);
+        const CTransaction* orig = pool.mapNextTx.find(outpoint)->second.ptx;
+
+        bool collectMore = false;
+        bool seen;
+        {
+            std::lock_guard<std::mutex> lock(respentBeforeMutex);
+            seen = respentBefore->contains(outpoint);
+        }
+        for (auto& a : actions) {
+            // Actions can return true if they want to check more
+            // outpoints for conflicts.
+            bool m = a->AddOutpointConflict(outpoint, orig, tx, seen,
+                                                   tx.IsEquivalentTo(*orig));
+            collectMore = collectMore || m;
+        }
+        if (!collectMore)
+            return;
+    }
+}
+
+void RespendDetector::SetValid(bool valid) {
+    if (valid) {
+        std::lock_guard<std::mutex> lock(respentBeforeMutex);
+        for (auto& o : conflictingOutpoints) {
+            respentBefore->insert(o);
+        }
+    }
+    for (auto& a : actions) {
+        a->SetValid(valid);
+    }
+}
+
+bool RespendDetector::IsRespend() const {
+    return !conflictingOutpoints.empty();
+}
+
+bool RespendDetector::IsInteresting() const {
+    return std::any_of(begin(actions), end(actions), [](const RespendActionPtr& a) {
+            return a->IsInteresting();
+        });
+}
+
+} // ns respend

--- a/src/respend/respenddetector.h
+++ b/src/respend/respenddetector.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2018 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_RESPEND_RESPENDTRIGGER_H
+#define BITCOIN_RESPEND_RESPENDTRIGGER_H
+
+#include "respend/respendaction.h"
+#include "primitives/transaction.h"
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+
+
+class CTxMemPool;
+class CTransaction;
+class CRollingBloomFilter;
+
+namespace respend {
+
+std::vector<RespendActionPtr> CreateDefaultActions();
+
+// Detects if a transaction is in conflict with mempool, and feeds various
+// actions with data about the respend. Finally triggers the actions.
+class RespendDetector {
+    public:
+
+        RespendDetector(const CTxMemPool& pool, const CTransaction& tx,
+                       std::vector<RespendActionPtr> = CreateDefaultActions());
+
+        ~RespendDetector();
+        void CheckForRespend(const CTxMemPool& pool, const CTransaction& tx);
+        void SetValid(bool valid);
+        bool IsRespend() const;
+
+        // Respend is interesting enough to trigger full tx validation.
+        bool IsInteresting() const;
+
+    private:
+        std::vector<COutPoint> conflictingOutpoints;
+
+        // Outputs we've already seen in valid double spending transactions
+        static std::unique_ptr<CRollingBloomFilter> respentBefore;
+        static std::mutex respentBeforeMutex;
+        std::vector<RespendActionPtr> actions;
+};
+
+} // ns respend
+
+#endif

--- a/src/respend/respendlogger.cpp
+++ b/src/respend/respendlogger.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2018 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "respend/respendlogger.h"
+#include "primitives/transaction.h"
+#include "util.h"
+
+namespace respend {
+
+RespendLogger::RespendLogger() :
+    equivalent(false), valid("indeterminate"), newConflict(false)
+{
+}
+
+bool RespendLogger::AddOutpointConflict(
+        const COutPoint&, const CTransaction* mempoolTx,
+        const CTransaction& respendTx, bool seen, bool isEquivalent)
+{
+    orig = mempoolTx->GetHash().ToString();
+    respend = respendTx.GetHash().ToString();
+    equivalent = isEquivalent;
+    newConflict = newConflict || !seen;
+
+    // We have enough info for logging purposes.
+    return false;
+}
+
+bool RespendLogger::IsInteresting() const {
+    // Logging never triggers full tx validation
+    return false;
+}
+
+void RespendLogger::Trigger() {
+    if (respend.empty())
+        return;
+
+    const std::string msg = "respend: Tx %s conflicts with %s"
+        " (new conflict: %s, equivalent %s, valid %s)\n";
+
+    LogPrint("respend", msg.c_str(), orig, respend,
+              newConflict ? "yes" : "no",
+              equivalent ? "yes" : "no", valid);
+}
+
+}

--- a/src/respend/respendlogger.h
+++ b/src/respend/respendlogger.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2018 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_RESPEND_RESPENDLOGGER_H
+#define BITCOIN_RESPEND_RESPENDLOGGER_H
+
+#include "respend/respendaction.h"
+#include <string>
+
+namespace respend {
+
+class RespendLogger : public RespendAction {
+    public:
+        RespendLogger();
+
+        bool AddOutpointConflict(
+                const COutPoint&, const CTransaction* originalTx,
+                const CTransaction& respendTx, bool seen, bool isEquivalent) override;
+
+        virtual bool IsInteresting() const override;
+
+        void Trigger() override;
+
+        void SetValid(bool v) override {
+            valid = v ? "yes" : "no";
+        }
+
+    private:
+        std::string orig;
+        std::string respend;
+        bool equivalent;
+        std::string valid;
+        bool newConflict; // TX has at least 1 output that's not respent earlier
+};
+
+} // ns respend
+
+#endif

--- a/src/respend/respendrelayer.cpp
+++ b/src/respend/respendrelayer.cpp
@@ -1,0 +1,91 @@
+// Copyright (c) 2018 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "respend/respendrelayer.h"
+#include "net.h" // RelayTransaction
+#include "options.h"
+#include "primitives/transaction.h"
+#include "protocol.h"
+#include "streams.h"
+#include "util.h"
+#include "utilprocessmsg.h"
+#include <mutex>
+
+namespace respend {
+
+namespace {
+
+// Apply an independent rate limit to double-spend relays
+class RelayLimiter {
+    public:
+        RelayLimiter() : respendCount(0), lastRespendTime(0) { }
+
+        bool HasLimitExceeded(const CTransaction& doubleSpend)
+        {
+            unsigned int size = ::GetSerializeSize(doubleSpend,
+                                                   SER_NETWORK, PROTOCOL_VERSION);
+
+            std::lock_guard<std::mutex> lock(cs);
+            int64_t limit = Opt().RespendRelayLimit();
+            if (RateLimitExceeded(respendCount, lastRespendTime, limit, size)) {
+                LogPrint("respend", "respend: Double-spend relay rejected by rate limiter\n");
+                return true;
+            }
+
+            LogPrint("respend", "respend: Double-spend relay rate limiter: %g => %g\n",
+                     respendCount, respendCount + size);
+            return false;
+        }
+
+    private:
+        double respendCount;
+        int64_t lastRespendTime;
+        std::mutex cs;
+};
+
+} // ns anon
+
+RespendRelayer::RespendRelayer() : interesting(false), valid(false)
+{
+}
+
+bool RespendRelayer::AddOutpointConflict(
+        const COutPoint&, const CTransaction*,
+        const CTransaction& respendTx,
+        bool seenBefore, bool isEquivalent)
+{
+    if (seenBefore || isEquivalent)
+        return true; // look at more outpoints
+
+    // Is static to hold relay statistics
+    static RelayLimiter limiter;
+
+    if (limiter.HasLimitExceeded(respendTx)) {
+        // we won't relay this tx, so no no need to look at more outputs.
+        return false;
+    }
+
+    respend = respendTx;
+    interesting = true;
+    return false;
+}
+
+bool RespendRelayer::IsInteresting() const {
+    return interesting;
+}
+
+void RespendRelayer::SetValid(bool v) {
+    valid = v;
+}
+
+void RespendRelayer::Trigger() {
+    if (!valid || !interesting)
+        return;
+
+    std::vector<uint256> vAncestors;
+    vAncestors.push_back(respend.GetHash()); // Alert only for the tx itself
+    RelayTransaction(respend, vAncestors);
+}
+
+} // ns respend

--- a/src/respend/respendrelayer.h
+++ b/src/respend/respendrelayer.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2018 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_RESPEND_RESPENDRELAYER_H
+#define BITCOIN_RESPEND_RESPENDRELAYER_H
+
+#include "respend/respendaction.h"
+#include "primitives/transaction.h"
+
+namespace respend {
+
+// Relays double spends to other peers so they also may detect the doublespend.
+class RespendRelayer : public RespendAction {
+    public:
+        RespendRelayer();
+
+        bool AddOutpointConflict(
+                const COutPoint&, const CTransaction*,
+                const CTransaction& respendTx,
+                bool seenBefore, bool isEquivalent) override;
+
+        bool IsInteresting() const override;
+        void SetValid(bool v) override;
+
+        void Trigger() override;
+
+    private:
+        bool interesting;
+        bool valid;
+        CTransaction respend;
+};
+
+} // ns respend
+
+#endif

--- a/src/respend/test/respenddetector_tests.cpp
+++ b/src/respend/test/respenddetector_tests.cpp
@@ -1,0 +1,189 @@
+// Copyright (c) 2018 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include "key.h"
+#include "random.h"
+#include "respend/respendaction.h"
+#include "respend/respenddetector.h"
+#include "script/standard.h"
+#include "txmempool.h"
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+using namespace respend;
+
+namespace {
+
+class DummyRespendAction : public RespendAction {
+    public:
+        DummyRespendAction() : addOutpointCalls(0), respentBefore(false),
+                               isEquivalent(false), triggered(false),
+                               returnInteresting(false), valid(false)
+        {
+        }
+
+        bool AddOutpointConflict(
+                const COutPoint& out,
+                const CTransaction* originalTx,
+                const CTransaction& respendTx,
+                bool respentBefore,
+                bool isEquivalent) override
+        {
+            addOutpointCalls++;
+            this->respentBefore = respentBefore;
+            this->isEquivalent = isEquivalent;
+            return false;
+        }
+
+        bool IsInteresting() const override {
+            return returnInteresting;
+        }
+        void SetValid(bool v) override {
+            valid = v;
+        }
+        void Trigger() override {
+            triggered = true;
+        }
+
+        int addOutpointCalls;
+        bool respentBefore;
+        bool isEquivalent;
+        bool triggered;
+        bool returnInteresting;
+        bool valid;
+};
+
+class RespendFixture : public BasicTestingSetup {
+    public:
+        RespendFixture() :
+            mempool(CFeeRate(0)),
+            dummyaction(new DummyRespendAction)
+        {
+        }
+        CTxMemPool mempool;
+        std::shared_ptr<DummyRespendAction> dummyaction;
+};
+
+CMutableTransaction CreateRandomTx() {
+    CKey key;
+    key.MakeNewKey(true);
+
+    CMutableTransaction tx;
+    tx.vin.resize(1);
+    tx.vin[0].prevout.n = 0;
+    tx.vin[0].prevout.hash = GetRandHash();
+    tx.vin[0].scriptSig << OP_1;
+    tx.vout.resize(1);
+    tx.vout[0].nValue = 1*CENT;
+    tx.vout[0].scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());
+    return tx;
+}
+
+} // ns anon
+
+BOOST_FIXTURE_TEST_SUITE(respenddetector_tests, RespendFixture);
+
+BOOST_AUTO_TEST_CASE(not_a_respend) {
+    CMutableTransaction tx1 = CreateRandomTx();
+    CMutableTransaction tx2 = CreateRandomTx();
+
+    // Nothing in mempool, can't be a respend.
+    {
+        RespendDetector detector(mempool, tx1, { dummyaction });
+        BOOST_CHECK(!detector.IsRespend());
+        BOOST_CHECK_EQUAL(0, dummyaction->addOutpointCalls);
+    }
+
+    TestMemPoolEntryHelper entry;
+    mempool.addUnchecked(tx1.GetHash(), entry.FromTx(tx1));
+
+    // tx2 is not a respend of tx1
+    RespendDetector detector(mempool, tx2, { dummyaction });
+    BOOST_CHECK(!detector.IsRespend());
+    BOOST_CHECK_EQUAL(0, dummyaction->addOutpointCalls);
+}
+
+BOOST_AUTO_TEST_CASE(only_script_differs) {
+    CMutableTransaction tx1 = CreateRandomTx();
+    CMutableTransaction tx2 = tx1;
+    tx2.vin[0].scriptSig << OP_DROP << OP_1;
+
+    TestMemPoolEntryHelper entry;
+    mempool.addUnchecked(tx1.GetHash(), entry.FromTx(tx1));
+    RespendDetector detector(mempool, tx2, { dummyaction });
+    BOOST_CHECK(detector.IsRespend());
+    // when only the script differs, the isEquivalent flag should be set
+    BOOST_CHECK(dummyaction->isEquivalent);
+    BOOST_CHECK(!dummyaction->respentBefore);
+}
+
+BOOST_AUTO_TEST_CASE(seen_before) {
+    CMutableTransaction tx1 = CreateRandomTx();
+    CMutableTransaction tx2 = tx1;
+    tx2.vout[0].scriptPubKey = CreateRandomTx().vout[0].scriptPubKey;
+
+    TestMemPoolEntryHelper entry;
+    mempool.addUnchecked(tx1.GetHash(), entry.FromTx(tx1));
+
+    {
+        RespendDetector detector(mempool, tx2, { dummyaction });
+        BOOST_CHECK(detector.IsRespend());
+        BOOST_CHECK(!dummyaction->isEquivalent);
+        BOOST_CHECK(!dummyaction->respentBefore);
+
+        // only valid txs are added to the seen before filter
+        detector.SetValid(true);
+    }
+
+    // tx3 differs from tx2, but spends the same input
+    CMutableTransaction tx3 = tx1;
+    tx3.vout[0].scriptPubKey = CreateRandomTx().vout[0].scriptPubKey;
+    {
+        RespendDetector detector(mempool, tx3, { dummyaction });
+        BOOST_CHECK(detector.IsRespend());
+        BOOST_CHECK(!dummyaction->isEquivalent);
+        BOOST_CHECK(dummyaction->respentBefore);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(triggers_actions) {
+    // Actions should trigger when RespendDetector goes out of scope.
+    {
+        RespendDetector detector(mempool, CTransaction{}, { dummyaction });
+        BOOST_CHECK(!dummyaction->triggered);
+    }
+    BOOST_CHECK(dummyaction->triggered);
+}
+
+BOOST_AUTO_TEST_CASE(is_interesting) {
+    // Respend is interesting when at least one action finds it interesting.
+    auto action1 = new DummyRespendAction;
+    auto action2 = new DummyRespendAction;
+    RespendDetector detector(mempool, CTransaction{},
+                           { RespendActionPtr(action1), RespendActionPtr(action2) });
+
+    action1->returnInteresting = false;
+    action2->returnInteresting = false;
+    BOOST_CHECK(!detector.IsInteresting());
+
+    action2->returnInteresting = true;
+    BOOST_CHECK(detector.IsInteresting());
+}
+
+BOOST_AUTO_TEST_CASE(set_valid) {
+    auto action1 = new DummyRespendAction;
+    auto action2 = new DummyRespendAction;
+    RespendDetector detector(mempool, CTransaction{},
+                           { RespendActionPtr(action1), RespendActionPtr(action2) });
+
+    detector.SetValid(true);
+    BOOST_CHECK(action1->valid);
+    BOOST_CHECK(action2->valid);
+
+    detector.SetValid(false);
+    BOOST_CHECK(!action1->valid);
+    BOOST_CHECK(!action2->valid);
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/respend/test/respendrelayer_tests.cpp
+++ b/src/respend/test/respendrelayer_tests.cpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2018 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "random.h"
+#include "respend/respendrelayer.h"
+#include "test/test_bitcoin.h"
+#include "test/thinblockutil.h"
+
+#include <boost/test/unit_test.hpp>
+
+using namespace respend;
+
+BOOST_FIXTURE_TEST_SUITE(respendrelayer_tests, BasicTestingSetup);
+
+BOOST_AUTO_TEST_CASE(not_interesting) {
+    RespendRelayer r;
+    BOOST_CHECK(!r.IsInteresting());
+    CTransaction dummy;
+    bool lookAtMore;
+
+    lookAtMore = r.AddOutpointConflict(COutPoint{}, &dummy, CTransaction{},
+                                            true /* seen before */, false);
+    BOOST_CHECK(lookAtMore);
+    BOOST_CHECK(!r.IsInteresting());
+
+    lookAtMore = r.AddOutpointConflict(COutPoint{}, &dummy, CTransaction{},
+                                       false, true /* is equivalent */);
+    BOOST_CHECK(lookAtMore);
+    BOOST_CHECK(!r.IsInteresting());
+}
+
+BOOST_AUTO_TEST_CASE(is_interesting) {
+    RespendRelayer r;
+    CTransaction dummy;
+    bool lookAtMore;
+
+    lookAtMore = r.AddOutpointConflict(COutPoint{}, &dummy, CTransaction{}, false, false);
+    BOOST_CHECK(!lookAtMore);
+    BOOST_CHECK(r.IsInteresting());
+}
+
+BOOST_AUTO_TEST_CASE(triggers_correctly) {
+    CTransaction dummy;
+    CMutableTransaction respend;
+    respend.vin.resize(1);
+    respend.vin[0].prevout.n = 0;
+    respend.vin[0].prevout.hash = GetRandHash();
+    respend.vin[0].scriptSig << OP_1;
+
+    DummyNode node;
+    node.fRelayTxes = true;
+    LOCK(cs_vNodes);
+    vNodes.push_back(&node);
+
+    // Create a "not interesting" respend
+    RespendRelayer r;
+    r.AddOutpointConflict(COutPoint{}, &dummy, respend, true, false);
+    r.Trigger();
+    BOOST_CHECK_EQUAL(size_t(0), node.vInventoryToSend.size());
+    r.SetValid(true);
+    r.Trigger();
+    BOOST_CHECK_EQUAL(size_t(0), node.vInventoryToSend.size());
+
+    // Create an interesting, but invalid respend
+    r.AddOutpointConflict(COutPoint{}, &dummy, respend, false, false);
+    BOOST_CHECK(r.IsInteresting());
+    r.SetValid(false);
+    r.Trigger();
+    BOOST_CHECK_EQUAL(size_t(0), node.vInventoryToSend.size());
+    // make valid
+    r.SetValid(true);
+    r.Trigger();
+    BOOST_CHECK_EQUAL(size_t(1), node.vInventoryToSend.size());
+    BOOST_CHECK(respend.GetHash() == node.vInventoryToSend.at(0).hash);
+    vNodes.erase(vNodes.end() - 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/respend/test/walletnotifier_tests.cpp
+++ b/src/respend/test/walletnotifier_tests.cpp
@@ -1,0 +1,85 @@
+// Copyright (c) 2018 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "random.h"
+#include "respend/walletnotifier.h"
+#include "test/test_bitcoin.h"
+#include "validationinterface.h"
+
+#include <boost/test/unit_test.hpp>
+
+using namespace respend;
+
+BOOST_FIXTURE_TEST_SUITE(respend_walletnotifier_tests, BasicTestingSetup);
+
+BOOST_AUTO_TEST_CASE(not_interesting) {
+    WalletNotifier w;
+    BOOST_CHECK(!w.IsInteresting());
+    CTransaction dummy;
+    bool lookAtMore;
+
+    lookAtMore = w.AddOutpointConflict(COutPoint{}, &dummy, CTransaction{},
+                                            true /* seen before */, false);
+    BOOST_CHECK(lookAtMore);
+    BOOST_CHECK(!w.IsInteresting());
+
+    lookAtMore = w.AddOutpointConflict(COutPoint{}, &dummy, CTransaction{},
+                                       false, true /* is equivalent */);
+    BOOST_CHECK(lookAtMore);
+    BOOST_CHECK(!w.IsInteresting());
+}
+
+BOOST_AUTO_TEST_CASE(is_interesting) {
+    WalletNotifier w;
+    CTransaction dummy;
+    bool lookAtMore;
+
+    lookAtMore = w.AddOutpointConflict(COutPoint{}, &dummy, CTransaction{}, false, false);
+    BOOST_CHECK(!lookAtMore);
+    BOOST_CHECK(w.IsInteresting());
+}
+
+BOOST_AUTO_TEST_CASE(triggers_correctly) {
+    CTransaction slotTx;
+    bool slotRespend = false;
+    int slotCalls = 0;
+    auto dummyslot = [&slotCalls, &slotTx, &slotRespend](const CTransaction& tx, const CBlock*, bool respend) {
+        slotCalls++;
+        slotTx = tx;
+        slotRespend = respend;
+    };
+    GetMainSignals().SyncTransaction.connect(dummyslot);
+
+    CTransaction dummy;
+    CMutableTransaction respend;
+    respend.vin.resize(1);
+    respend.vin[0].prevout.n = 0;
+    respend.vin[0].prevout.hash = GetRandHash();
+    respend.vin[0].scriptSig << OP_1;
+
+    // Create a "not interesting" respend
+    WalletNotifier w;
+    w.AddOutpointConflict(COutPoint{}, &dummy, respend, true, false);
+    w.Trigger();
+    BOOST_CHECK_EQUAL(0, slotCalls);
+    w.SetValid(true);
+    w.Trigger();
+    BOOST_CHECK_EQUAL(0, slotCalls);
+
+    // Create an interesting, but invalid respend
+    w.AddOutpointConflict(COutPoint{}, &dummy, respend, false, false);
+    BOOST_CHECK(w.IsInteresting());
+    w.SetValid(false);
+    w.Trigger();
+    BOOST_CHECK_EQUAL(0, slotCalls);
+    // make valid
+    w.SetValid(true);
+    w.Trigger();
+    BOOST_CHECK_EQUAL(1, slotCalls);
+    BOOST_CHECK(slotRespend);
+    BOOST_CHECK(CTransaction(respend) == slotTx);
+    GetMainSignals().SyncTransaction.disconnect_all_slots();
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/respend/walletnotifier.cpp
+++ b/src/respend/walletnotifier.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2018 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "respend/walletnotifier.h"
+#include "validationinterface.h"
+
+namespace respend {
+
+WalletNotifier::WalletNotifier() : valid(false), interesting(false)
+{
+}
+
+bool WalletNotifier::AddOutpointConflict(
+        const COutPoint&, const CTransaction*,
+        const CTransaction& respendTx,
+        bool seenBefore, bool isEquivalent)
+{
+    if (isEquivalent || seenBefore)
+        return true; // look at more outpoints
+
+    if (interesting)
+        return false; // we already have a copy
+
+    interesting = true;
+    this->respendTx = respendTx;
+
+    // we have enough info
+    return false;
+}
+
+bool WalletNotifier::IsInteresting() const {
+    return interesting;
+}
+
+void WalletNotifier::SetValid(bool v) {
+    valid = v;
+}
+
+void WalletNotifier::Trigger() {
+    if (!valid || !interesting) {
+        return;
+    }
+    SyncWithWallets(respendTx, nullptr, true);
+}
+
+} // ns respend

--- a/src/respend/walletnotifier.h
+++ b/src/respend/walletnotifier.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2018 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_RESPEND_WALLETNOTIFYER_H
+#define BITCOIN_RESPEND_WALLETNOTIFYER_H
+
+#include "respend/respendaction.h"
+#include "primitives/transaction.h"
+
+namespace respend {
+
+// Notifies the wallet of a potentially conflicting double spend.
+class WalletNotifier : public RespendAction {
+    public:
+        WalletNotifier();
+
+        bool AddOutpointConflict(
+                const COutPoint&, const CTransaction* originalTx,
+                const CTransaction& respendTx,
+                bool seenBefore, bool isEquivalent) override;
+
+        bool IsInteresting() const override;
+        void SetValid(bool v) override;
+        void Trigger() override;
+
+    private:
+        CTransaction respendTx;
+        bool valid;
+        bool interesting;
+};
+
+} // ns respend
+
+#endif

--- a/src/utilprocessmsg.cpp
+++ b/src/utilprocessmsg.cpp
@@ -1,9 +1,10 @@
 #include "utilprocessmsg.h"
 #include "chain.h"
 #include "main.h" // mapBlockIndex
-#include "options.h"
 #include "net.h"
 #include "nodestate.h"
+#include "options.h"
+#include "utiltime.h"
 
 bool HaveBlockData(const uint256& hash) {
     return mapBlockIndex.count(hash)
@@ -44,4 +45,16 @@ void UpdateBestHeaderSent(CNode& node, CBlockIndex* blockIndex) {
 
     if (state->bestHeaderSent->nHeight <= blockIndex->nHeight)
         state->bestHeaderSent = blockIndex;
+}
+
+// Exponentially limit the rate of nSize flow to nLimit.  nLimit unit is thousands-per-minute.
+bool RateLimitExceeded(double& dCount, int64_t& nLastTime, int64_t nLimit, unsigned int nSize)
+{
+    int64_t nNow = GetTime();
+    dCount *= pow(1.0 - 1.0/600.0, (double)(nNow - nLastTime));
+    nLastTime = nNow;
+    if (dCount >= nLimit*10*1000)
+        return true;
+    dCount += nSize;
+    return false;
 }

--- a/src/utilprocessmsg.h
+++ b/src/utilprocessmsg.h
@@ -2,6 +2,8 @@
 #define BITCOIN_UTILPROCESSMSG_H
 
 #include <vector>
+#include <cstdint>
+
 class uint256;
 class CNode;
 class CBlockHeader;
@@ -26,5 +28,8 @@ inline BlockInFlightMarker::~BlockInFlightMarker() { }
 bool KeepOutgoingPeer(const CNode&);
 
 void UpdateBestHeaderSent(CNode& node, CBlockIndex* blockIndex);
+
+// Exponentially limit the rate of nSize flow to nLimit.  nLimit unit is thousands-per-minute.
+bool RateLimitExceeded(double& dCount, int64_t& nLastTime, int64_t nLimit, unsigned int nSize);
 
 #endif


### PR DESCRIPTION
This moves logic for handling double spends out of AcceptToMemoryPool. Each distinct action (relay, notify wallet, logging) is implemented as a separate "respend action". 

Unit test coverage is added for all features.

This also improves logging (enable with debug=respend) and fixes an issue where notification to wallet would be stopped by the relay limiter. The relay filter is replaced with a rolling bloom filter.

This will make it easier to add additional features such as https://github.com/bitcoinxt/bitcoinxt/issues/246 or RPC notifications on respends. New features can be added by implementing the _RespendAction_ interface.

