### PR TITLE
Benchmark cherries

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -9,7 +9,8 @@ bench_bench_bitcoin_SOURCES = \
   bench/bench.h \
   bench/Examples.cpp \
   bench/rollingbloom.cpp \
-  bench/crypto_hash.cpp
+  bench/crypto_hash.cpp \
+  bench/base58.cpp
 
 bench_bench_bitcoin_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(EVENT_CLFAGS) $(EVENT_PTHREADS_CFLAGS) -I$(builddir)/bench/
 bench_bench_bitcoin_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -8,7 +8,8 @@ bench_bench_bitcoin_SOURCES = \
   bench/bench.cpp \
   bench/bench.h \
   bench/Examples.cpp \
-  bench/rollingbloom.cpp
+  bench/rollingbloom.cpp \
+  bench/crypto_hash.cpp
 
 bench_bench_bitcoin_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(EVENT_CLFAGS) $(EVENT_PTHREADS_CFLAGS) -I$(builddir)/bench/
 bench_bench_bitcoin_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -13,7 +13,9 @@ bench_bench_bitcoin_SOURCES = \
   bench/ccoins_caching.cpp \
   bench/mempool_eviction.cpp \
   bench/verify_script.cpp \
-  bench/base58.cpp
+  bench/base58.cpp \
+  bench/perf.cpp \
+  bench/perf.h
 
 bench_bench_bitcoin_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(EVENT_CLFAGS) $(EVENT_PTHREADS_CFLAGS) -I$(builddir)/bench/
 bench_bench_bitcoin_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -10,6 +10,9 @@ bench_bench_bitcoin_SOURCES = \
   bench/Examples.cpp \
   bench/rollingbloom.cpp \
   bench/crypto_hash.cpp \
+  bench/ccoins_caching.cpp \
+  bench/mempool_eviction.cpp \
+  bench/verify_script.cpp \
   bench/base58.cpp
 
 bench_bench_bitcoin_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(EVENT_CLFAGS) $(EVENT_PTHREADS_CFLAGS) -I$(builddir)/bench/
@@ -26,7 +29,8 @@ bench_bench_bitcoin_LDADD = \
   $(LIBSECP256K1)
 
 if ENABLE_WALLET
