### PR TITLE
[Tests] Correct tests to pre-thirdfork env

### DIFF
--- a/qa/rpc-tests/abc-p2p-fullblocktest.py
+++ b/qa/rpc-tests/abc-p2p-fullblocktest.py
@@ -28,6 +28,8 @@ LEGACY_MAX_BLOCK_SIZE = ONE_MEGABYTE
 
 # far into the past
 UAHF_START_TIME = 30000000
+# far into the future
+MONOLITH_START_TIME = 2000000000
 
 class PreviousSpendableOutput(object):
 
@@ -98,8 +100,8 @@ class FullBlockTest(ComparisonTestFramework):
                             '-limitdescendantsize=9999',
                             '-maxmempool=999',
                             "-uahfstarttime=%d" % UAHF_START_TIME,
-                            "-excessiveblocksize=%d"
-                            % self.excessive_block_size]]
+                            "-excessiveblocksize=%d" % self.excessive_block_size,
+                            "-thirdhftime=%d" % MONOLITH_START_TIME]]
         else:
             self.extra_args = [['-debug',
                             '-relaypriority=0',
@@ -109,7 +111,8 @@ class FullBlockTest(ComparisonTestFramework):
                             '-limitdescendantcount=9999',
                             '-limitdescendantsize=9999',
                             '-maxmempool=999',
-                            "-uahftime=%d" % UAHF_START_TIME]]
+                            "-uahftime=%d" % UAHF_START_TIME,
+                            "-thirdhftime=%d" % MONOLITH_START_TIME]]
 
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
                                  self.extra_args,

--- a/qa/rpc-tests/mempool_reorg.py
+++ b/qa/rpc-tests/mempool_reorg.py
@@ -13,6 +13,9 @@ from test_framework.util import *
 import os
 import shutil
 
+# far into the future
+MONOLITH_START_TIME = 2000000000
+
 # Create one-input, one-output, no-fee transaction:
 class MempoolCoinbaseTest(BitcoinTestFramework):
     def __init__(self):
@@ -23,7 +26,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
     alert_filename = None  # Set by setup_network
 
     def setup_network(self):
-        args = ["-checkmempool", "-debug=mempool", "-relaypriority=0"]
+        args = ["-checkmempool", "-debug=mempool", "-relaypriority=0", "-thirdhftime=%d" % MONOLITH_START_TIME]
         self.nodes = []
         self.nodes.append(start_node(0, self.options.tmpdir, args))
         self.nodes.append(start_node(1, self.options.tmpdir, args))


### PR DESCRIPTION
Once the fork deployed, these tests were sensitive to the mempool being cleared as the fork was "rolled back" by invalidations.