### PR TITLE
Add verbose flag to rpc-tests

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -228,9 +228,12 @@ class RPCTestHandler:
             self.num_running += 1
             t = self.test_list.pop(0)
             port_seed = ["--portseed=%s" % len(self.test_list)]
+            cmd = (RPC_TESTS_DIR + t).split() + self.flags + port_seed
+            if '-v' in opts:
+                print("Run: %s" % " ".join(cmd))
             self.jobs.append((t,
                               time.time(),
-                              subprocess.Popen((RPC_TESTS_DIR + t).split() + self.flags + port_seed,
+                              subprocess.Popen(cmd,
                                                universal_newlines=True,
                                                stdout=subprocess.PIPE,
                                                stderr=subprocess.PIPE)))


### PR DESCRIPTION
-v for verbose, outputs the command called to run each test script

Useful to find the parameters needed to debug a rpc test.

```
dagurval@dev:~/bitcoinxt$ ./qa/pull-tester/rpc-tests.py -v pruning
Run: /home/dagurval/bitcoinxt/qa/rpc-tests/pruning.py --srcdir=/home/dagurval/bitcoinxt/src --portseed=0
```