-bench_bench_bitcoin_LDADD += $(LIBBITCOIN_WALLET)
+bench_bench_bitcoin_SOURCES += bench/coin_selection.cpp
+bench_bench_bitcoin_LDADD += $(LIBBITCOIN_WALLET) $(LIBBITCOIN_CRYPTO)
 endif
 
 bench_bench_bitcoin_LDADD += $(BOOST_LIBS) $(BDB_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(MINIUPNPC_LIBS) $(EVENT_PTHREADS_LIBS) $(EVENT_LIBS)

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -26,7 +26,8 @@ bench_bench_bitcoin_LDADD = \
   $(LIBBITCOIN_CRYPTO) \
   $(LIBLEVELDB) \
   $(LIBMEMENV) \
-  $(LIBSECP256K1)
+  $(LIBSECP256K1) \
+  $(CURL_LIBS)
 
 if ENABLE_WALLET
 bench_bench_bitcoin_SOURCES += bench/coin_selection.cpp

--- a/src/bench/base58.cpp
+++ b/src/bench/base58.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2016 the Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "bench.h"
+
+#include "main.h"
+#include "base58.h"
+
+#include <vector>
+#include <string>
+
+
+static void Base58Encode(benchmark::State& state)
+{
+    unsigned char buff[32] = {
+        17, 79, 8, 99, 150, 189, 208, 162, 22, 23, 203, 163, 36, 58, 147,
+        227, 139, 2, 215, 100, 91, 38, 11, 141, 253, 40, 117, 21, 16, 90,
+        200, 24
+    };
+    unsigned char* b = buff;
+    while (state.KeepRunning()) {
+        EncodeBase58(b, b + 32);
+    }
+}
+
+
+static void Base58CheckEncode(benchmark::State& state)
+{
+    unsigned char buff[32] = {
+        17, 79, 8, 99, 150, 189, 208, 162, 22, 23, 203, 163, 36, 58, 147,
+        227, 139, 2, 215, 100, 91, 38, 11, 141, 253, 40, 117, 21, 16, 90,
+        200, 24
+    };
+    unsigned char* b = buff;
+    std::vector<unsigned char> vch;
+    vch.assign(b, b + 32);
+    while (state.KeepRunning()) {
+        EncodeBase58Check(vch);
+    }
+}
+
+
+static void Base58Decode(benchmark::State& state)
+{
+    const char* addr = "17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem";
+    std::vector<unsigned char> vch;
+    while (state.KeepRunning()) {
+        DecodeBase58(addr, vch);
+    }
+}
+
+
+BENCHMARK(Base58Encode);
+BENCHMARK(Base58CheckEncode);
+BENCHMARK(Base58Decode);

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include "bench.h"
 #include <iostream>
+#include <iomanip>
 #include <sys/time.h>
 
 using namespace benchmark;
@@ -23,7 +24,7 @@ BenchRunner::BenchRunner(std::string name, BenchFunction func)
 void
 BenchRunner::RunAll(double elapsedTimeForOne)
 {
-    std::cout << "Benchmark" << "," << "count" << "," << "min" << "," << "max" << "," << "average" << "\n";
+    std::cout << "#Benchmark" << "," << "count" << "," << "min" << "," << "max" << "," << "average" << "\n";
 
     for (std::map<std::string,BenchFunction>::iterator it = benchmarks.begin();
          it != benchmarks.end(); ++it) {
@@ -36,22 +37,34 @@ BenchRunner::RunAll(double elapsedTimeForOne)
 
 bool State::KeepRunning()
 {
+    if (count & countMask) {
+      ++count;
+      return true;
+    }
     double now;
     if (count == 0) {
-        beginTime = now = gettimedouble();
+        lastTime = beginTime = now = gettimedouble();
     }
     else {
-        // timeCheckCount is used to avoid calling gettime most of the time,
-        // so benchmarks that run very quickly get consistent results.
-        if ((count+1)%timeCheckCount != 0) {
-            ++count;
-            return true; // keep going
-        }
         now = gettimedouble();
-        double elapsedOne = (now - lastTime)/timeCheckCount;
+        double elapsed = now - lastTime;
+        double elapsedOne = elapsed * countMaskInv;
         if (elapsedOne < minTime) minTime = elapsedOne;
         if (elapsedOne > maxTime) maxTime = elapsedOne;
-        if (elapsedOne*timeCheckCount < maxElapsed/16) timeCheckCount *= 2;
+        if (elapsed*128 < maxElapsed) {
+          // If the execution was much too fast (1/128th of maxElapsed), increase the count mask by 8x and restart timing.
+          // The restart avoids including the overhead of this code in the measurement.
+          countMask = ((countMask<<3)|7) & ((1LL<<60)-1);
+          countMaskInv = 1./(countMask+1);
+          count = 0;
+          minTime = std::numeric_limits<double>::max();
+          maxTime = std::numeric_limits<double>::min();
+          return true;
+        }
+        if (elapsed*16 < maxElapsed) {
+          countMask = ((countMask<<1)|1) & ((1LL<<60)-1);
+          countMaskInv = 1./(countMask+1);
+        }
     }
     lastTime = now;
     ++count;
@@ -62,7 +75,7 @@ bool State::KeepRunning()
 
     // Output results
     double average = (now-beginTime)/count;
-    std::cout << name << "," << count << "," << minTime << "," << maxTime << "," << average << "\n";
+    std::cout << std::fixed << std::setprecision(15) << name << "," << count << "," << minTime << "," << maxTime << "," << average << "\n";
 
     return false;
 }

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include "bench.h"
+#include "perf.h"
+
 #include <iostream>
 #include <iomanip>
 #include <sys/time.h>
@@ -24,7 +26,9 @@ BenchRunner::BenchRunner(std::string name, BenchFunction func)
 void
 BenchRunner::RunAll(double elapsedTimeForOne)
 {
-    std::cout << "#Benchmark" << "," << "count" << "," << "min" << "," << "max" << "," << "average" << "\n";
+    perf_init();
+    std::cout << "#Benchmark" << "," << "count" << "," << "min" << "," << "max" << "," << "average" << ","
+              << "min_cycles" << "," << "max_cycles" << "," << "average_cycles" << "\n";
 
     for (std::map<std::string,BenchFunction>::iterator it = benchmarks.begin();
          it != benchmarks.end(); ++it) {
@@ -33,6 +37,7 @@ BenchRunner::RunAll(double elapsedTimeForOne)
         BenchFunction& func = it->second;
         func(state);
     }
+    perf_fini();
 }
 
 bool State::KeepRunning()
@@ -42,8 +47,10 @@ bool State::KeepRunning()
       return true;
     }
     double now;
+    uint64_t nowCycles;
     if (count == 0) {
         lastTime = beginTime = now = gettimedouble();
+        lastCycles = beginCycles = nowCycles = perf_cpucycles();
     }
     else {
         now = gettimedouble();
@@ -51,6 +58,13 @@ bool State::KeepRunning()
         double elapsedOne = elapsed * countMaskInv;
         if (elapsedOne < minTime) minTime = elapsedOne;
         if (elapsedOne > maxTime) maxTime = elapsedOne;
+
+        // We only use relative values, so don't have to handle 64-bit wrap-around specially
+        nowCycles = perf_cpucycles();
+        uint64_t elapsedOneCycles = (nowCycles - lastCycles) * countMaskInv;
+        if (elapsedOneCycles < minCycles) minCycles = elapsedOneCycles;
+        if (elapsedOneCycles > maxCycles) maxCycles = elapsedOneCycles;
+
         if (elapsed*128 < maxElapsed) {
           // If the execution was much too fast (1/128th of maxElapsed), increase the count mask by 8x and restart timing.
           // The restart avoids including the overhead of this code in the measurement.
@@ -59,6 +73,8 @@ bool State::KeepRunning()
           count = 0;
           minTime = std::numeric_limits<double>::max();
           maxTime = std::numeric_limits<double>::min();
+          minCycles = std::numeric_limits<uint64_t>::max();
+          maxCycles = std::numeric_limits<uint64_t>::min();
           return true;
         }
         if (elapsed*16 < maxElapsed) {
@@ -70,6 +86,7 @@ bool State::KeepRunning()
         }
     }
     lastTime = now;
+    lastCycles = nowCycles;
     ++count;
 
     if (now - beginTime < maxElapsed) return true; // Keep going
@@ -78,7 +95,9 @@ bool State::KeepRunning()
 
     // Output results
     double average = (now-beginTime)/count;
-    std::cout << std::fixed << std::setprecision(15) << name << "," << count << "," << minTime << "," << maxTime << "," << average << "\n";
+    int64_t averageCycles = (nowCycles-beginCycles)/count;
+    std::cout << std::fixed << std::setprecision(15) << name << "," << count << "," << minTime << "," << maxTime << "," << average << ","
+              << minCycles << "," << maxCycles << "," << averageCycles << "\n";
 
     return false;
 }

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -62,8 +62,11 @@ bool State::KeepRunning()
           return true;
         }
         if (elapsed*16 < maxElapsed) {
-          countMask = ((countMask<<1)|1) & ((1LL<<60)-1);
-          countMaskInv = 1./(countMask+1);
+          uint64_t newCountMask = ((countMask<<1)|1) & ((1LL<<60)-1);
+          if ((count & newCountMask)==0) {
+              countMask = newCountMask;
+              countMaskInv = 1./(countMask+1);
+          }
         }
     }
     lastTime = now;

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -40,12 +40,18 @@ namespace benchmark {
         double maxElapsed;
         double beginTime;
         double lastTime, minTime, maxTime, countMaskInv;
-        int64_t count;
-        int64_t countMask;
+        uint64_t count;
+        uint64_t countMask;
+        uint64_t beginCycles;
+        uint64_t lastCycles;
+        uint64_t minCycles;
+        uint64_t maxCycles;
     public:
         State(std::string _name, double _maxElapsed) : name(_name), maxElapsed(_maxElapsed), count(0) {
             minTime = std::numeric_limits<double>::max();
             maxTime = std::numeric_limits<double>::min();
+            minCycles = std::numeric_limits<uint64_t>::max();
+            maxCycles = std::numeric_limits<uint64_t>::min();
             countMask = 1;
             countMaskInv = 1./(countMask + 1);
         }

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -39,14 +39,15 @@ namespace benchmark {
         std::string name;
         double maxElapsed;
         double beginTime;
-        double lastTime, minTime, maxTime;
+        double lastTime, minTime, maxTime, countMaskInv;
         int64_t count;
-        int64_t timeCheckCount;
+        int64_t countMask;
     public:
         State(std::string _name, double _maxElapsed) : name(_name), maxElapsed(_maxElapsed), count(0) {
             minTime = std::numeric_limits<double>::max();
             maxTime = std::numeric_limits<double>::min();
-            timeCheckCount = 1;
+            countMask = 1;
+            countMaskInv = 1./(countMask + 1);
         }
         bool KeepRunning();
     };

--- a/src/bench/ccoins_caching.cpp
+++ b/src/bench/ccoins_caching.cpp
@@ -1,0 +1,87 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "bench.h"
+#include "coins.h"
+#include "policy/policy.h"
+#include "wallet/crypter.h"
+
+#include <vector>
+
+// FIXME: Dedup with SetupDummyInputs in test/transaction_tests.cpp.
+//
+// Helper: create two dummy transactions, each with
+// two outputs.  The first has 11 and 50 CENT outputs
+// paid to a TX_PUBKEY, the second 21 and 22 CENT outputs
+// paid to a TX_PUBKEYHASH.
+//
+static std::vector<CMutableTransaction>
+SetupDummyInputs(CBasicKeyStore& keystoreRet, CCoinsViewCache& coinsRet)
+{
+    std::vector<CMutableTransaction> dummyTransactions;
+    dummyTransactions.resize(2);
+
+    // Add some keys to the keystore:
+    CKey key[4];
+    for (int i = 0; i < 4; i++) {
+        key[i].MakeNewKey(i % 2);
+        keystoreRet.AddKey(key[i]);
+    }
+
+    // Create some dummy input transactions
+    dummyTransactions[0].vout.resize(2);
+    dummyTransactions[0].vout[0].nValue = 11 * CENT;
+    dummyTransactions[0].vout[0].scriptPubKey << ToByteVector(key[0].GetPubKey()) << OP_CHECKSIG;
+    dummyTransactions[0].vout[1].nValue = 50 * CENT;
+    dummyTransactions[0].vout[1].scriptPubKey << ToByteVector(key[1].GetPubKey()) << OP_CHECKSIG;
+    coinsRet.ModifyCoins(dummyTransactions[0].GetHash())->FromTx(dummyTransactions[0], 0);
+
+    dummyTransactions[1].vout.resize(2);
+    dummyTransactions[1].vout[0].nValue = 21 * CENT;
+    dummyTransactions[1].vout[0].scriptPubKey = GetScriptForDestination(key[2].GetPubKey().GetID());
+    dummyTransactions[1].vout[1].nValue = 22 * CENT;
+    dummyTransactions[1].vout[1].scriptPubKey = GetScriptForDestination(key[3].GetPubKey().GetID());
+    coinsRet.ModifyCoins(dummyTransactions[1].GetHash())->FromTx(dummyTransactions[1], 0);
+
+    return dummyTransactions;
+}
+
+// Microbenchmark for simple accesses to a CCoinsViewCache database. Note from
+// laanwj, "replicating the actual usage patterns of the client is hard though,
+// many times micro-benchmarks of the database showed completely different
+// characteristics than e.g. reindex timings. But that's not a requirement of
+// every benchmark."
+// (https://github.com/bitcoin/bitcoin/issues/7883#issuecomment-224807484)
+static void CCoinsCaching(benchmark::State& state)
+{
+    CBasicKeyStore keystore;
+    CCoinsView coinsDummy;
+    CCoinsViewCache coins(&coinsDummy);
+    std::vector<CMutableTransaction> dummyTransactions = SetupDummyInputs(keystore, coins);
+
+    CMutableTransaction t1;
+    t1.vin.resize(3);
+    t1.vin[0].prevout.hash = dummyTransactions[0].GetHash();
+    t1.vin[0].prevout.n = 1;
+    t1.vin[0].scriptSig << std::vector<unsigned char>(65, 0);
+    t1.vin[1].prevout.hash = dummyTransactions[1].GetHash();
+    t1.vin[1].prevout.n = 0;
+    t1.vin[1].scriptSig << std::vector<unsigned char>(65, 0) << std::vector<unsigned char>(33, 4);
+    t1.vin[2].prevout.hash = dummyTransactions[1].GetHash();
+    t1.vin[2].prevout.n = 1;
+    t1.vin[2].scriptSig << std::vector<unsigned char>(65, 0) << std::vector<unsigned char>(33, 4);
+    t1.vout.resize(2);
+    t1.vout[0].nValue = 90 * CENT;
+    t1.vout[0].scriptPubKey << OP_1;
+
+    // Benchmark.
+    while (state.KeepRunning()) {
+        bool success = AreInputsStandard(t1, coins);
+        assert(success);
+        CAmount value = coins.GetValueIn(t1);
+        assert(value == (50 + 21 + 22) * CENT);
+    }
+}
+
+BENCHMARK(CCoinsCaching);

--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -1,0 +1,62 @@
+// Copyright (c) 2012-2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "bench.h"
+#include "wallet/wallet.h"
+
+#include <boost/foreach.hpp>
+#include <set>
+
+using namespace std;
+
+static void addCoin(const CAmount& nValue, const CWallet& wallet, vector<COutput>& vCoins)
+{
+    int nInput = 0;
+
+    static int nextLockTime = 0;
+    CMutableTransaction tx;
+    tx.nLockTime = nextLockTime++; // so all transactions get different hashes
+    tx.vout.resize(nInput + 1);
+    tx.vout[nInput].nValue = nValue;
+    CWalletTx* wtx = new CWalletTx(&wallet, tx);
+
+    int nAge = 6 * 24;
+    COutput output(wtx, nInput, nAge, true, true);
+    vCoins.push_back(output);
+}
+
+// Simple benchmark for wallet coin selection. Note that it maybe be necessary
+// to build up more complicated scenarios in order to get meaningful
+// measurements of performance. From laanwj, "Wallet coin selection is probably
+// the hardest, as you need a wider selection of scenarios, just testing the
+// same one over and over isn't too useful. Generating random isn't useful
+// either for measurements."
+// (https://github.com/bitcoin/bitcoin/issues/7883#issuecomment-224807484)
+static void CoinSelection(benchmark::State& state)
+{
+    const CWallet wallet;
+    vector<COutput> vCoins;
+    LOCK(wallet.cs_wallet);
+
+    while (state.KeepRunning()) {
+        // Empty wallet.
+        BOOST_FOREACH (COutput output, vCoins)
+            delete output.tx;
+        vCoins.clear();
+
+        // Add coins.
+        for (int i = 0; i < 1000; i++)
+            addCoin(1000 * COIN, wallet, vCoins);
+        addCoin(3 * COIN, wallet, vCoins);
+
+        set<pair<const CWalletTx*, unsigned int> > setCoinsRet;
+        CAmount nValueRet;
+        bool success = wallet.SelectCoinsMinConf(1003 * COIN, 1, 6, vCoins, setCoinsRet, nValueRet);
+        assert(success);
+        assert(nValueRet == 1003 * COIN);
+        assert(setCoinsRet.size() == 2);
+    }
+}
+
+BENCHMARK(CoinSelection);

--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -22,7 +22,7 @@ static void addCoin(const CAmount& nValue, const CWallet& wallet, vector<COutput
     CWalletTx* wtx = new CWalletTx(&wallet, tx);
 
     int nAge = 6 * 24;
-    COutput output(wtx, nInput, nAge, true, true);
+    COutput output(wtx, nInput, nAge, true);
     vCoins.push_back(output);
 }
 

--- a/src/bench/crypto_hash.cpp
+++ b/src/bench/crypto_hash.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <iostream>
+
+#include "bench.h"
+#include "bloom.h"
+#include "utiltime.h"
+#include "crypto/ripemd160.h"
+#include "crypto/sha1.h"
+#include "crypto/sha256.h"
+#include "crypto/sha512.h"
+
+/* Number of bytes to hash per iteration */
+static const uint64_t BUFFER_SIZE = 1000*1000;
+
+static void RIPEMD160(benchmark::State& state)
+{
+    uint8_t hash[CRIPEMD160::OUTPUT_SIZE];
+    std::vector<uint8_t> in(BUFFER_SIZE,0);
+    while (state.KeepRunning())
+        CRIPEMD160().Write(begin_ptr(in), in.size()).Finalize(hash);
+}
+
+static void SHA1(benchmark::State& state)
+{
+    uint8_t hash[CSHA1::OUTPUT_SIZE];
+    std::vector<uint8_t> in(BUFFER_SIZE,0);
+    while (state.KeepRunning())
+        CSHA1().Write(begin_ptr(in), in.size()).Finalize(hash);
+}
+
+static void SHA256(benchmark::State& state)
+{
+    uint8_t hash[CSHA256::OUTPUT_SIZE];
+    std::vector<uint8_t> in(BUFFER_SIZE,0);
+    while (state.KeepRunning())
+        CSHA256().Write(begin_ptr(in), in.size()).Finalize(hash);
+}
+
+static void SHA512(benchmark::State& state)
+{
+    uint8_t hash[CSHA512::OUTPUT_SIZE];
+    std::vector<uint8_t> in(BUFFER_SIZE,0);
+    while (state.KeepRunning())
+        CSHA512().Write(begin_ptr(in), in.size()).Finalize(hash);
+}
+
+BENCHMARK(RIPEMD160);
+BENCHMARK(SHA1);
+BENCHMARK(SHA256);
+BENCHMARK(SHA512);

--- a/src/bench/crypto_hash.cpp
+++ b/src/bench/crypto_hash.cpp
@@ -6,6 +6,8 @@
 
 #include "bench.h"
 #include "bloom.h"
+#include "hash.h"
+#include "uint256.h"
 #include "utiltime.h"
 #include "crypto/ripemd160.h"
 #include "crypto/sha1.h"
@@ -39,6 +41,16 @@ static void SHA256(benchmark::State& state)
         CSHA256().Write(begin_ptr(in), in.size()).Finalize(hash);
 }
 
