### PR TITLE
Introduce DummyArgGetter

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -122,3 +122,19 @@ std::unique_ptr<ArgReset> SetDummyArgGetter(std::unique_ptr<ArgGetter> getter) {
 ArgReset::~ArgReset() {
     Args.reset(new DefaultGetter());
 }
+
+bool DummyArgGetter::GetBool(const std::string& arg, bool def) {
+    return customArgs.count(arg) ? bool(customArgs[arg]) : def;
+}
+
+std::vector<std::string> DummyArgGetter::GetMultiArgs(const std::string&) {
+    assert(!"not supported");
+}
+
+int64_t DummyArgGetter::GetArg(const std::string& arg, int64_t def) {
+    return customArgs.count(arg) ? customArgs[arg] : def;
+}
+
+void DummyArgGetter::Set(const std::string& arg, int64_t val) {
+    customArgs[arg] = val;
+}

--- a/src/options.h
+++ b/src/options.h
@@ -7,25 +7,26 @@
 #include <string>
 #include <vector>
 
-struct Opt {
-    Opt();
+class Opt {
+    public:
+        Opt();
 
-    bool IsStealthMode();
-    bool HidePlatform();
-    std::vector<std::string> UAComment(bool validate = false);
-    int ScriptCheckThreads();
-    int64_t CheckpointDays();
-    uint64_t MaxBlockSizeVote();
-    int64_t UAHFTime() const;
-    int UAHFProtectSunset();
-    int64_t RespendRelayLimit() const;
-    bool UseCashAddr() const;
+        bool IsStealthMode();
+        bool HidePlatform();
+        std::vector<std::string> UAComment(bool validate = false);
+        int ScriptCheckThreads();
+        int64_t CheckpointDays();
+        uint64_t MaxBlockSizeVote();
+        int64_t UAHFTime() const;
+        int UAHFProtectSunset();
+        int64_t RespendRelayLimit() const;
+	bool UseCashAddr() const;
 
-    // Thin block options
-    bool UsingThinBlocks();
-    bool AvoidFullBlocks();
-    int ThinBlocksMaxParallel();
-    bool PreferXThinBlocks() const;
+        // Thin block options
+        bool UsingThinBlocks();
+        bool AvoidFullBlocks();
+        int ThinBlocksMaxParallel();
+        bool PreferXThinBlocks() const;
 };
 
 /** Maximum number of script-checking threads allowed */

--- a/src/qt/test/guiutiltests.cpp
+++ b/src/qt/test/guiutiltests.cpp
@@ -6,23 +6,6 @@
 #include "receiverequestdialog.h"
 #include "options.h"
 
-namespace {
-class DummyArgGetter : public ArgGetter {
-    public:
-        DummyArgGetter() : ArgGetter(), useCashAddr(false) { }
-        int64_t GetArg(const std::string& strArg, int64_t def) override {
-            return def;
-        }
-        std::vector<std::string> GetMultiArgs(const std::string& arg) override {
-            assert(false);
-        }
-        bool GetBool(const std::string& arg, bool def) override {
-            return arg == "-usecashaddr" ? useCashAddr : def;
-        }
-        bool useCashAddr;
-};
-} // ns anon
-
 void GUIUtilTests::toCurrentEncodingTest() {
 #ifdef ENABLE_WALLET //< receiverequestdialog is not compiled unless this is defined
     auto arg = new DummyArgGetter;
@@ -35,11 +18,11 @@ void GUIUtilTests::toCurrentEncodingTest() {
         "bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a";
     QString base58_pubkey = "1BpEi6DfDAUFd7GtittLSdBeYJvcoaVggu";
 
-    arg->useCashAddr = true;
+    arg->Set("-usecashaddr", 1);
     QVERIFY(ToCurrentEncoding(cashaddr_pubkey) == cashaddr_pubkey);
     QVERIFY(ToCurrentEncoding(base58_pubkey) == cashaddr_pubkey);
 
-    arg->useCashAddr = false;
+    arg->Set("-usecashaddr", 0);
     QVERIFY(ToCurrentEncoding(cashaddr_pubkey) == base58_pubkey);
     QVERIFY(ToCurrentEncoding(base58_pubkey) == base58_pubkey);
 #endif

--- a/src/qt/test/uritests.cpp
+++ b/src/qt/test/uritests.cpp
@@ -155,30 +155,12 @@ void URITests::uriTestsCashAddr() {
     QVERIFY(!GUIUtil::parseBitcoinURI(scheme, uri, &rv));
 }
 
-namespace {
-class DummyArgGetter : public ArgGetter {
-    public:
-        DummyArgGetter() : ArgGetter(), useCashAddr(false) { }
-        int64_t GetArg(const std::string& strArg, int64_t def) override {
-            return def;
-        }
-        std::vector<std::string> GetMultiArgs(const std::string& arg) override {
-            assert(false);
-        }
-        bool GetBool(const std::string& arg, bool def) override {
-            return arg == "-usecashaddr" ? useCashAddr : def;
-        }
-        bool useCashAddr;
-};
-
-} // anon ns
-
 void URITests::uriTestFormatURI() {
 
     auto arg = new DummyArgGetter;
     auto raii = SetDummyArgGetter(std::unique_ptr<ArgGetter>(arg));
     {
-        arg->useCashAddr = true;
+        arg->Set("-usecashaddr", 1);
         SendCoinsRecipient r;
         r.address = "bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a";
         r.message = "test";
@@ -188,7 +170,7 @@ void URITests::uriTestFormatURI() {
     }
 
     {
-        arg->useCashAddr = false;
+        arg->Set("-usecashaddr", 0);
         SendCoinsRecipient r;
         r.address = "175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W";
         r.message = "test";
@@ -203,14 +185,14 @@ void URITests::uriTestScheme() {
     auto raii = SetDummyArgGetter(std::unique_ptr<ArgGetter>(arg));
     {
         // cashaddr - scheme depends on selected chain params
-        arg->useCashAddr = true;
+        arg->Set("-usecashaddr", 1);
         QVERIFY("bitcoincash" == GUIUtil::bitcoinURIScheme(Params(CBaseChainParams::MAIN)));
         QVERIFY("bchtest" == GUIUtil::bitcoinURIScheme(Params(CBaseChainParams::TESTNET)));
         QVERIFY("bchreg" == GUIUtil::bitcoinURIScheme(Params(CBaseChainParams::REGTEST)));
     }
     {
         // legacy - scheme is "bitcoincash" regardless of chain params
-        arg->useCashAddr = false;
+        arg->Set("-usecashaddr", 0);
         QVERIFY("bitcoincash" == GUIUtil::bitcoinURIScheme(Params(CBaseChainParams::MAIN)));
         QVERIFY("bitcoincash" == GUIUtil::bitcoinURIScheme(Params(CBaseChainParams::TESTNET)));
         QVERIFY("bitcoincash" == GUIUtil::bitcoinURIScheme(Params(CBaseChainParams::REGTEST)));

--- a/src/test/chainparams_tests.cpp
+++ b/src/test/chainparams_tests.cpp
@@ -2,43 +2,25 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <boost/test/unit_test.hpp>
 #include "chainparams.h"
 #include "options.h"
+#include "test/test_bitcoin.h"
 
-namespace {
+#include <boost/test/unit_test.hpp>
 
-class OptDummy : public ArgGetter {
-    public:
-        OptDummy() : uahftime(0) { }
-        int64_t GetArg(const std::string& arg, int64_t def) override {
-            return arg == "-uahftime" ? uahftime : def;
-        }
-
-        bool GetBool(const std::string&, bool def) override
-        { return def; }
-
-        std::vector<std::string> GetMultiArgs(const std::string&) override
-        { return { }; }
-
-        int64_t uahftime;
-};
-
-} // anon ns
-
-BOOST_AUTO_TEST_SUITE(chainparams_tests);
+BOOST_FIXTURE_TEST_SUITE(chainparams_tests, BasicTestingSetup);
 
 BOOST_AUTO_TEST_CASE(check_network_magic) {
-    auto cfg = new OptDummy();
+    auto cfg = new DummyArgGetter;
     auto raii = SetDummyArgGetter(std::unique_ptr<ArgGetter>(cfg));
 
     // Should return BTC magic.
-    cfg->uahftime = 0;
+    cfg->Set("-uahftime", 0);
     auto magic = Params(CBaseChainParams::MAIN).NetworkMagic();
     BOOST_CHECK_EQUAL(0xf9, magic[0]);
 
     // Should return BCH magic.
-    cfg->uahftime = 42;
+    cfg->Set("-uahftime", 42);
     magic = Params(CBaseChainParams::MAIN).NetworkMagic();
     BOOST_CHECK_EQUAL(0xe3, magic[0]);
 }

--- a/src/test/clientversion_tests.cpp
+++ b/src/test/clientversion_tests.cpp
@@ -14,9 +14,9 @@
 
 BOOST_AUTO_TEST_SUITE(clientversion_tests)
 
-struct DummyArgGetter : public ArgGetter {
+struct CVArgGetter : public ArgGetter {
 
-    DummyArgGetter() : stealthmode(false), hideplatform(false)
+    CVArgGetter() : stealthmode(false), hideplatform(false)
     {
     }
 
@@ -55,10 +55,8 @@ bool OsInStr(const std::string& version) {
 
 BOOST_AUTO_TEST_CASE(platform_in_xtsubversion)
 {
-    std::unique_ptr<DummyArgGetter> arg(new DummyArgGetter);
-    DummyArgGetter* argPtr = arg.get();
-    std::unique_ptr<ArgReset> argraii
-        = SetDummyArgGetter(std::unique_ptr<ArgGetter>(arg.release()));
+    auto argPtr = new CVArgGetter;
+    auto argraii = SetDummyArgGetter(std::unique_ptr<ArgGetter>(argPtr));
 
     argPtr->hideplatform = true;
     argPtr->stealthmode = false;
@@ -77,10 +75,8 @@ BOOST_AUTO_TEST_CASE(platform_in_xtsubversion)
 
 BOOST_AUTO_TEST_CASE(xtsubversion_stealthmode)
 {
-    std::unique_ptr<DummyArgGetter> arg(new DummyArgGetter);
-    DummyArgGetter* argPtr = arg.get();
-    std::unique_ptr<ArgReset> argraii
-        = SetDummyArgGetter(std::unique_ptr<ArgGetter>(arg.release()));
+    auto argPtr = new CVArgGetter;
+    auto argraii = SetDummyArgGetter(std::unique_ptr<ArgGetter>(argPtr));
 
     argPtr->stealthmode = true;
     BOOST_CHECK(XTSubVersion(0).find("XT") == std::string::npos);
@@ -91,10 +87,8 @@ BOOST_AUTO_TEST_CASE(xtsubversion_stealthmode)
 
 BOOST_AUTO_TEST_CASE(xtsubversion_uacomment)
 {
-    std::unique_ptr<DummyArgGetter> arg(new DummyArgGetter);
-    DummyArgGetter* argPtr = arg.get();
-    std::unique_ptr<ArgReset> argraii
-        = SetDummyArgGetter(std::unique_ptr<ArgGetter>(arg.release()));
+    auto argPtr = new CVArgGetter;
+    auto argraii = SetDummyArgGetter(std::unique_ptr<ArgGetter>(argPtr));
 
     argPtr->hideplatform = true;
 
@@ -127,4 +121,3 @@ BOOST_AUTO_TEST_CASE(xtsubversion_eb)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-

--- a/src/test/dstencode_tests.cpp
+++ b/src/test/dstencode_tests.cpp
@@ -9,25 +9,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-namespace {
-
-class DummyArgGetter : public ArgGetter {
-    public:
-        DummyArgGetter() : ArgGetter(), useCashAddr(false) { }
-        int64_t GetArg(const std::string& strArg, int64_t def) override {
-            return def;
-        }
-        std::vector<std::string> GetMultiArgs(const std::string& arg) override {
-            assert(false);
-        }
-        bool GetBool(const std::string& arg, bool def) override {
-            return arg == "-usecashaddr" ? useCashAddr : def;
-        }
-        bool useCashAddr;
-};
-
-} // anon ns
-
 BOOST_FIXTURE_TEST_SUITE(dstencode_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(test_addresses) {
@@ -50,10 +31,10 @@ BOOST_AUTO_TEST_CASE(test_addresses) {
     auto raii = SetDummyArgGetter(std::unique_ptr<ArgGetter>(arg));
 
     // Check encoding
-    arg->useCashAddr = true;
+    arg->Set("-usecashaddr", 1);
     BOOST_CHECK_EQUAL(cashaddr_pubkey, EncodeDestination(dstKey, params));
     BOOST_CHECK_EQUAL(cashaddr_script, EncodeDestination(dstScript, params));
-    arg->useCashAddr = false;
+    arg->Set("-usecashaddr", 0);
     BOOST_CHECK_EQUAL(base58_pubkey, EncodeDestination(dstKey, params));
     BOOST_CHECK_EQUAL(base58_script, EncodeDestination(dstScript, params));
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -398,19 +398,9 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_bip100str)
     BOOST_CHECK(c.find("/BIP100/EB1/") != std::string::npos);
     BOOST_CHECK(c.find("/B1/") == std::string::npos);
 
-    // Vote for 16MB blocks (using -maxblocksizevote)
-    struct Dummy : public ArgGetter {
-        int64_t GetArg(const std::string& arg, int64_t def) override {
-            return arg == "-maxblocksizevote" ? 16 : def;
-        }
-
-        bool GetBool(const std::string&, bool def) override
-        { return def; }
-
-        std::vector<std::string> GetMultiArgs(const std::string&) override
-        { return { }; }
-    };
-    auto reset = SetDummyArgGetter(std::unique_ptr<ArgGetter>(new Dummy));
+    auto arg = new DummyArgGetter;
+    auto argraii = SetDummyArgGetter(std::unique_ptr<ArgGetter>(arg));
+    arg->Set("-maxblocksizevote", 16);
 
     c = DefaultCoinbaseStr();
     BOOST_CHECK(c.find("/BIP100/B16/EB1/") != std::string::npos);

--- a/src/test/options_tests.cpp
+++ b/src/test/options_tests.cpp
@@ -7,71 +7,41 @@
 #include "options.h"
 #include <limits.h>
 
-const int NOT_SET = std::numeric_limits<int>::min();
-
-struct DummyArgGetter : public ArgGetter {
-
-    DummyArgGetter() : ArgGetter(),
-        par(NOT_SET), checkpdays(NOT_SET)
-    {
-    }
-
-    virtual int64_t GetArg(const std::string& strArg, int64_t nDefault) {
-        if (strArg == "-par")
-            return par == NOT_SET ? nDefault : par;
-
-        if (strArg == "-checkpoint-days")
-            return checkpdays == NOT_SET ? nDefault : checkpdays;
-
-        assert(false);
-    }
-    virtual std::vector<std::string> GetMultiArgs(const std::string& arg) {
-        assert(false);
-    }
-    virtual bool GetBool(const std::string& arg, bool def) {
-        assert(false);
-    }
-    int par;
-    int checkpdays;
-};
-
 BOOST_AUTO_TEST_SUITE(options_tests);
 
 BOOST_AUTO_TEST_CASE(scripthreads) {
-    std::unique_ptr<DummyArgGetter> arg(new DummyArgGetter);
-    DummyArgGetter* argPtr = arg.get();
-    std::unique_ptr<ArgReset> argraii
-        = SetDummyArgGetter(std::unique_ptr<ArgGetter>(arg.release()));
+    auto arg = new DummyArgGetter;
+    auto argraii = SetDummyArgGetter(std::unique_ptr<ArgGetter>(arg));
 
-    argPtr->par = 1; // not threaded
+    // not threaded
+    arg->Set("-par", 1);
     BOOST_CHECK_EQUAL(0, Opt().ScriptCheckThreads());
 
-    argPtr->par = 3; // 3 threads
+    // 3 threads
+    arg->Set("-par", 3);
     BOOST_CHECK_EQUAL(3, Opt().ScriptCheckThreads());
 
     // auto case not tested
 }
 
 BOOST_AUTO_TEST_CASE(checkpointdays) {
-    std::unique_ptr<DummyArgGetter> arg(new DummyArgGetter);
-    DummyArgGetter* argPtr = arg.get();
-    std::unique_ptr<ArgReset> argraii
-        = SetDummyArgGetter(std::unique_ptr<ArgGetter>(arg.release()));
+    auto arg = new DummyArgGetter;
+    auto argraii = SetDummyArgGetter(std::unique_ptr<ArgGetter>(arg));
 
     // No multiplier
-    argPtr->par = 1;
+    arg->Set("-par", 1);
     BOOST_CHECK_EQUAL(DEFAULT_CHECKPOINT_DAYS, Opt().CheckpointDays());
 
     // x3 multiplier (3 script threads)
-    argPtr->par = 3;
+    arg->Set("-par", 3);
     BOOST_CHECK_EQUAL(3 * DEFAULT_CHECKPOINT_DAYS, Opt().CheckpointDays());
 
     // Explicitly set days overrides default and multipliers
-    argPtr->checkpdays = 1;
+    arg->Set("-checkpoint-days", 1);
     BOOST_CHECK_EQUAL(1, Opt().CheckpointDays());
 
      // Can't have less than 1 day
-    argPtr->checkpdays = 0;
+    arg->Set("-checkpoint-days", 0);
     BOOST_CHECK_EQUAL(1, Opt().CheckpointDays());
 }
 

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -267,19 +267,10 @@ BOOST_AUTO_TEST_CASE(rpc_getblocktemplate_vote)
     BOOST_CHECK(f.find("/BIP100/EB1/") != std::string::npos);
     BOOST_CHECK(f.find("/B1/") == std::string::npos);
 
-    // Vote for 16MB blocks (using -maxblocksizevote)
-    struct Dummy : public ArgGetter {
-        int64_t GetArg(const std::string& arg, int64_t def) override {
-            return arg == "-maxblocksizevote" ? 16 : def;
-        }
-
-        bool GetBool(const std::string&, bool def) override
-        { return def; }
-
-        std::vector<std::string> GetMultiArgs(const std::string&) override
-        { return { }; }
-    };
-    auto reset = SetDummyArgGetter(std::unique_ptr<ArgGetter>(new Dummy));
+    // Vote for 16MB blocks
+    auto arg = new DummyArgGetter;
+    auto argraii = SetDummyArgGetter(std::unique_ptr<ArgGetter>(arg));
+    arg->Set("-maxblocksizevote", 16);
 
     UniValue hasVote = CallRPC("getblocktemplate");
     f = get_coinbaseaux_flags(hasVote);


### PR DESCRIPTION
This removes the need to implement a custom DummyArgGetter when overriding options in unittests.

Also turned Opt into a class (instead of struct)