### PR TITLE
Add -stopatheight for benchmarking + bugfixes

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -408,6 +408,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-fuzzmessagestest=<n>", "Randomly fuzz 1 of every <n> network messages");
         strUsage += HelpMessageOpt("-flushwallet", strprintf("Run a thread to flush wallet periodically (default: %u)", 1));
         strUsage += HelpMessageOpt("-stopafterblockimport", strprintf("Stop running after importing blocks from disk (default: %u)", 0));
+        strUsage += HelpMessageOpt("-stopatheight", strprintf("Stop running after reaching the given height in the main chain (default: %u)", DEFAULT_STOPATHEIGHT));
         strUsage += HelpMessageOpt("-limitancestorcount=<n>", strprintf("Do not accept transactions if number of in-mempool ancestors is <n> or more (default: %u)", DEFAULT_ANCESTOR_LIMIT));
         strUsage += HelpMessageOpt("-limitancestorsize=<n>", strprintf("Do not accept transactions whose size with all in-mempool ancestors exceeds <n> kilobytes (default: %u)", DEFAULT_ANCESTOR_SIZE_LIMIT));
         strUsage += HelpMessageOpt("-limitdescendantcount=<n>", strprintf("Do not accept transactions if any ancestor would have <n> or more in-mempool descendants (default: %u)", DEFAULT_DESCENDANT_LIMIT));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1549,10 +1549,18 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
             vImportFiles.push_back(strFile);
     }
     threadGroup.create_thread(boost::bind(&ThreadImport, vImportFiles));
-    if (chainActive.Tip() == NULL) {
-        LogPrintf("Waiting for genesis block to be imported...\n");
-        while (!fRequestShutdown && chainActive.Tip() == NULL)
+
+    // Wait for genesis block to be processed
+    bool fHaveGenesis = false;
+    while (!fHaveGenesis && !fRequestShutdown) {
+        {
+            LOCK(cs_main);
+            fHaveGenesis = (chainActive.Tip() != NULL);
+        }
+
+        if (!fHaveGenesis) {
             MilliSleep(10);
+        }
     }
 
     // ********************************************************* Step 10: start node

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2581,6 +2581,9 @@ bool ActivateBestChain(CValidationState &state, CBlock *pblock, const BlockSourc
     const CChainParams& chainParams = Params();
     do {
         boost::this_thread::interruption_point();
+        if (ShutdownRequested())
+            break;
+
         CBlockIndex *pindexNewTip = nullptr;
         const CBlockIndex *pindexFork;
         bool fInitialDownload;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2579,6 +2579,7 @@ static bool ActivateBestChainStep(CValidationState &state, CBlockIndex *pindexMo
 bool ActivateBestChain(CValidationState &state, CBlock *pblock, const BlockSource& blockSource, CConnman* connman) {
     CBlockIndex *pindexMostWork = NULL;
     CBlockIndex *pindexNewTip = nullptr;
+    int nStopAtHeight = GetArg("-stopatheight", DEFAULT_STOPATHEIGHT);
     const CChainParams& chainParams = Params();
     do {
         boost::this_thread::interruption_point();
@@ -2643,6 +2644,7 @@ bool ActivateBestChain(CValidationState &state, CBlock *pblock, const BlockSourc
             if (!hashesToAnnounce.empty())
                 uiInterface.NotifyBlockTip(hashesToAnnounce.front());
         }
+        if (nStopAtHeight && pindexNewTip && pindexNewTip->nHeight >= nStopAtHeight) StartShutdown();
     } while(pindexNewTip != pindexMostWork);
     CheckBlockIndex();
 
@@ -2650,9 +2652,6 @@ bool ActivateBestChain(CValidationState &state, CBlock *pblock, const BlockSourc
     if (!FlushStateToDisk(state, FLUSH_STATE_PERIODIC)) {
         return false;
     }
-
-    int nStopAtHeight = GetArg("-stopatheight", DEFAULT_STOPATHEIGHT);
-    if (nStopAtHeight && pindexNewTip && pindexNewTip->nHeight >= nStopAtHeight) StartShutdown();
 
     return true;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -197,7 +197,7 @@ namespace {
     int nQueuedValidatedHeaders = 0;
 
     /** Number of preferable block download peers. */
-    int nPreferredDownload = 0;
+    std::atomic<int> nPreferredDownload(0);
 
     /** Dirty block index entries. */
     set<CBlockIndex*> setDirtyBlockIndex;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2651,6 +2651,9 @@ bool ActivateBestChain(CValidationState &state, CBlock *pblock, const BlockSourc
         return false;
     }
 
+    int nStopAtHeight = GetArg("-stopatheight", DEFAULT_STOPATHEIGHT);
+    if (nStopAtHeight && pindexNewTip->nHeight >= nStopAtHeight) StartShutdown();
+
     return true;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2652,7 +2652,7 @@ bool ActivateBestChain(CValidationState &state, CBlock *pblock, const BlockSourc
     }
 
     int nStopAtHeight = GetArg("-stopatheight", DEFAULT_STOPATHEIGHT);
-    if (nStopAtHeight && pindexNewTip->nHeight >= nStopAtHeight) StartShutdown();
+    if (nStopAtHeight && pindexNewTip && pindexNewTip->nHeight >= nStopAtHeight) StartShutdown();
 
     return true;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2578,13 +2578,13 @@ static bool ActivateBestChainStep(CValidationState &state, CBlockIndex *pindexMo
  */
 bool ActivateBestChain(CValidationState &state, CBlock *pblock, const BlockSource& blockSource, CConnman* connman) {
     CBlockIndex *pindexMostWork = NULL;
+    CBlockIndex *pindexNewTip = nullptr;
     const CChainParams& chainParams = Params();
     do {
         boost::this_thread::interruption_point();
         if (ShutdownRequested())
             break;
 
-        CBlockIndex *pindexNewTip = nullptr;
         const CBlockIndex *pindexFork;
         bool fInitialDownload;
         int nNewHeight;
@@ -2643,7 +2643,7 @@ bool ActivateBestChain(CValidationState &state, CBlock *pblock, const BlockSourc
             if (!hashesToAnnounce.empty())
                 uiInterface.NotifyBlockTip(hashesToAnnounce.front());
         }
-    } while(pindexMostWork != chainActive.Tip());
+    } while(pindexNewTip != pindexMostWork);
     CheckBlockIndex();
 
     // Write changes periodically to disk, after relay.

--- a/src/main.h
+++ b/src/main.h
@@ -94,6 +94,9 @@ static const unsigned int AVG_ADDRESS_BROADCAST_INTERVAL = 30;
  *  Blocks, whitelisted receivers, and a random 25% of transactions bypass this. */
 static const unsigned int AVG_INVENTORY_BROADCAST_INTERVAL = 5;
 
+/** Default for -stopatheight */
+static const int DEFAULT_STOPATHEIGHT = 0;
+
 struct BlockHasher
 {
     size_t operator()(const uint256& hash) const { return hash.GetCheapHash(); }


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/pull/7821 - init: allow shutdown during 'Activating best chain...

719de56 from https://github.com/bitcoin/bitcoin/pull/7942
The other commit (efb54ba) is not needed because nodestate has its own lock. nPreferredDownload was unprotected though, so I added a commit to make it atomic.

https://github.com/bitcoin/bitcoin/pull/8063 - Acquire lock to check for genesis block
https://github.com/bitcoin/bitcoin/pull/10290 - Add -stopatheight for benchmarking
https://github.com/bitcoin/bitcoin/pull/10305 - Fix potential NPD introduced in b297426c
https://github.com/bitcoin/bitcoin/pull/10569 - Fix stopatheight