+static void SHA256_32b(benchmark::State& state)
+{
+    std::vector<uint8_t> in(32,0);
+    while (state.KeepRunning()) {
+        for (int i = 0; i < 1000000; i++) {
+            CSHA256().Write(begin_ptr(in), in.size()).Finalize(&in[0]);
+        }
+    }
+}
+
 static void SHA512(benchmark::State& state)
 {
     uint8_t hash[CSHA512::OUTPUT_SIZE];
@@ -47,7 +59,20 @@ static void SHA512(benchmark::State& state)
         CSHA512().Write(begin_ptr(in), in.size()).Finalize(hash);
 }
 
+static void SipHash_32b(benchmark::State& state)
+{
+    uint256 x;
+    while (state.KeepRunning()) {
+        for (int i = 0; i < 1000000; i++) {
+            *((uint64_t*)x.begin()) = SipHashUint256(0, i, x);
+        }
+    }
+}
+
 BENCHMARK(RIPEMD160);
 BENCHMARK(SHA1);
 BENCHMARK(SHA256);
 BENCHMARK(SHA512);
+
+BENCHMARK(SHA256_32b);
+BENCHMARK(SipHash_32b);

--- a/src/bench/mempool_eviction.cpp
+++ b/src/bench/mempool_eviction.cpp
@@ -1,0 +1,115 @@
+// Copyright (c) 2011-2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "bench.h"
+#include "policy/policy.h"
+#include "txmempool.h"
+
+#include <list>
+#include <vector>
+
+static void AddTx(const CTransaction& tx, const CAmount& nFee, CTxMemPool& pool)
+{
+    int64_t nTime = 0;
+    double dPriority = 10.0;
+    unsigned int nHeight = 1;
+    bool spendsCoinbase = false;
+    unsigned int sigOpCost = 4;
+    LockPoints lp;
+    pool.addUnchecked(tx.GetHash(), CTxMemPoolEntry(
+                                        tx, nFee, nTime, dPriority, nHeight, pool.HasNoInputsOf(tx),
+                                        tx.GetValueOut(), spendsCoinbase, sigOpCost, lp));
+}
+
+// Right now this is only testing eviction performance in an extremely small
+// mempool. Code needs to be written to generate a much wider variety of
+// unique transactions for a more meaningful performance measurement.
+static void MempoolEviction(benchmark::State& state)
+{
+    CMutableTransaction tx1 = CMutableTransaction();
+    tx1.vin.resize(1);
+    tx1.vin[0].scriptSig = CScript() << OP_1;
+    tx1.vout.resize(1);
+    tx1.vout[0].scriptPubKey = CScript() << OP_1 << OP_EQUAL;
+    tx1.vout[0].nValue = 10 * COIN;
+
+    CMutableTransaction tx2 = CMutableTransaction();
+    tx2.vin.resize(1);
+    tx2.vin[0].scriptSig = CScript() << OP_2;
+    tx2.vout.resize(1);
+    tx2.vout[0].scriptPubKey = CScript() << OP_2 << OP_EQUAL;
+    tx2.vout[0].nValue = 10 * COIN;
+
+    CMutableTransaction tx3 = CMutableTransaction();
+    tx3.vin.resize(1);
+    tx3.vin[0].prevout = COutPoint(tx2.GetHash(), 0);
+    tx3.vin[0].scriptSig = CScript() << OP_2;
+    tx3.vout.resize(1);
+    tx3.vout[0].scriptPubKey = CScript() << OP_3 << OP_EQUAL;
+    tx3.vout[0].nValue = 10 * COIN;
+
+    CMutableTransaction tx4 = CMutableTransaction();
+    tx4.vin.resize(2);
+    tx4.vin[0].prevout.SetNull();
+    tx4.vin[0].scriptSig = CScript() << OP_4;
+    tx4.vin[1].prevout.SetNull();
+    tx4.vin[1].scriptSig = CScript() << OP_4;
+    tx4.vout.resize(2);
+    tx4.vout[0].scriptPubKey = CScript() << OP_4 << OP_EQUAL;
+    tx4.vout[0].nValue = 10 * COIN;
+    tx4.vout[1].scriptPubKey = CScript() << OP_4 << OP_EQUAL;
+    tx4.vout[1].nValue = 10 * COIN;
+
+    CMutableTransaction tx5 = CMutableTransaction();
+    tx5.vin.resize(2);
+    tx5.vin[0].prevout = COutPoint(tx4.GetHash(), 0);
+    tx5.vin[0].scriptSig = CScript() << OP_4;
+    tx5.vin[1].prevout.SetNull();
+    tx5.vin[1].scriptSig = CScript() << OP_5;
+    tx5.vout.resize(2);
+    tx5.vout[0].scriptPubKey = CScript() << OP_5 << OP_EQUAL;
+    tx5.vout[0].nValue = 10 * COIN;
+    tx5.vout[1].scriptPubKey = CScript() << OP_5 << OP_EQUAL;
+    tx5.vout[1].nValue = 10 * COIN;
+
+    CMutableTransaction tx6 = CMutableTransaction();
+    tx6.vin.resize(2);
+    tx6.vin[0].prevout = COutPoint(tx4.GetHash(), 1);
+    tx6.vin[0].scriptSig = CScript() << OP_4;
+    tx6.vin[1].prevout.SetNull();
+    tx6.vin[1].scriptSig = CScript() << OP_6;
+    tx6.vout.resize(2);
+    tx6.vout[0].scriptPubKey = CScript() << OP_6 << OP_EQUAL;
+    tx6.vout[0].nValue = 10 * COIN;
+    tx6.vout[1].scriptPubKey = CScript() << OP_6 << OP_EQUAL;
+    tx6.vout[1].nValue = 10 * COIN;
+
+    CMutableTransaction tx7 = CMutableTransaction();
+    tx7.vin.resize(2);
+    tx7.vin[0].prevout = COutPoint(tx5.GetHash(), 0);
+    tx7.vin[0].scriptSig = CScript() << OP_5;
+    tx7.vin[1].prevout = COutPoint(tx6.GetHash(), 0);
+    tx7.vin[1].scriptSig = CScript() << OP_6;
+    tx7.vout.resize(2);
+    tx7.vout[0].scriptPubKey = CScript() << OP_7 << OP_EQUAL;
+    tx7.vout[0].nValue = 10 * COIN;
+    tx7.vout[1].scriptPubKey = CScript() << OP_7 << OP_EQUAL;
+    tx7.vout[1].nValue = 10 * COIN;
+
+    CTxMemPool pool(CFeeRate(1000));
+
+    while (state.KeepRunning()) {
+        AddTx(tx1, 10000LL, pool);
+        AddTx(tx2, 5000LL, pool);
+        AddTx(tx3, 20000LL, pool);
+        AddTx(tx4, 7000LL, pool);
+        AddTx(tx5, 1000LL, pool);
+        AddTx(tx6, 1100LL, pool);
+        AddTx(tx7, 9000LL, pool);
+        pool.TrimToSize(pool.DynamicMemoryUsage() * 3 / 4);
+        pool.TrimToSize(GetVirtualTransactionSize(tx1));
+    }
+}
+
+BENCHMARK(MempoolEviction);

