### PR TITLE
BIP64 cleanup

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -121,7 +121,8 @@ testScripts = [
     'blockchain.py',
     'disablewallet.py',
     'rpcnamedargs.py',
-    'abc-monolith-activation.py'
+    'abc-monolith-activation.py',
+    'bip64.py'
 ]
 
 testScriptsExt = [

--- a/qa/rpc-tests/bip64.py
+++ b/qa/rpc-tests/bip64.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+#
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+
+import binascii
+
+from test_framework.mininode import SingleNodeConnCB, NodeConn, NetworkThread, \
+    wait_until, FromHex, CTransaction, COutPoint, COIN
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import p2p_port, assert_equal, create_confirmed_utxos
+from test_framework.bip64 import msg_getutxos
+import random
+
+class TestNode(SingleNodeConnCB):
+    def __init__(self):
+        SingleNodeConnCB.__init__(self)
+        self.last_getheaders = None
+        self.last_headers = None
+        self.utxos = None
+
+    def on_getheaders(self, conn, message):
+        self.last_getheaders = message
+
+    def on_headers(self, conn, message):
+        self.last_headers = message
+
+    def on_utxos(self, conn, message):
+        self.utxos = message
+
+    def handshake(self):
+        self.wait_for_verack()
+
+        # Exchange headers (just mirror header request/response)
+        got_getheaders = wait_until(lambda: self.last_getheaders != None)
+        assert(got_getheaders)
+        self.send_message(self.last_getheaders)
+
+        got_headers = wait_until(lambda: self.last_headers != None)
+        assert(got_headers)
+        self.send_message(self.last_headers)
+
+
+class BIP64_test(BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 1
+
+    def wait_for_utxo(self):
+        got_utxos = wait_until(lambda: self.test_node.utxos != None)
+        assert(got_utxos)
+        assert_equal(self.test_node.utxos.hash, int(self.xt_node.getbestblockhash(), 16))
+        assert_equal(self.test_node.utxos.height, self.xt_node.getblockcount())
+
+    def get_utxos(self, outpoints, checkmempool):
+        self.test_node.utxos = None
+        self.test_node.send_message(msg_getutxos(checkmempool, outpoints))
+        self.wait_for_utxo()
+
+    def run_test(self):
+        self.xt_node = self.nodes[0]
+
+        # generate a block to get out of IBD
+        self.xt_node.generate(1)
+
+        self.test_node = TestNode()
+        self.test_node.add_connection(NodeConn('127.0.0.1', p2p_port(0), self.xt_node, self.test_node))
+
+        NetworkThread().start()
+        self.test_node.handshake()
+
+        self.test_basics(self.xt_node, self.test_node)
+        self.test_garbage(self.test_node)
+        self.test_big_bitmap(self.xt_node, self.test_node, 8 * 2)
+        self.test_big_bitmap(self.xt_node, self.test_node, 8 * 128)
+
+    # Requests utxos that never existed
+    def test_garbage(self, test_node):
+        self.log.info("bip64: test requesting garbage")
+        import hashlib
+        m = hashlib.sha256()
+        outpoints = [ ]
+        for _ in range(8):
+            m.update(b"garbage")
+            outpoints.append(COutPoint(int(m.hexdigest(), 16), random.randrange(1000)))
+        self.get_utxos(outpoints, checkmempool = True)
+        assert_equal(int('00000000', 2), test_node.utxos.bitmap[0])
+        assert_equal(0, len(test_node.utxos.result))
+
+    def test_basics(self, xt_node, test_node):
+        self.log.info("bip64: basic checks")
+        txid = xt_node.sendtoaddress(xt_node.getnewaddress(), 0.1)
+        tx = FromHex(CTransaction(), xt_node.getrawtransaction(txid))
+        tx.rehash()
+
+        new_outpoint = COutPoint(tx.sha256, 0)
+        prev_outpoint = tx.vin[0].prevout
+
+        # Test that the utxo doesn't exist in the chain.
+        self.get_utxos([new_outpoint], checkmempool = False)
+        assert_equal(test_node.utxos.bitmap[0], int('0', 2))
+        assert_equal(len(test_node.utxos.result), 0)
+
+        # It does exist in the mempool.
+        self.get_utxos([new_outpoint], checkmempool = True)
+        assert_equal(test_node.utxos.bitmap[0], int('1', 2))
+        assert_equal(len(test_node.utxos.result), 1)
+        magic_inmempool_height = 2147483647
+        assert_equal(test_node.utxos.result[0].height, magic_inmempool_height)
+
+        # The prevout exists in the chain
+        self.get_utxos([prev_outpoint], checkmempool = False)
+        assert_equal(test_node.utxos.bitmap[0], int('1', 2))
+
+        # The prevout is spent in the mempool.
+        self.get_utxos([prev_outpoint], checkmempool = True)
+        assert_equal(test_node.utxos.bitmap[0], int('0', 2))
+
+        # Mine tx creating new_outpoint, now it should exist in the chain.
+        xt_node.generate(1)
+        self.get_utxos([new_outpoint], checkmempool = False)
+        assert_equal(test_node.utxos.bitmap[0], int('1', 2))
+        assert_equal(test_node.utxos.result[0].height, xt_node.getblockcount())
+
+        # .. same result when including mempool
+        self.get_utxos([new_outpoint], checkmempool = True)
+        assert_equal(test_node.utxos.bitmap[0], int('1', 2))
+
+        # Check that we can fetch multiple outpoints
+        self.get_utxos([new_outpoint, prev_outpoint], checkmempool = False)
+        assert_equal(test_node.utxos.bitmap[0], int('01', 2))
+        self.get_utxos([prev_outpoint, new_outpoint], checkmempool = False)
+        assert_equal(test_node.utxos.bitmap[0], int('10', 2))
+        self.get_utxos([new_outpoint, prev_outpoint, new_outpoint], checkmempool = False)
+        assert_equal(test_node.utxos.bitmap[0], int('101', 2))
+
+    def test_big_bitmap(self, xt_node, test_node, num_utxos):
+        assert(num_utxos % 8 == 0)
+        bitmap_bytes = int(num_utxos / 8)
+        num_spent = int(num_utxos / 2)
+
+        self.log.info("bip64: creating a getutxos request for %d outpoints (%d bitmap bytes)",
+            num_utxos, bitmap_bytes)
+
+        create_confirmed_utxos(
+                xt_node.getnetworkinfo()["relayfee"],
+                xt_node, num_spent)
+
+        spent = [ ]
+        unspent = [ ]
+        unspent_values = [ ]
+
+        # spend utxos
+        for _ in range(0, num_spent):
+            amount = round(random.random() + 0.01, 2)
+            txid = xt_node.sendtoaddress(xt_node.getnewaddress(), amount)
+            tx = FromHex(CTransaction(), xt_node.getrawtransaction(txid))
+            spent.append(tx.vin[0].prevout)
+
+        # find equal amount of unspent
+        utxos = create_confirmed_utxos(
+                xt_node.getnetworkinfo()["relayfee"],
+                xt_node, num_spent)
+
+        assert(len(utxos) >= num_spent)
+        for _ in range(0, num_spent):
+            u = utxos.pop()
+            unspent.append(COutPoint(int(u["txid"], 16), u["vout"]))
+            unspent_values.append(u["amount"] * COIN)
+
+        assert(len(spent) + len(unspent) == num_utxos)
+
+        while (xt_node.getmempoolinfo()['size'] > 0):
+            xt_node.generate(1)
+
+        outpoints = [ ]
+        for b in range(0, bitmap_bytes):
+            o = b * 4 # offset: 4 utxos per byte from each of spent, unspent
+            outpoints.extend([
+                    unspent[o], unspent[o + 1], unspent[o + 2], unspent[o + 3],
+                    spent[o], spent[o + 1], spent[o + 2], spent[o + 3] ])
+
+        self.get_utxos(outpoints, False)
+
+        assert_equal(len(test_node.utxos.bitmap), bitmap_bytes)
+        assert_equal(len(test_node.utxos.result), len(unspent))
+        # check that returned results are in the same order as requested
+        for i in range(0, len(unspent_values)):
+            assert_equal(unspent_values[i], test_node.utxos.result[i].out.nValue)
+        for b in range(0, bitmap_bytes):
+            assert_equal(test_node.utxos.bitmap[b], int('00001111', 2))
+
+
+    def setup_network(self, split = False):
+        self.extra_args = [['-debug']]
+        self.nodes = self.setup_nodes()
+        self.is_network_split = split
+
+if __name__ == '__main__':
+    BIP64_test().main()

--- a/qa/rpc-tests/test_framework/bip64.py
+++ b/qa/rpc-tests/test_framework/bip64.py
@@ -1,0 +1,89 @@
+import struct
+import copy
+from test_framework.mininode import ser_vector, deser_vector, COutPoint, deser_uint256, deser_compact_size, CTxOut
+
+class msg_getutxos(object):
+    command = b"getutxos"
+
+    def __init__(self, checkmempool = False, outpoints = []):
+        self.checkmempool = checkmempool
+        self.outpoints = outpoints
+
+    def deserialize(self, f):
+        self.checkmempool = struct.unpack("<?", f.read(1))[0]
+        self.outpoints = deser_vector(f, COutPoint)
+
+    def serialize(self):
+        r = b""
+        r += struct.pack("<?", self.checkmempool)
+        r += ser_vector(self.outpoints)
+        return r
+
+    def __repr__(self):
+        return "msg_getutxos(checkmempool=%s, outpoints=%s)" % (self.checkmempool, repr(self.outpoints))
+
+class BIP64Coin(object):
+    def __init__(self, bip64coin = None):
+        if bip64coin is None:
+            self.txversion = 0,
+            self.height = 0,
+            self.out = None
+        else:
+            self.txversion = bip64coin.txversion
+            self.height = bip64.height
+            self.out = copy.deepcopy(bip64coin.out)
+
+    def deserialize(self, f):
+        self.txversion = struct.unpack("<I", f.read(4))[0]
+        self.height = struct.unpack("<I", f.read(4))[0]
+        self.out = CTxOut()
+        self.out.deserialize(f)
+
+    def serialize(self):
+        r = b""
+        r += struct.pack("<I", self.txversion)
+        r += struct.pack("<I", self.height)
+        r += self.out.serialize()
+        return r
+
+    def __repr__(self):
+        return "BIP64Coin(txversion=%i height=%i out=%s)" % (self.txversion, self.height, repr(self.out))
+
+def deser_byte_vector(f):
+    nit = deser_compact_size(f)
+    r = []
+    for i in range(nit):
+        t = struct.unpack("<B", f.read(1))[0]
+        r.append(t)
+    return r
+
+def ser_byte_vector(l):
+    r = ser_compact_size(len(l))
+    for i in l:
+        r += struct.pack("B", i)
+    return r
+
+class msg_utxos(object):
+    command = b"utxos"
+    def __init__(self, height = 0, hash = 0, bitmap = [], result = []):
+        self.height = height
+        self.hash = hash
+        self.bitmap = bitmap
+        self.result = result
+
+    def deserialize(self, f):
+        self.height = struct.unpack("<I", f.read(4))[0]
+        self.hash = deser_uint256(f)
+        self.bitmap = deser_byte_vector(f)
+        self.result = deser_vector(f, BIP64Coin)
+
+    def serialize(self):
+        r = b""
+        r += self.pack("<I", self.height)
+        r += ser_uint256(self.hash)
+        r += ser_byte_vector(self.bitmap)
+        r += ser_vector(BIP64Coin, self.result)
+        return r
+
+    def __repr__(self):
+        return "msg_utxos(height=%i hash=%064x bitmap=%s result=%s)" % (self.height, self.hash, repr(self.bitmap), repr(self.result))

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -1393,7 +1393,9 @@ class NodeConnCB(object):
             "headers": self.on_headers,
             "getheaders": self.on_getheaders,
             "reject": self.on_reject,
-            "mempool": self.on_mempool
+            "mempool": self.on_mempool,
+            "utxos" : self.on_utxos
+
         }
 
     def deliver(self, conn, message):
@@ -1444,6 +1446,7 @@ class NodeConnCB(object):
     def on_cmpctblock(self, conn, message): pass
     def on_getblocktxn(self, conn, message): pass
     def on_blocktxn(self, conn, message): pass
+    def on_utxos(self, conn, message): pass
 
 # More useful callbacks and functions for NodeConnCB's which have a single NodeConn
 class SingleNodeConnCB(NodeConnCB):
@@ -1479,6 +1482,7 @@ class SingleNodeConnCB(NodeConnCB):
 # The actual NodeConn class
 # This class provides an interface for a p2p connection to a specified node
 class NodeConn(asyncore.dispatcher):
+    from test_framework.bip64 import msg_utxos
     messagemap = {
         b"version": msg_version,
         b"verack": msg_verack,
@@ -1501,7 +1505,8 @@ class NodeConn(asyncore.dispatcher):
         b"sendcmpct": msg_sendcmpct,
         b"cmpctblock": msg_cmpctblock,
         b"getblocktxn": msg_getblocktxn,
-        b"blocktxn": msg_blocktxn
+        b"blocktxn": msg_blocktxn,
+        b"utxos": msg_utxos
     }
 
     MAGIC_BYTES = {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -81,9 +81,10 @@ BITCOIN_CORE_H = \
   addrdb.h \
   addrman.h \
   base58.h \
+  bip64_getutxo.h \
   blockannounce.h \
-  blockheaderprocessor.h \
   blockencodings.h \
+  blockheaderprocessor.h \
   blockprocessor.h \
   blocksender.h \
   bloom.h \
@@ -202,6 +203,7 @@ libbitcoin_server_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_server_a_SOURCES = \
   addrdb.cpp \
   addrman.cpp \
+  bip64_getutxo.cpp \
   blockannounce.cpp \
   blockheaderprocessor.cpp \
   blockencodings.cpp \

--- a/src/bip64_getutxo.cpp
+++ b/src/bip64_getutxo.cpp
@@ -1,0 +1,51 @@
+#include "bip64_getutxo.h"
+#include "txmempool.h"
+#include "coins.h"
+
+namespace bip64 {
+
+UTXORetriever::UTXORetriever(
+        const std::vector<COutPoint>& o,
+        CCoinsView& viewChain,
+        CTxMemPool* mempool) : outpoints(o)
+{
+    if (mempool != nullptr) {
+        // also check mempool if provided
+        CCoinsViewMemPool viewMempool(&viewChain, *mempool);
+        Process(&viewMempool, mempool);
+    }
+    else {
+        Process(&viewChain, nullptr);
+    }
+}
+
+void UTXORetriever::Process(CCoinsView* view, CTxMemPool* mempool) {
+    for (const COutPoint& vOutPoint : outpoints) {
+        Coin coin;
+        bool hit = view->GetCoin(vOutPoint, coin);
+        if (mempool)
+            hit = hit && !mempool->isSpent(vOutPoint);
+        hits.push_back(hit);
+        if (hit) outs.emplace_back(std::move(coin));
+    }
+}
+
+std::vector<uint8_t> UTXORetriever::GetBitmap() const {
+    std::vector<uint8_t> bitmap;
+    bitmap.resize((outpoints.size() + 7) / 8);
+    for (size_t i = 0; i < hits.size(); ++i) {
+        const bool hit = hits[i];
+        bitmap[i / 8] |= ((uint8_t)hit) << (i % 8);
+    }
+    return bitmap;
+}
+
+std::string UTXORetriever::GetBitmapStr() const {
+    std::string bitmap;
+    for (bool hit : hits) {
+        bitmap.append(hit ? "1" : "0");
+    }
+    return bitmap;
+}
+
+} // ns bip64

--- a/src/bip64_getutxo.cpp
+++ b/src/bip64_getutxo.cpp
@@ -7,26 +7,39 @@ namespace bip64 {
 UTXORetriever::UTXORetriever(
         const std::vector<COutPoint>& o,
         CCoinsView& viewChain,
-        CTxMemPool* mempool) : outpoints(o)
+        CTxMemPool* mempool,
+        size_t maxBytes) : outpoints(o)
 {
     if (mempool != nullptr) {
         // also check mempool if provided
         CCoinsViewMemPool viewMempool(&viewChain, *mempool);
-        Process(&viewMempool, mempool);
+        Process(&viewMempool, mempool, maxBytes);
     }
     else {
-        Process(&viewChain, nullptr);
+        Process(&viewChain, nullptr, maxBytes);
     }
 }
 
-void UTXORetriever::Process(CCoinsView* view, CTxMemPool* mempool) {
+void UTXORetriever::Process(CCoinsView* view, CTxMemPool* mempool, size_t maxBytes) {
+    size_t bytesUsed = outpoints.size() / 8;
+
     for (const COutPoint& vOutPoint : outpoints) {
         Coin coin;
         bool hit = view->GetCoin(vOutPoint, coin);
         if (mempool)
             hit = hit && !mempool->isSpent(vOutPoint);
         hits.push_back(hit);
-        if (hit) outs.emplace_back(std::move(coin));
+        if (!hit)
+            continue;
+
+        CCoin bip64coin(std::move(coin));
+        bytesUsed += bip64coin.GetSizeOf();
+        if (maxBytes != 0 && bytesUsed > maxBytes) {
+            hits.clear();
+            outs.clear();
+            throw std::runtime_error("utxos result exceed max bytes limit");
+        }
+        outs.emplace_back(bip64coin);
     }
 }
 

--- a/src/bip64_getutxo.h
+++ b/src/bip64_getutxo.h
@@ -22,6 +22,10 @@ struct CCoin {
     CCoin() : nHeight(0) {}
     CCoin(Coin&& in) : nHeight(in.nHeight), out(std::move(in.out)) {}
 
+    size_t GetSizeOf() {
+        return 8 /* two uint32_t */ + 8 /* out.nValue */ + out.scriptPubKey.size();
+    }
+
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action)
     {
@@ -36,7 +40,9 @@ class UTXORetriever {
 public:
     UTXORetriever(const std::vector<COutPoint>& o,
                   CCoinsView& viewChain,
-                  CTxMemPool* mempool);
+                  CTxMemPool* mempool,
+                  //! throws if result objects exceed maxBytes (0 == no limit)
+                  size_t maxBytes = 0);
 
     //! An array of bytes encoding one bit for each outpoint queried. Each bit
     //! indicates whether the queried outpoint was found in the UTXO set or not.
@@ -54,7 +60,7 @@ private:
     std::vector<bool> hits;
     std::vector<CCoin> outs;
 
-    void Process(CCoinsView*, CTxMemPool*);
+    void Process(CCoinsView*, CTxMemPool*, size_t maxBytes);
 };
 
 } // ns bip64

--- a/src/bip64_getutxo.h
+++ b/src/bip64_getutxo.h
@@ -1,0 +1,62 @@
+#ifndef BITCOIN_BIP64_GETUTXOS_H
+#define BITCOIN_BIP64_GETUTXOS_H
+
+#include "primitives/transaction.h"
+#include "serialize.h"
+#include "coins.h"
+
+#include <cstdint>
+#include <vector>
+#include <string>
+
+class CTxMemPool;
+
+namespace bip64 {
+
+struct CCoin {
+    uint32_t nHeight;
+    CTxOut out;
+
+    ADD_SERIALIZE_METHODS;
+
+    CCoin() : nHeight(0) {}
+    CCoin(Coin&& in) : nHeight(in.nHeight), out(std::move(in.out)) {}
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        uint32_t nTxVerDummy = 0;
+        READWRITE(nTxVerDummy);
+        READWRITE(nHeight);
+        READWRITE(out);
+    }
+};
+
+class UTXORetriever {
+public:
+    UTXORetriever(const std::vector<COutPoint>& o,
+                  CCoinsView& viewChain,
+                  CTxMemPool* mempool);
+
+    //! An array of bytes encoding one bit for each outpoint queried. Each bit
+    //! indicates whether the queried outpoint was found in the UTXO set or not.
+    std::vector<uint8_t> GetBitmap() const;
+    //! String representation for GetBitmap (human-readable for json output)
+    std::string GetBitmapStr() const;
+    //! Result objects as defined in BIP64
+    const std::vector<CCoin>& GetResults() const { return outs; }
+
+private:
+    // input
+    const std::vector<COutPoint> outpoints;
+
+    // output
+    std::vector<bool> hits;
+    std::vector<CCoin> outs;
+
+    void Process(CCoinsView*, CTxMemPool*);
+};
+
+} // ns bip64
+
+#endif // BITCOIN_BIP64_GETUTXOS_H

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -848,6 +848,9 @@ bool CCoinsViewMemPool::GetCoin(const COutPoint &outpoint, Coin &coin) const {
     if (mempool.lookup(outpoint.hash, tx)) {
         if (outpoint.n < tx.vout.size()) {
             coin = Coin(tx.vout[outpoint.n], MEMPOOL_HEIGHT, false);
+            // FIXME: Always returning true is inconsistent with other
+            // CCoinsView interfaces, where return value is based on coin
+            // spentness.
             return true;
         } else {
             return false;


### PR DESCRIPTION
This introduces the class `bip64::UTXORetriever` to encapsulate and remove duplicate logic between the network message `getutxos` and the rest call `get_utxos`.

In addition a qa test for BIP64 is added.