### PR TITLE
Use respend framework for respends found in blocks

### DIFF
--- a/qa/rpc-tests/txn_clone.py
+++ b/qa/rpc-tests/txn_clone.py
@@ -24,6 +24,9 @@ class TxnMallTest(BitcoinTestFramework):
         parser.add_option("--mineblock", dest="mine_block", default=False, action="store_true",
                           help="Test double-spend of 1-confirmed transaction")
 
+    def setup_nodes(self):
+        return start_nodes(self.num_nodes, self.options.tmpdir, extra_args=[['-debug=respend'],]*4)
+
     def setup_network(self):
         # Start with split network:
         return super(TxnMallTest, self).setup_network(True)

--- a/qa/rpc-tests/txn_doublespend.py
+++ b/qa/rpc-tests/txn_doublespend.py
@@ -24,6 +24,9 @@ class TxnMallTest(BitcoinTestFramework):
         parser.add_option("--mineblock", dest="mine_block", default=False, action="store_true",
                           help="Test double-spend of 1-confirmed transaction")
 
+    def setup_nodes(self):
+        return start_nodes(self.num_nodes, self.options.tmpdir, extra_args=[['-debug=respend'],]*4)
+
     def setup_network(self):
         # Start with split network:
         return super(TxnMallTest, self).setup_network(True)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -145,6 +145,7 @@ BITCOIN_CORE_H = \
   respend/respendrelayer.h \
   respend/respenddetector.h \
   respend/walletnotifier.h \
+  respend/mempoolremover.h \
   rpc/client.h \
   rpc/protocol.h \
   rpc/server.h \
@@ -239,6 +240,7 @@ libbitcoin_server_a_SOURCES = \
   respend/respendrelayer.cpp \
   respend/respenddetector.cpp \
   respend/walletnotifier.cpp \
+  respend/mempoolremover.cpp \
   rpc/blockchain.cpp \
   rpc/mining.cpp \
   rpc/misc.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -401,7 +401,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-limitdescendantcount=<n>", strprintf("Do not accept transactions if any ancestor would have <n> or more in-mempool descendants (default: %u)", DEFAULT_DESCENDANT_LIMIT));
         strUsage += HelpMessageOpt("-limitdescendantsize=<n>", strprintf("Do not accept transactions if any ancestor would have more than <n> kilobytes of in-mempool descendants (default: %u).", DEFAULT_DESCENDANT_SIZE_LIMIT));
     }
-    string debugCategories = "addrman, alert, bench, coindb, db, leveldb, libevent, lock, rand, rpc, selectcoins, mempool, net, proxy, prune, reindex, http"; // Don't translate these and qt below
+    string debugCategories = "addrman, alert, bench, coindb, db, leveldb, libevent, lock, rand, rpc, selectcoins, mempool, respend, net, proxy, prune, reindex, http"; // Don't translate these and qt below
     if (mode == HMM_BITCOIN_QT)
         debugCategories += ", qt";
     strUsage += HelpMessageOpt("-debug=<category>", strprintf(_("Output debugging information (default: %u, supplying <category> is optional)"), 0) + ". " +

--- a/src/respend/mempoolremover.cpp
+++ b/src/respend/mempoolremover.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2018 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "respend/mempoolremover.h"
+
+namespace respend {
+
+MempoolRemover::MempoolRemover(CTxMemPool& pool, std::list<CTransaction>& removed) :
+        pool(pool), removed(removed), valid(false)
+{
+}
+
+bool MempoolRemover::AddOutpointConflict(
+        const COutPoint&, const CTxMemPool::txiter mempoolEntry,
+        const CTransaction& respendTx,
+        bool seenBefore, bool isEquivalent)
+{
+    tx1s.insert(mempoolEntry);
+
+    // Keep gathering conflicting transactions
+    return true;
+}
+
+bool MempoolRemover::IsInteresting() const {
+    return true;
+}
+
+void MempoolRemover::Trigger() {
+    if (valid) {
+        for (const auto& tx1Entry : tx1s)
+            pool.removeRecursive(tx1Entry->GetTx(), removed);
+    }
+}
+
+} // ns respend

--- a/src/respend/mempoolremover.h
+++ b/src/respend/mempoolremover.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2018 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_RESPEND_MEMPOOLREMOVER_H
+#define BITCOIN_RESPEND_MEMPOOLREMOVER_H
+
+#include "respend/respendaction.h"
+
+namespace respend {
+
+// Removes any conflicting txes from the mempool
+class MempoolRemover : public RespendAction {
+    public:
+        MempoolRemover(CTxMemPool& pool, std::list<CTransaction>& removed);
+
+        bool AddOutpointConflict(
+                const COutPoint&, const CTxMemPool::txiter,
+                const CTransaction& respendTx,
+                bool seenBefore, bool isEquivalent) override;
+
+        bool IsInteresting() const override;
+        void SetValid(bool v) override {
+            valid = v;
+        }
+        void Trigger() override;
+
+    private:
+        CTxMemPool& pool;
+        std::list<CTransaction>& removed;
+        CTxMemPool::setEntries tx1s;
+        bool valid;
+};
+
+} // ns respend
+
+#endif

--- a/src/respend/respenddetector.cpp
+++ b/src/respend/respenddetector.cpp
@@ -77,7 +77,7 @@ void RespendDetector::CheckForRespend(
         conflictingOutpoints.push_back(outpoint);
 
         CTxMemPool::txiter poolIter = pool.mapTx.find(spendIter->second.ptx->GetHash());
-        if (poolIter == pool.mapTx.end())
+        if (poolIter == pool.mapTx.end() || poolIter->GetTx() == tx)
             continue;
 
         bool collectMore = false;

--- a/src/respend/respendlogger.cpp
+++ b/src/respend/respendlogger.cpp
@@ -31,7 +31,7 @@ bool RespendLogger::IsInteresting() const {
 }
 
 void RespendLogger::Trigger() {
-    if (respend.empty())
+    if (respend.empty() || !newConflict)
         return;
 
     const std::string msg = "respend: Tx %s conflicts with %s"


### PR DESCRIPTION
Reuse the new framework and avoid the need to repeat logging in CTxMemPool::removeConflicts(...)

Functional test `txn_doublespend.py` should succeed and log the respend found in a block, while `txn_clone.py` should succeed and not log the respend because the RespendLogger doesn't log equivalent clones.