--- a/src/bench/mempool_eviction.cpp
+++ b/src/bench/mempool_eviction.cpp
@@ -19,7 +19,7 @@ static void AddTx(const CTransaction& tx, const CAmount& nFee, CTxMemPool& pool)
     LockPoints lp;
     pool.addUnchecked(tx.GetHash(), CTxMemPoolEntry(
                                         tx, nFee, nTime, dPriority, nHeight, pool.HasNoInputsOf(tx),
-                                        tx.GetValueOut(), spendsCoinbase, sigOpCost, lp));
+                                        spendsCoinbase, lp, sigOpCost));
 }
 
 // Right now this is only testing eviction performance in an extremely small
@@ -108,7 +108,7 @@ static void MempoolEviction(benchmark::State& state)
         AddTx(tx6, 1100LL, pool);
         AddTx(tx7, 9000LL, pool);
         pool.TrimToSize(pool.DynamicMemoryUsage() * 3 / 4);
-        pool.TrimToSize(GetVirtualTransactionSize(tx1));
+        pool.TrimToSize(::GetSerializeSize(tx1, SER_NETWORK, PROTOCOL_VERSION));
     }
 }
 

--- a/src/bench/perf.cpp
+++ b/src/bench/perf.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "perf.h"
+
+#if defined(__i386__) || defined(__x86_64__)
+
+/* These architectures support quering the cycle counter
+ * from user space, no need for any syscall overhead.
+ */
+void perf_init(void) { }
+void perf_fini(void) { }
+
+#elif defined(__linux__)
+
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <linux/perf_event.h>
+
+static int fd = -1;
+static struct perf_event_attr attr;
+
+void perf_init(void)
+{
+    attr.type = PERF_TYPE_HARDWARE;
+    attr.config = PERF_COUNT_HW_CPU_CYCLES;
+    fd = syscall(__NR_perf_event_open, &attr, 0, -1, -1, 0);
+}
+
+void perf_fini(void)
+{
+    if (fd != -1) {
+        close(fd);
+    }
+}
+
+uint64_t perf_cpucycles(void)
+{
+    uint64_t result = 0;
+    if (fd == -1 || read(fd, &result, sizeof(result)) < (ssize_t)sizeof(result)) {
+        return 0;
+    }
+    return result;
+}
+
+#else /* Unhandled platform */
+
+void perf_init(void) { }
+void perf_fini(void) { }
+uint64_t perf_cpucycles(void) { return 0; }
+
+#endif

