### PR TITLE
Replace BCC ticker with BCH in debian package

### DIFF
--- a/contrib/gitian-debian/postinst
+++ b/contrib/gitian-debian/postinst
@@ -57,8 +57,8 @@ if [ "$RET" = "Bitcoin (BTC)" ]; then
 else
     if grep -q '^uahftime' $BITCOIN_CONF; then
         sed -i 's/^uahftime.*//' $BITCOIN_CONF
-        echo "BCC selected: Removing uahftime from $BITCOIN_CONF"
+        echo "BCH selected: Removing uahftime from $BITCOIN_CONF"
     else
-        echo "BCC selected: No configuration change needed."
+        echo "BCH selected: No configuration change needed."
     fi;
 fi

--- a/contrib/gitian-debian/templates
+++ b/contrib/gitian-debian/templates
@@ -5,10 +5,10 @@ Description: Automatically enable and start systemd bitcoinxtd.service?
 
 Template: bitcoinxt/select_network
 Type: select
-Default: Bitcoin Cash (BCC)
-Choices: Bitcoin Cash (BCC), Bitcoin (BTC)
+Default: Bitcoin Cash (BCH)
+Choices: Bitcoin Cash (BCH), Bitcoin (BTC)
 Description: Which network shall Bitcoin XT connect to?
-  Bitcoin XT is configured to use the BCC network by default.
+  Bitcoin XT is configured to use the BCH network by default.
   BTC is selected by adding uahftime=0 to /etc/bitcoinxt/bitcoin.conf.
   If your bitcoin.conf is located at a different location, you must edit it yourself.
   -


### PR DESCRIPTION
The package in our Debian repository already has this patch applied.

fixes #383 