### PR TITLE
Ensure http server thread is only stopped if it was started.

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -502,7 +502,9 @@ void StopHTTPServer()
             LogPrintf("HTTP event loop did not exit within allotted time, sending loopbreak\n");
             event_base_loopbreak(eventBase);
         }
-        threadHTTP.join();
+        if (threadHTTP.joinable()) {
+            threadHTTP.join();
+        }
     }
     if (eventHTTP) {
         evhttp_free(eventHTTP);


### PR DESCRIPTION
Thread startup (StartHTTPServer) is separate  from
initalization (InitHTTPServer), so we need to check whether the thread
was started before stopping it.

Fixes #381