--- a/src/bench/perf.h
+++ b/src/bench/perf.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+/** Functions for measurement of CPU cycles */
+#ifndef H_PERF
+#define H_PERF
+
+#include <stdint.h>
+
+#if defined(__i386__)
+
+static inline uint64_t perf_cpucycles(void)
+{
+    uint64_t x;
+    __asm__ volatile (".byte 0x0f, 0x31" : "=A" (x));
+    return x;
+}
+
+#elif defined(__x86_64__)
+
+static inline uint64_t perf_cpucycles(void)
+{
+    uint32_t hi, lo;
+    __asm__ __volatile__ ("rdtsc" : "=a"(lo), "=d"(hi));
+    return ((uint64_t)lo)|(((uint64_t)hi)<<32);
+}
+#else
+
+uint64_t perf_cpucycles(void);
+
+#endif
+
+void perf_init(void);
+void perf_fini(void);
+
+#endif // H_PERF

--- a/src/bench/verify_script.cpp
+++ b/src/bench/verify_script.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "bench.h"
+#include "key.h"
+#if defined(HAVE_CONSENSUS_LIB)
+#include "script/bitcoinconsensus.h"
+#endif
+#include "script/script.h"
+#include "script/sign.h"
+#include "streams.h"
+
+// FIXME: Dedup with BuildCreditingTransaction in test/script_tests.cpp.
+static CMutableTransaction BuildCreditingTransaction(const CScript& scriptPubKey)
+{
+    CMutableTransaction txCredit;
+    txCredit.nVersion = 1;
+    txCredit.nLockTime = 0;
+    txCredit.vin.resize(1);
+    txCredit.vout.resize(1);
+    txCredit.vin[0].prevout.SetNull();
+    txCredit.vin[0].scriptSig = CScript() << CScriptNum(0) << CScriptNum(0);
+    txCredit.vin[0].nSequence = CTxIn::SEQUENCE_FINAL;
+    txCredit.vout[0].scriptPubKey = scriptPubKey;
+    txCredit.vout[0].nValue = 1;
+
+    return txCredit;
+}
+
+// FIXME: Dedup with BuildSpendingTransaction in test/script_tests.cpp.
+static CMutableTransaction BuildSpendingTransaction(const CScript& scriptSig, const CMutableTransaction& txCredit)
+{
+    CMutableTransaction txSpend;
+    txSpend.nVersion = 1;
+    txSpend.nLockTime = 0;
+    txSpend.vin.resize(1);
+    txSpend.vout.resize(1);
+    txSpend.wit.vtxinwit.resize(1);
+    txSpend.vin[0].prevout.hash = txCredit.GetHash();
+    txSpend.vin[0].prevout.n = 0;
+    txSpend.vin[0].scriptSig = scriptSig;
+    txSpend.vin[0].nSequence = CTxIn::SEQUENCE_FINAL;
+    txSpend.vout[0].scriptPubKey = CScript();
+    txSpend.vout[0].nValue = txCredit.vout[0].nValue;
+
+    return txSpend;
+}
+
+// Microbenchmark for verification of a basic P2WPKH script. Can be easily
+// modified to measure performance of other types of scripts.
+static void VerifyScriptBench(benchmark::State& state)
+{
+    const int flags = SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH;
+    const int witnessversion = 0;
+
+    // Keypair.
+    CKey key;
+    const unsigned char vchKey[32] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
+    key.Set(vchKey, vchKey + 32, false);
+    CPubKey pubkey = key.GetPubKey();
+    uint160 pubkeyHash;
+    CHash160().Write(pubkey.begin(), pubkey.size()).Finalize(pubkeyHash.begin());
+
+    // Script.
+    CScript scriptPubKey = CScript() << witnessversion << ToByteVector(pubkeyHash);
+    CScript scriptSig;
+    CScript witScriptPubkey = CScript() << OP_DUP << OP_HASH160 << ToByteVector(pubkeyHash) << OP_EQUALVERIFY << OP_CHECKSIG;
+    CTransaction txCredit = BuildCreditingTransaction(scriptPubKey);
+    CMutableTransaction txSpend = BuildSpendingTransaction(scriptSig, txCredit);
+    CScriptWitness& witness = txSpend.wit.vtxinwit[0].scriptWitness;
+    witness.stack.emplace_back();
+    key.Sign(SignatureHash(witScriptPubkey, txSpend, 0, SIGHASH_ALL, txCredit.vout[0].nValue, SIGVERSION_WITNESS_V0), witness.stack.back(), 0);
+    witness.stack.back().push_back(static_cast<unsigned char>(SIGHASH_ALL));
+    witness.stack.push_back(ToByteVector(pubkey));
+
+    // Benchmark.
+    while (state.KeepRunning()) {
+        ScriptError err;
+        bool success = VerifyScript(
+            txSpend.vin[0].scriptSig,
+            txCredit.vout[0].scriptPubKey,
+            &txSpend.wit.vtxinwit[0].scriptWitness,
+            flags,
+            MutableTransactionSignatureChecker(&txSpend, 0, txCredit.vout[0].nValue),
+            &err);
+        assert(err == SCRIPT_ERR_OK);
+        assert(success);
+
+#if defined(HAVE_CONSENSUS_LIB)
+        CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+        stream << txSpend;
+        int csuccess = bitcoinconsensus_verify_script_with_amount(
+            begin_ptr(txCredit.vout[0].scriptPubKey),
+            txCredit.vout[0].scriptPubKey.size(),
+            txCredit.vout[0].nValue,
+            (const unsigned char*)&stream[0], stream.size(), 0, flags, nullptr);
+        assert(csuccess == 1);
+#endif
+    }
+}
+
+BENCHMARK(VerifyScriptBench);

