### PR TITLE
add acceptnonstdtxn flag

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -69,7 +69,7 @@ const CMessageHeader::MessageStartChars& CChainParams::DBMagic() const {
 bool CChainParams::RequireStandard() const {
     // the acceptnonstdtxn flag can only be used to narrow the behavior.
     // A blockchain whose default is to allow nonstandard txns can be configured to disallow them.
-    return fRequireStandard || !GetArg("-acceptnonstdtxn", true);
+    return fRequireStandard || !GetBoolArg("-acceptnonstdtxn", true);
 }
 
 /**

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -66,6 +66,12 @@ const CMessageHeader::MessageStartChars& CChainParams::DBMagic() const {
     return pchMessageStart;
 }
 
+bool CChainParams::RequireStandard() const {
+    // the acceptnonstdtxn flag can only be used to narrow the behavior.
+    // A blockchain whose default is to allow nonstandard txns can be configured to disallow them.
+    return fRequireStandard || !GetArg("-acceptnonstdtxn", true);
+}
+
 /**
  * Main network
  */

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -65,7 +65,7 @@ public:
     /** Default value for -checkmempool and -checkblockindex argument */
     bool DefaultConsistencyChecks() const { return fDefaultConsistencyChecks; }
     /** Policy: Filter transactions that do not match well-defined patterns */
-    bool RequireStandard() const { return fRequireStandard; }
+    bool RequireStandard() const;
     int64_t PruneAfterHeight() const { return nPruneAfterHeight; }
     /** Minimum number of max-sized blocks in blk?????.dat files */
     int64_t MinBlockFileBlocks() const { return nMinBlockfileBlocks; }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -902,6 +902,12 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
             return InitError(strprintf(_("Invalid amount for -minrelaytxfee=<amount>: '%s'"), mapArgs["-minrelaytxfee"]));
     }
 
+    bool fStandard = !GetBoolArg("-acceptnonstdtxn", !Params().RequireStandard());
+    // If we specified an override but that override was not accepted then its an error
+    if (fStandard != Params().RequireStandard())
+        return InitError(
+            strprintf("acceptnonstdtxn is not currently supported for %s chain", chainparams.NetworkIDString()));
+
 #ifdef ENABLE_WALLET
     if (mapArgs.count("-mintxfee"))
     {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -439,7 +439,8 @@ std::string HelpMessage(HelpMessageMode mode)
 
     strUsage += HelpMessageGroup(_("Node relay options:"));
     strUsage += HelpMessageOpt("-datacarrier", strprintf(_("Relay and mine data carrier transactions (default: %u)"), 1));
-    strUsage += HelpMessageOpt("-datacarriersize", strprintf(_("Maximum size of data in data carrier transactions we relay and mine (default: %u)"), MAX_OP_RETURN_RELAY));
+    strUsage += HelpMessageOpt("-datacarriersize=<n>", strprintf(_("Maximum size of data in data carrier transactions we relay and mine (default: %u)"), MAX_OP_RETURN_RELAY));
+    strUsage += HelpMessageOpt("-acceptnonstdtxn", "testnet/regtest only: Relay and mine \"non-standard\" transactions (default: 1)");
 
     strUsage += HelpMessageGroup(_("Block creation options:"));
     strUsage += HelpMessageOpt("-blockmaxsize=<n>", _("Set maximum block size in bytes (default: network sizelimit)"));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -906,7 +906,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     // If we specified an override but that override was not accepted then its an error
     if (fStandard != Params().RequireStandard())
         return InitError(
-            strprintf("acceptnonstdtxn is not currently supported for %s chain", chainparams.NetworkIDString()));
+            strprintf("-acceptnonstdtxn is not currently supported for %s chain", chainparams.NetworkIDString()));
 
 #ifdef ENABLE_WALLET
     if (mapArgs.count("-mintxfee"))


### PR DESCRIPTION
This flag (when set to 0) makes testnet and regtest behave like mainnet by rejecting nonstandard transactions.  The flag name and behavior is awkwardly chosen to be compatible with other Satoshi clients.

Also I fixed a small issue in the description of datacarriersize.