### PR TITLE
read config file before checking for existence of datadir

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -592,6 +592,9 @@ void ReadConfigFile(map<string, string>& mapSettingsRet,
     }
     // If datadir is changed in .conf file:
     ClearDatadirCache();
+    if (!boost::filesystem::is_directory(GetDataDir(false))) {
+        throw std::runtime_error(strprintf("specified data directory \"%s\" does not exist.", GetArg("-datadir", "").c_str()));
+    }
 }
 
 #ifndef WIN32


### PR DESCRIPTION
Fixes #241

The code was checking for the existence of the `datadir` *before* reading and processing the config file. This means that when the datadir was only specified in the config file, we ended up checking whether the default dir existed, which it does, and then reading in a nonexistent datadir after that, causing later code (which assumes this check has already been performed and passed) to have erratic behavior.

~~So the fix is just to move the "read config" code up higher so it happens first. I think in general reading the config file should be as high as possible in this function, or maybe even up higher in the call tree? Not sure how the GUI mode interacts with the conf file yet though.~~

Fixed by checking that the datadir exists inside the `ReadConfigFile` function, just before returning. Cherry-picked from https://github.com/bitcoin/bitcoin/pull/11829