### PR TITLE
Terminate immediately when allocation fails

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -37,7 +37,7 @@ LIBUNIVALUE=univalue/libunivalue.la
 
 $(LIBSECP256K1): $(wildcard secp256k1/src/*) $(wildcard secp256k1/include/*)
 	$(AM_V_at)$(MAKE) $(AM_MAKEFLAGS) -C $(@D) $(@F)
-  
+
 $(LIBUNIVALUE): $(wildcard univalue/lib/*)
 	$(AM_V_at)$(MAKE) $(AM_MAKEFLAGS) -C univalue/
 
@@ -182,11 +182,12 @@ BITCOIN_CORE_H = \
   uint256.h \
   undo.h \
   util.h \
+  utildebug.h \
+  utilfork.h \
   utilmoneystr.h \
+  utilprocessmsg.h \
   utilstrencodings.h \
   utiltime.h \
-  utilprocessmsg.h \
-  utilfork.h \
   validationinterface.h \
   version.h \
   versionbits.h \
@@ -259,8 +260,9 @@ libbitcoin_server_a_SOURCES = \
   timedata.cpp \
   txdb.cpp \
   txmempool.cpp \
-  utilprocessmsg.cpp \
+  utildebug.cpp \
   utilfork.cpp \
+  utilprocessmsg.cpp \
   validationinterface.cpp \
   xthin.cpp \
   versionbits.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -643,6 +643,19 @@ bool AppInitServers(boost::thread_group& threadGroup)
     return true;
 }
 
+[[noreturn]] static void new_handler_terminate()
+{
+    // Rather than throwing std::bad-alloc if allocation fails, terminate
+    // immediately to (try to) avoid chain corruption.
+    // Since LogPrintf may itself allocate memory, set the handler directly
+    // to terminate first.
+    std::set_new_handler(std::terminate);
+    LogPrintf("Error: Out of memory. Terminating.\n");
+
+    // The log was successful, terminate now.
+    std::terminate();
+};
+
 /** Initialize bitcoin.
  *  @pre Parameters should be parsed and config file should be read.
  */
@@ -1519,6 +1532,8 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         threadGroup.create_thread(boost::bind(&ThreadFlushWalletDB, boost::ref(pwalletMain->strWalletFile)));
     }
 #endif
+
+    std::set_new_handler(new_handler_terminate);
 
     return !fRequestShutdown;
 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -28,6 +28,7 @@
 #include "txdb.h"
 #include "ui_interface.h"
 #include "util.h"
+#include "utildebug.h"
 #include "utilmoneystr.h"
 #include "validationinterface.h"
 #ifdef ENABLE_WALLET
@@ -652,7 +653,8 @@ bool AppInitServers(boost::thread_group& threadGroup)
     std::set_new_handler(std::terminate);
     LogPrintf("Error: Out of memory. Terminating.\n");
 
-    // The log was successful, terminate now.
+    dump_backtrace_stderr();
+
     std::terminate();
 };
 

--- a/src/utildebug.cpp
+++ b/src/utildebug.cpp
@@ -1,0 +1,28 @@
+#include "utildebug.h"
+
+#ifdef __linux__
+#include <execinfo.h>
+#include <unistd.h>
+#endif
+#include <iostream>
+
+void dump_backtrace_stderr() {
+#ifdef __linux__
+    void* trace[100];
+    int nptrs = backtrace(trace, 100);
+    fprintf(stderr, "\nBacktrace dump:\n");
+    backtrace_symbols_fd(trace, nptrs, STDERR_FILENO);
+
+    std::cerr << std::endl
+              << "To translate addresses to symbols, start GDB (gdb ./bitcoind)\n"
+              << "Then call 'info symbol <address>'\n"
+              << "Example stacktrace:\n"
+              << "\t./bitcoind(+0x39ae5)[0x56140c19dae5]\n"
+              << "Example GDB output:\n"
+              << "\t(gdb) info symbol +0x39ae5\n"
+              << "\tAppInit(int, char**) + 2568 in section .text\n"
+              << std::endl;
+#else
+    std::cerr << "Backtrace not available on this platform" << std::endl;
+#endif
+}

--- a/src/utildebug.h
+++ b/src/utildebug.h
@@ -1,0 +1,6 @@
+#ifndef BITCOIN_UTILDEBUG_H
+#define BITCOIN_UTILDEBUG_H
+
+void dump_backtrace_stderr();
+
+#endif


### PR DESCRIPTION
This includes c5f008a from https://github.com/bitcoin/bitcoin/pull/9856

In addition, to be able to debug cause of OOM, I've made the OOM handler dump a backtrace.

Example output:
```
$ ./bitcoind 

Backtrace dump:
./bitcoind(+0x35cc38)[0x5654c1282c38]
./bitcoind(+0x61469)[0x5654c0f87469]
/usr/lib/x86_64-linux-gnu/libstdc++.so.6(_Znwm+0x2c)[0x7f927a36a46c]
./bitcoind(+0x6a9fc)[0x5654c0f909fc]
./bitcoind(+0x39b05)[0x5654c0f5fb05]
./bitcoind(+0x3a092)[0x5654c0f60092]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf1)[0x7f927978f1c1]
./bitcoind(+0x38faa)[0x5654c0f5efaa]

To translate addresses to symbols, start GDB (gdb ./bitcoind)
Then call 'info symbol <address>'
Example stacktrace:
	./bitcoind(+0x39ae5)[0x56140c19dae5]
Example GDB output:
	(gdb) info symbol +0x39ae5
	AppInit(int, char**) + 2568 in section .text
```

Tested by adding this code snippet after call to std::set_new_handler
```
try {
    while (true) {
    new int[100000000ul];
}
} catch (const std::bad_alloc& e) {
    std::cout << e.what() << '\n';
}

```
