### PR TITLE
Add BCH checkpoint

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -174,11 +174,12 @@ public:
             (225430, uint256S("0x00000000000001c108384350f74090433e7fcf79a606b8e797f065b130575932"))
             (250000, uint256S("0x000000000000003887df1f29024b06fc2200b55f8af8f35453d7be294df2d214"))
             (279000, uint256S("0x0000000000000001ae8c72a0b0c301f67e3afca10e819efa9041e458e9bd7e40"))
-            (295000, uint256S("0x00000000000000004d9b4ef50f0f9d686fd69db2e03af35a100370c64632a983")),
-            1397080064, // * UNIX timestamp of last checkpoint block
-            36544669,   // * total number of transactions between genesis and last checkpoint
+            (295000, uint256S("0x00000000000000004d9b4ef50f0f9d686fd69db2e03af35a100370c64632a983"))
+            (478559, uint256S("0x000000000000000000651ef99cb9fcbe0dadde1d424bd9f15ff20136191a5eec")),
+            1501611161, // * UNIX timestamp of last checkpoint block
+            243283753,  // * total number of transactions between genesis and last checkpoint
                         //   (the tx=... number in the SetBestChain debug.log lines)
-            60000.0     // * estimated number of transactions per day after checkpoint
+            33521.0     // * estimated number of transactions per day after checkpoint
         };
     }
 };

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -875,6 +875,10 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     }
     fCheckBlockIndex = GetBoolArg("-checkblockindex", chainparams.DefaultConsistencyChecks());
     fCheckpointsEnabled = GetBoolArg("-checkpoints", true);
+    if (fCheckpointsEnabled && !Opt().UAHFTime()) {
+        InitWarning(_("Warning: checkpoints are not supported on the BTC chain."));
+        fCheckpointsEnabled = false;
+    }
 
     // -mempoollimit limits
     int64_t nMempoolSizeLimit = GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;


### PR DESCRIPTION
Checkpoint the BCH fork block and dedicate checkpoint support to the BCH fork.

Issue a warning when launching in BTC mode that checkpoints are not supported.

BCH tx/day was calculated as follows:
```
blocks: 525751 - 478559 = 47192
tx: 248776463 - 243283753 = 5492710
5492710 / 47192 = 116.39 tx/block
*144 = 16760 tx/day
*2 = 33521 allow for 2x overall average growth before next checkpoint
```

