### PR TITLE
Divergence between 32- and 64-bit when hashing >4GB affects `gettxoutsetinfo`

### DIFF
--- a/src/crypto/ripemd160.h
+++ b/src/crypto/ripemd160.h
@@ -14,7 +14,7 @@ class CRIPEMD160
 private:
     uint32_t s[5];
     unsigned char buf[64];
-    size_t bytes;
+    uint64_t bytes;
 
 public:
     static const size_t OUTPUT_SIZE = 20;

--- a/src/crypto/sha1.h
+++ b/src/crypto/sha1.h
@@ -14,7 +14,7 @@ class CSHA1
 private:
     uint32_t s[5];
     unsigned char buf[64];
-    size_t bytes;
+    uint64_t bytes;
 
 public:
     static const size_t OUTPUT_SIZE = 20;

--- a/src/crypto/sha256.h
+++ b/src/crypto/sha256.h
@@ -14,7 +14,7 @@ class CSHA256
 private:
     uint32_t s[8];
     unsigned char buf[64];
-    size_t bytes;
+    uint64_t bytes;
 
 public:
     static const size_t OUTPUT_SIZE = 32;

--- a/src/crypto/sha512.h
+++ b/src/crypto/sha512.h
@@ -14,7 +14,7 @@ class CSHA512
 private:
     uint64_t s[8];
     unsigned char buf[128];
-    size_t bytes;
+    uint64_t bytes;
 
 public:
     static const size_t OUTPUT_SIZE = 64;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -463,6 +463,7 @@ static bool GetUTXOStats(CCoinsView *view, CCoinsStats &stats)
         CCoins coins;
         if (pcursor->GetKey(key) && pcursor->GetValue(coins)) {
             stats.nTransactions++;
+            ss << key;
             for (unsigned int i=0; i<coins.vout.size(); i++) {
                 const CTxOut &out = coins.vout[i];
                 if (!out.IsNull()) {


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/pull/7848

Skipped the release-notes commit when cherry-picking.