### PR TITLE
Enter safe mode and warn of network upgrade

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4425,6 +4425,19 @@ string GetWarnings(string strFor)
         strStatusBar = strRPC = _("Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.");
     }
 
+    {
+        LOCK(cs_main);
+        CBlockIndex* tip = chainActive.Tip();
+        if (tip && IsMay2018HFActive(tip->GetMedianTimePast()))
+        {
+            std::string err =
+                "Error: This version of Bitcoin XT is outdated, please upgrade. "
+                "Sending transactions MAY CAUSE LOSS OF FUNDS. "
+                "Network upgrade (hard fork) was scheduled for May 15th 2018.";
+            strStatusBar = strRPC = err;
+        }
+    }
+
     if (strFor == "statusbar")
         return strStatusBar;
     else if (strFor == "rpc")

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -74,7 +74,7 @@ uint64_t Opt::MaxBlockSizeVote() {
     return Args->GetArg("-maxblocksizevote", 0);
 }
 
-int64_t Opt::UAHFTime() {
+int64_t Opt::UAHFTime() const {
     int64_t defaultUAHFTime = Params().NetworkIDString() == CBaseChainParams::REGTEST ?
                               Params().GenesisBlock().nTime :
                               UAHF_DEFAULT_ACTIVATION_TIME;
@@ -84,6 +84,17 @@ int64_t Opt::UAHFTime() {
 
 int Opt::UAHFProtectSunset() {
     return Args->GetArg("-uahfprotectsunset", UAHF_DEFAULT_PROTECT_THIS_SUNSET);
+}
+
+int64_t Opt::May2018HFTime() const {
+
+    // Never activate if we're on the BTC chain
+    if (!bool(UAHFTime()))
+        return 0;
+
+    // Tuesday, May 15, 2018 4:00:00 PM
+    const int64_t MAY_HF_DEFAULT_ACTIVATION_TIME = 1526400000;
+    return Args->GetArg("-may2018hftime", MAY_HF_DEFAULT_ACTIVATION_TIME);
 }
 
 int64_t Opt::RespendRelayLimit() const {

--- a/src/options.h
+++ b/src/options.h
@@ -15,9 +15,10 @@ struct Opt {
     int ScriptCheckThreads();
     int64_t CheckpointDays();
     uint64_t MaxBlockSizeVote();
-    int64_t UAHFTime();
+    int64_t UAHFTime() const;
     int UAHFProtectSunset();
     int64_t RespendRelayLimit() const;
+    int64_t May2018HFTime() const;
 
     // Thin block options
     bool UsingThinBlocks();

--- a/src/test/utilfork_tests.cpp
+++ b/src/test/utilfork_tests.cpp
@@ -1,10 +1,12 @@
-// Copyright (c) 2017 The Bitcoin XT developers
+// Copyright (c) 2017 - 2018 The Bitcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include "chain.h"
 #include "chainparams.h"
 #include "options.h"
+#include "test/test_bitcoin.h"
 #include "utilfork.h"
+
 #include <limits.h>
 #include <iostream>
 
@@ -13,11 +15,13 @@
 namespace {
 class DummyArgGetter : public ArgGetter {
     public:
-    DummyArgGetter() : ArgGetter(), uahf(-1) { }
+    DummyArgGetter() : ArgGetter(), uahf(-1), mayhf(-1) { }
 
     int64_t GetArg(const std::string& arg, int64_t def) override {
         if (arg == "-uahftime")
             return uahf;
+        if (arg == "-may2018hftime")
+            return mayhf;
         throw std::runtime_error("not implemented");
     }
     std::vector<std::string> GetMultiArgs(const std::string&) override {
@@ -27,14 +31,7 @@ class DummyArgGetter : public ArgGetter {
         throw std::runtime_error("not implemented");
     }
     int64_t uahf;
-};
-
-// Workaround for segfaulting
-class Workaround {
-    public:
-    Workaround() {
-        SelectParams(CBaseChainParams::MAIN);
-    }
+    int64_t mayhf;
 };
 
 bool isActivating(const CBlockIndex& b) {
@@ -43,7 +40,7 @@ bool isActivating(const CBlockIndex& b) {
 
 } // ns anon
 
-BOOST_FIXTURE_TEST_SUITE(utilfork_tests, Workaround);
+BOOST_FIXTURE_TEST_SUITE(utilfork_tests, BasicTestingSetup);
 
 BOOST_AUTO_TEST_CASE(is_uahf_activating_block_at_genesis) {
 
@@ -113,6 +110,44 @@ BOOST_AUTO_TEST_CASE(is_uahf_activating_block_normal) {
     BOOST_CHECK(!isActivating(block2));
     BOOST_CHECK(!isActivating(block3));
     BOOST_CHECK(!isActivating(block4));
+}
+
+BOOST_AUTO_TEST_CASE(is_may2018hf_active) {
+    auto arg = new DummyArgGetter;
+    auto argraii = SetDummyArgGetter(std::unique_ptr<ArgGetter>(arg));
+
+    CBlockIndex genesis;
+    genesis.pprev = nullptr;
+    genesis.nTime = 11;
+
+    CBlockIndex block2;
+    block2.pprev = &genesis;
+    block2.nTime = 42;
+
+    CBlockIndex block3;
+    block3.pprev = &block2;
+    block3.nTime = 50;
+
+    CBlockIndex block4;
+    block4.pprev = &block3;
+    block4.nTime = 100;
+
+    arg->uahf = 1;
+    // Activation time is exactly mtp of block2.
+    // In this test block2 and block3 have the same mtp.
+    arg->mayhf = block2.GetMedianTimePast();
+
+    BOOST_CHECK(!IsMay2018HFActive(genesis.GetMedianTimePast()));
+    BOOST_CHECK(IsMay2018HFActive(block2.GetMedianTimePast()));
+    BOOST_CHECK(IsMay2018HFActive(block3.GetMedianTimePast()));
+    BOOST_CHECK(IsMay2018HFActive(block4.GetMedianTimePast()));
+
+    // Never active if mayhf is disabled.
+    arg->mayhf = 0;
+    BOOST_CHECK(!IsMay2018HFActive(genesis.GetMedianTimePast()));
+    BOOST_CHECK(!IsMay2018HFActive(block2.GetMedianTimePast()));
+    BOOST_CHECK(!IsMay2018HFActive(block3.GetMedianTimePast()));
+    BOOST_CHECK(!IsMay2018HFActive(block4.GetMedianTimePast()));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/utilfork.cpp
+++ b/src/utilfork.cpp
@@ -20,3 +20,12 @@ bool IsUAHFActivatingBlock(int64_t mtpCurrent, CBlockIndex* pindexPrev) {
 
     return pindexPrev->GetMedianTimePast() < Opt().UAHFTime();
 }
+
+bool IsMay2018HFActive(int64_t mtpChainTip) {
+    int64_t mtpHF = Opt().May2018HFTime();
+
+    if (!mtpHF)
+        return false;
+
+    return mtpChainTip >= mtpHF;
+}

--- a/src/utilfork.h
+++ b/src/utilfork.h
@@ -8,5 +8,6 @@
 class CBlockIndex;
 
 bool IsUAHFActivatingBlock(int64_t mtpCurrent, CBlockIndex* pindexPrev);
+bool IsMay2018HFActive(int64_t mtpChainTip);
 
 #endif


### PR DESCRIPTION
If we plan a release before implementing the changes in next [scheduled network upgrade](https://github.com/bitcoincashorg/spec/pull/53), this will make the node enter safe mode and warn the user of outdated software.