### PR TITLE
fix build on osx

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -337,7 +337,7 @@ case $host in
 
      AX_CHECK_LINK_FLAG([[-Wl,-headerpad_max_install_names]], [LDFLAGS="$LDFLAGS -Wl,-headerpad_max_install_names"])
      CPPFLAGS="$CPPFLAGS -DMAC_OSX"
-     OBJCXXFLAGS="$CXXFLAGS"
+     OBJCXXFLAGS="-std=c++11 $CXXFLAGS"
      ;;
    *linux*)
      TARGET_OS=linux

--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,6 @@ else
   CXXFLAGS_overridden=no
 fi
 AC_PROG_CXX
-m4_ifdef([AC_PROG_OBJCXX],[AC_PROG_OBJCXX])
 
 dnl By default, libtool for mingw refuses to link static libs into a dll for
 dnl fear of mixing pic/non-pic objects, and import/export complications. Since
@@ -52,6 +51,17 @@ case $host in
 esac
 dnl Require C++11 compiler (no GNU extensions)
 AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
+
+
+dnl Unless the user specified OBJCXX, force it to be the same as CXX. This ensures
+dnl that we get the same -std flags for both.
+m4_ifdef([AC_PROG_OBJCXX],[
+if test "x${OBJCXX+set}" = "x"; then
+  OBJCXX="${CXX}"
+fi
+AC_PROG_OBJCXX
+])
+
 dnl Libtool init checks.
 LT_INIT([pic-only])
 
@@ -337,7 +347,7 @@ case $host in
 
      AX_CHECK_LINK_FLAG([[-Wl,-headerpad_max_install_names]], [LDFLAGS="$LDFLAGS -Wl,-headerpad_max_install_names"])
      CPPFLAGS="$CPPFLAGS -DMAC_OSX"
-     OBJCXXFLAGS="-std=c++11 $CXXFLAGS"
+     OBJCXXFLAGS="$CXXFLAGS"
      ;;
    *linux*)
      TARGET_OS=linux

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -32,7 +32,7 @@ Instructions: Homebrew
 
 #### Install dependencies using Homebrew
 
-        brew install autoconf automake berkeley-db4 libtool boost miniupnpc openssl pkg-config protobuf qt5
+        brew install autoconf automake berkeley-db4 libtool boost miniupnpc openssl pkg-config protobuf qt5 libevent
 
 NOTE: Building with Qt4 is still supported, however, could result in a broken UI. As such, building with Qt5 is recommended.
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -210,7 +210,7 @@ struct mempoolentry_txid
 class CompareTxMemPoolEntryByFee
 {
 public:
-    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b)
+    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b) const
     {
         bool fUseADescendants = UseDescendantFeeRate(a);
         bool fUseBDescendants = UseDescendantFeeRate(b);
@@ -232,7 +232,7 @@ public:
     }
 
     // Calculate which feerate to use for an entry (avoiding division).
-    bool UseDescendantFeeRate(const CTxMemPoolEntry &a)
+    bool UseDescendantFeeRate(const CTxMemPoolEntry &a) const
     {
         double f1 = (double)a.GetFee() * a.GetSizeWithDescendants();
         double f2 = (double)a.GetFeesWithDescendants() * a.GetTxSize();
@@ -243,7 +243,7 @@ public:
 class CompareTxMemPoolEntryByEntryTime
 {
 public:
-    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b)
+    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b) const
     {
         return a.GetTime() < b.GetTime();
     }
@@ -252,7 +252,7 @@ public:
 class CompareTxMemPoolEntryByAncestorFee
 {
 public:
-    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b)
+    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b) const
     {
         // Fee delta is used to prefer local transactions
         double aFeeDelta = a.GetFeeDelta();


### PR DESCRIPTION
Hello, I'm new here. 👋 

Wanting to get my hands dirty and help out a little. The first problem I ran into was that I couldn't build the project in my OSX environment, so I took to fixing that. This is the result.

Specifically

- OSX needs `libevent` as a dependency (probably other envs do too?) but it wasn't in the build doc so I added that.
- boost as of v 1.66+ has some differently typed function signatures, I guess. `brew` on osx installs 1.67.0 as of this writing. So I fixed the incompatibility, same as was done in core [here](https://github.com/bitcoin/bitcoin/pull/11847/files)
- similarly, qt 5.7+ (`brew` installs 5.10.1 as the latest) had compatibility issues. Core fixed that with [this change](https://github.com/bitcoin/bitcoin/pull/9169), ~~but I tried that and it didn't work for me. Looking deeper, their fix seems to be a more complex fix than the simplest fix, which was intended to be "future proof" for newer compilers, but based on the fact that it didn't work for me here in the future that wasn't right. So I just have the simple fix here in this PR (just adding the `-std=c++11` to `OBJCXXFLAGS` because for whatever reason qt doesn't respect the flag in `CXXCPP` and/or `CXX` set by `AX_CXX_COMPILE_STDCXX`.~~ and that is replicated here.