### PR TITLE
[doc] Replace dependency libcurl4-openssl-dev with libcurl4-gnutls-dev

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -59,7 +59,7 @@ Dependency Build Instructions: Ubuntu & Debian
 ----------------------------------------------
 Build requirements:
 
-	sudo apt-get install build-essential libtool autotools-dev autoconf pkg-config libssl-dev libcurl4-openssl-dev libevent-dev
+	sudo apt-get install build-essential libtool autotools-dev autoconf pkg-config libssl-dev libcurl4-gnutls-dev libevent-dev
 
 for Ubuntu 12.04 and later or Debian 7 and later libboost-all-dev has to be installed:
 


### PR DESCRIPTION
libcurl4-openssl-dev requires libssl 1.0, but is happy to link with
libssl 1.1 on debian systems, resulting in a segfault.

Workaround problem by using libcurl4-gnutls-dev

fixes #382 