### PR TITLE
Extend coins_tests

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -227,6 +227,15 @@ bool CCoinsViewCache::Flush() {
     return fOk;
 }
 
+void CCoinsViewCache::Uncache(const COutPoint& hash)
+{
+    CCoinsMap::iterator it = cacheCoins.find(hash);
+    if (it != cacheCoins.end() && it->second.flags == 0) {
+        cachedCoinsUsage -= it->second.coins.DynamicMemoryUsage();
+        cacheCoins.erase(it);
+    }
+}
+
 unsigned int CCoinsViewCache::GetCacheSize() const {
     return cacheCoins.size();
 }

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -154,6 +154,11 @@ bool CCoinsViewCache::HaveCoins(const COutPoint &outpoint) const {
     return (it != cacheCoins.end() && !it->second.coins.IsPruned());
 }
 
+bool CCoinsViewCache::HaveCoinsInCache(const COutPoint &outpoint) const {
+    CCoinsMap::const_iterator it = cacheCoins.find(outpoint);
+    return it != cacheCoins.end();
+}
+
 uint256 CCoinsViewCache::GetBestBlock() const {
     if (hashBlock.IsNull())
         hashBlock = base->GetBestBlock();

--- a/src/coins.h
+++ b/src/coins.h
@@ -430,6 +430,13 @@ public:
     bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock);
 
     /**
+     * Check if we have the given utxo already loaded in this cache.
+     * The semantics are the same as HaveCoin(), but no calls to
+     * the backing CCoinsView are made.
+     */
+    bool HaveCoinsInCache(const COutPoint &outpoint) const;
+
+    /**
      * Return a reference to Coin in the cache, or a pruned one if not found. This is
      * more efficient than GetCoins. Modifications to other cache entries are
      * allowed while accessing the returned pointer.

--- a/src/coins.h
+++ b/src/coins.h
@@ -456,6 +456,12 @@ public:
      */
     bool Flush();
 
+    /**
+     * Removes the UTXO with the given outpoint from the cache, if it is
+     * not modified.
+     */
+    void Uncache(const COutPoint &outpoint);
+
     //! Calculate the size of the cache (in number of transaction outputs)
     unsigned int GetCacheSize() const;
 


### PR DESCRIPTION
On top of #418 

74d0f90 and 97bf377 from https://github.com/bitcoin/bitcoin/pull/6872
ce23efaa5 from Core#10195

Uncache and HaveCoinsInCache were added to avoid having to patch the tests. These methods are currently not used, but I plan to use them in the future.