### PR TITLE
Improve handling of block announcements

### DIFF
--- a/src/blockannounce.cpp
+++ b/src/blockannounce.cpp
@@ -57,13 +57,18 @@ BlockAnnounceReceiver::DownloadStrategy BlockAnnounceReceiver::pickDownloadStrat
     if (hasBlockData())
         return DONT_DOWNL;
 
+    NodeStatePtr nodestate(from.id);
+    // Peer has an unresolved unconnecting header situation, requesting new
+    // blocks may cause yet another unconnecting header to arrive.
+    if (nodestate->unconnectingHeaders)
+        return DONT_DOWNL;
+
+    if (nodestate->nBlocksInFlight >= MAX_BLOCKS_IN_TRANSIT_PER_PEER)
+        return DONT_DOWNL;
+
     if (!fetchAsThin()) {
 
         if (blocksInFlight.isInFlight(block))
-            return DONT_DOWNL;
-
-        NodeStatePtr nodestate(from.id);
-        if (nodestate->nBlocksInFlight >= MAX_BLOCKS_IN_TRANSIT_PER_PEER)
             return DONT_DOWNL;
 
         if (Opt().AvoidFullBlocks()) {

--- a/src/blockheaderprocessor.h
+++ b/src/blockheaderprocessor.h
@@ -23,7 +23,8 @@ class BlockHeaderProcessor {
                 bool peerSentMax,
                 bool maybeAnnouncement) = 0;
         virtual ~BlockHeaderProcessor() = 0;
-        virtual bool requestConnectHeaders(const CBlockHeader& h, CNode& from) = 0;
+        virtual bool requestConnectHeaders(const CBlockHeader& h, CNode& from,
+                                           bool bumpUnconnecting) = 0;
 };
 inline BlockHeaderProcessor::~BlockHeaderProcessor() { }
 
@@ -39,7 +40,8 @@ class DefaultHeaderProcessor : public BlockHeaderProcessor {
                 bool peerSentMax,
                 bool maybeAnnouncement) override;
 
-        bool requestConnectHeaders(const CBlockHeader& h, CNode& from) override;
+        bool requestConnectHeaders(const CBlockHeader& h, CNode& from,
+                                   bool bumpUnconnecting) override;
 
     protected:
          CBlockIndex* acceptHeaders(

--- a/src/blockprocessor.cpp
+++ b/src/blockprocessor.cpp
@@ -78,8 +78,8 @@ bool BlockProcessor::setToWork(const CBlockHeader& header, int activeChainHeight
     }
 }
 
-bool BlockProcessor::requestConnectHeaders(const CBlockHeader& header) {
-    bool needPrevHeaders = headerProcessor.requestConnectHeaders(header, from);
+bool BlockProcessor::requestConnectHeaders(const CBlockHeader& header, bool bumpUnconnecting) {
+    bool needPrevHeaders = headerProcessor.requestConnectHeaders(header, from, bumpUnconnecting);
 
     if (needPrevHeaders) {
         // We don't have previous block. We can't connect it to the chain.

--- a/src/blockprocessor.h
+++ b/src/blockprocessor.h
@@ -26,7 +26,7 @@ class BlockProcessor {
         CNode& from;
         ThinBlockWorker& worker;
         virtual void misbehave(int howmuch, const std::string& what);
-        bool requestConnectHeaders(const CBlockHeader&);
+        bool requestConnectHeaders(const CBlockHeader&, bool bumpUnconnecting);
         CBlockIndex* processHeader(const CBlockHeader& header, bool maybeAnnouncement);
 
     private:

--- a/src/compactblockprocessor.cpp
+++ b/src/compactblockprocessor.cpp
@@ -29,7 +29,11 @@ void CompactBlockProcessor::operator()(CDataStream& vRecv, const CTxMemPool& mem
         return;
     }
 
-    if (requestConnectHeaders(block.header)) {
+    // We (may) have requested node to announce blocks to us and it will
+    // continue to do so even if we haven't kept up. Don't misbehave it for
+    // sending us unconnected headers.
+    bool bumpUnconnecting = false;
+    if (requestConnectHeaders(block.header, bumpUnconnecting)) {
         worker.stopWork(hash);
         return;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -320,6 +320,10 @@ struct MarkBlockAsInFlight : public BlockInFlightMarker {
         nQueuedValidatedHeaders += newentry.fValidatedHeaders;
         list<QueuedBlock>::iterator it = state->vBlocksInFlight.insert(state->vBlocksInFlight.end(), newentry);
         state->nBlocksInFlight++;
+        if (state->nBlocksInFlight > MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
+            LogPrintf("Warning: Too many blocks in flight (%d of max %d) for peer=%d\n",
+                      state->nBlocksInFlight, MAX_BLOCKS_IN_TRANSIT_PER_PEER, nodeid);
+        }
         state->nBlocksInFlightValidHeaders += newentry.fValidatedHeaders;
         blocksInFlight.insert(it);
     };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5422,10 +5422,11 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv,
         MarkBlockAsInFlight inFlight;
         DefaultHeaderProcessor p(pfrom, blocksInFlight, thinblockmg, inFlight, CheckBlockIndex);
 
-        if (p.requestConnectHeaders(headers.at(0), *pfrom))
+        if (p.requestConnectHeaders(headers.at(0), *pfrom, true)) {
             // headers don't connect to active chain, requested
             // new headers to connect.
             return true;
+        }
 
         try {
             p(headers, nCount == MAX_HEADERS_RESULTS, true);
@@ -5487,7 +5488,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv,
         MarkBlockAsInFlight inFlight;
         DefaultHeaderProcessor p(pfrom, blocksInFlight, thinblockmg, inFlight, CheckBlockIndex);
 
-        if (p.requestConnectHeaders(block.GetBlockHeader(), *pfrom)) {
+        if (p.requestConnectHeaders(block.GetBlockHeader(), *pfrom, true)) {
             LogPrintf("Received block %s from peer=%d, but headers do "
                     "not connect. Discarding.\n",
                     inv.hash.ToString(), pfrom->id);

--- a/src/process_xthinblock.cpp
+++ b/src/process_xthinblock.cpp
@@ -31,7 +31,7 @@ void XThinBlockProcessor::operator()(
         return;
     }
 
-    if (requestConnectHeaders(block.header)) {
+    if (requestConnectHeaders(block.header, true)) {
         worker.stopWork(hash);
         return;
     }
@@ -70,4 +70,3 @@ void XThinBlockProcessor::operator()(
 
     from.PushMessage("get_xblocktx", req);
 }
-

--- a/src/test/blockannounce_tests.cpp
+++ b/src/test/blockannounce_tests.cpp
@@ -220,6 +220,19 @@ BOOST_AUTO_TEST_CASE(dowl_strategy_dont_dowl_5) {
             ann.pickDownloadStrategy());
 }
 
+BOOST_AUTO_TEST_CASE(dowl_strategy_dont_dowl_6) {
+
+    // Don't download a block from a peer if there are unconnecting headers
+
+    nodestate->unconnectingHeaders = 1;
+    BOOST_CHECK_EQUAL(BlockAnnounceReceiver::DONT_DOWNL,
+            ann.pickDownloadStrategy());
+
+    nodestate->unconnectingHeaders = 0;
+    BOOST_CHECK_EQUAL(BlockAnnounceReceiver::DOWNL_FULL_NOW,
+            ann.pickDownloadStrategy());
+}
+
 /// Helper class to check if request block is called.
 struct RequestBlockWorker : public DummyThinWorker {
     RequestBlockWorker(ThinBlockManager& mg, NodeId id)

--- a/src/test/blockannounce_tests.cpp
+++ b/src/test/blockannounce_tests.cpp
@@ -259,9 +259,8 @@ BOOST_AUTO_TEST_CASE(onannounced_downl_thin) {
     BOOST_CHECK(ann.onBlockAnnounced(r));
     BOOST_CHECK_EQUAL(1, worker->reqs);
 
-    // thin blocks come with a header, we should not
-    // have requested headers.
-    BOOST_CHECK_EQUAL(size_t(0), node.messages.size());
+    // we should request headers also, to avoid unconnected headers
+    BOOST_CHECK_EQUAL("getheaders", node.messages.at(0));
 }
 
 BOOST_AUTO_TEST_CASE(onannounced_downl_full) {

--- a/src/test/blockheaderprocessor_tests.cpp
+++ b/src/test/blockheaderprocessor_tests.cpp
@@ -29,17 +29,21 @@ BOOST_AUTO_TEST_CASE(test_connect_chain_req) {
 
     DefaultHeaderProcessor p(&from, inFlight, *thinmg, markAsInFlight, checkBlockIndex);
 
-    BOOST_CHECK(p.requestConnectHeaders(header, from));
+    BOOST_CHECK(p.requestConnectHeaders(header, from, true));
     BOOST_CHECK_EQUAL(1, NodeStatePtr(from.id)->unconnectingHeaders);
     BOOST_CHECK_EQUAL(size_t(1), from.messages.size());
     BOOST_CHECK_EQUAL("getheaders", from.messages.at(0));
+
+    // Test that unconnecting headers isn't bumped when requested not to
+    BOOST_CHECK(p.requestConnectHeaders(header, from, false));
+    BOOST_CHECK_EQUAL(1 /* no change */, NodeStatePtr(from.id)->unconnectingHeaders);
 
     // Add entry so that header connects. Try again.
 
     DummyBlockIndexEntry e3(header.hashPrevBlock);
 
     from.messages.clear();
-    BOOST_CHECK(!p.requestConnectHeaders(header, from));
+    BOOST_CHECK(!p.requestConnectHeaders(header, from, true));
     BOOST_CHECK_EQUAL(size_t(0), from.messages.size());
     BOOST_CHECK_EQUAL(1 /* no change */, NodeStatePtr(from.id)->unconnectingHeaders);
 }

--- a/src/test/compactblockprocessor_tests.cpp
+++ b/src/test/compactblockprocessor_tests.cpp
@@ -22,7 +22,7 @@ struct CmpctDummyHeaderProcessor : public BlockHeaderProcessor {
         index.nHeight = 2;
         return &index;
     }
-    bool requestConnectHeaders(const CBlockHeader& h, CNode& from) override {
+    bool requestConnectHeaders(const CBlockHeader& h, CNode& from, bool) override {
         return reqConnHeadResp;
     }
     bool reqConnHeadResp;

--- a/src/test/processmessage_tests.cpp
+++ b/src/test/processmessage_tests.cpp
@@ -46,7 +46,7 @@ struct DummyHeaderProcessor : public BlockHeaderProcessor {
         index.nHeight = 2;
         return &index;
     }
-    bool requestConnectHeaders(const CBlockHeader& h, CNode& from) override {
+    bool requestConnectHeaders(const CBlockHeader& h, CNode& from, bool) override {
         return false;
     }
     bool headerOK;

--- a/src/test/processmessage_tests.cpp
+++ b/src/test/processmessage_tests.cpp
@@ -82,7 +82,7 @@ struct DummyXThinProcessor : public XThinBlockProcessor {
         BlockHeaderProcessor& h) : XThinBlockProcessor(f, w, h), misbehaved(0)
     { }
 
-    virtual void misbehave(int howmuch) {
+    void misbehave(int howmuch, const std::string&) override {
         misbehaved += howmuch;
     }
     int misbehaved;


### PR DESCRIPTION
The first commit is a bugfix where we would exceed MAX_BLOCKS_IN_TRANSIT_PER_PEER. The second commit mitigates having us misbehave nodes for sending unconnected headers. See commit description for details.