--- a/src/script/bitcoinconsensus.h
+++ b/src/script/bitcoinconsensus.h
@@ -6,6 +6,8 @@
 #ifndef BITCOIN_BITCOINCONSENSUS_H
 #define BITCOIN_BITCOINCONSENSUS_H
 
+#include <stdint.h>
+
 #if defined(BUILD_BITCOIN_INTERNAL) && defined(HAVE_CONFIG_H)
 #include "config/bitcoin-config.h"
   #if defined(_WIN32)
@@ -49,6 +51,12 @@ enum
     bitcoinconsensus_SCRIPT_FLAGS_VERIFY_DERSIG              = (1U << 2), // enforce strict DER (BIP66) compliance
     bitcoinconsensus_SCRIPT_FLAGS_VERIFY_CHECKLOCKTIMEVERIFY = (1U << 9), // enable CHECKLOCKTIMEVERIFY (BIP65)
 };
+
+
+EXPORT_SYMBOL int bitcoinconsensus_verify_script_with_amount(
+        const unsigned char *scriptPubKey, unsigned int scriptPubKeyLen, int64_t amount,
+        const unsigned char *txTo, unsigned int txToLen,
+        unsigned int nIn, unsigned int flags, bitcoinconsensus_error* err);
 
 /// Returns 1 if the input nIn of the serialized transaction pointed to by
 /// txTo correctly spends the scriptPubKey pointed to by scriptPubKey under


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/pull/8039 - bench: Add crypto hash benchmarks
https://github.com/bitcoin/bitcoin/pull/8107 - bench: Added base58 encoding/decoding benchmarks
https://github.com/bitcoin/bitcoin/pull/8111 - Benchmark SipHash
https://github.com/bitcoin/bitcoin/pull/8115 - Avoid integer division in the benchmark inner-most loop.
https://github.com/bitcoin/bitcoin/pull/8873 - Add microbenchmarks to profile more code paths.
https://github.com/bitcoin/bitcoin/pull/9200 - bench: Fix subtle counting issue when rescaling iteration count

Most of these applied with no or trivial conflicts, except for https://github.com/bitcoin/bitcoin/pull/8873. The modifications needed were done in a separate commit.