### PR TITLE
Cherry-pick updates to contrib/linearize

### DIFF
--- a/contrib/linearize/README.md
+++ b/contrib/linearize/README.md
@@ -3,7 +3,7 @@ Construct a linear, no-fork, best version of the blockchain.
 
 ## Step 1: Download hash list
 
-   $ ./linearize-hashes.py linearize.cfg > hashlist.txt
+    $ ./linearize-hashes.py linearize.cfg > hashlist.txt
 
 Required configuration file settings for linearize-hashes:
 * RPC: rpcuser, rpcpassword
@@ -14,7 +14,7 @@ Optional config file setting for linearize-hashes:
 
 ## Step 2: Copy local block data
 
-   $ ./linearize-data.py linearize.cfg
+    $ ./linearize-data.py linearize.cfg
 
 Required configuration file settings:
 * "input": bitcoind blocks/ directory containing blkNNNNN.dat
@@ -26,7 +26,7 @@ output.
 
 Optional config file setting for linearize-data:
 * "netmagic": network magic number
-* "max_out_sz": maximum output file size (default 1000*1000*1000)
+* "max_out_sz": maximum output file size (default `1000*1000*1000`)
 * "split_timestamp": Split files when a new month is first seen, in addition to
 reaching a maximum file size.
 * "file_timestamp": Set each file's last-modified time to that of the

--- a/contrib/linearize/README.md
+++ b/contrib/linearize/README.md
@@ -32,8 +32,11 @@ Required configuration file settings:
 * `output`: Output directory for linearized `blocks/blkNNNNN.dat` output.
 
 Optional config file setting for linearize-data:
-* `file_timestamp`: Set each file's last-modified time to that of the most
-recent block in that file.
+* `debug_output`: Some printouts may not always be desired. If true, such output
+will be printed.
+* `file_timestamp`: Set each file's last-accessed and last-modified times,
+respectively, to the current time and to the timestamp of the most recent block
+written to the script's blockchain.
 * `genesis`: The hash of the genesis block in the blockchain.
 * `input`: bitcoind blocks/ directory containing blkNNNNN.dat
 * `hashlist`: text file containing list of block hashes created by
@@ -41,6 +44,9 @@ linearize-hashes.py.
 * `max_out_sz`: Maximum size for files created by the `output_file` option.
 (Default: `1000*1000*1000 bytes`)
 * `netmagic`: Network magic number.
+* `out_of_order_cache_sz`: If out-of-order blocks are being read, the block can
+be written to a cache so that the blockchain doesn't have to be seeked again.
+This option specifies the cache size. (Default: `100*1000*1000 bytes`)
 * `rev_hash_bytes`: If true, the block hash list written by linearize-hashes.py
 will be byte-reversed when read by linearize-data.py. See the linearize-hashes
 entry for more information.

--- a/contrib/linearize/README.md
+++ b/contrib/linearize/README.md
@@ -7,7 +7,8 @@ run using Python 3 but are compatible with Python 2.
     $ ./linearize-hashes.py linearize.cfg > hashlist.txt
 
 Required configuration file settings for linearize-hashes:
-* RPC: `rpcuser`, `rpcpassword`
+* RPC: `datadir` (Required if `rpcuser` and `rpcpassword` are not specified)
+* RPC: `rpcuser`, `rpcpassword` (Required if `datadir` is not specified)
 
 Optional config file setting for linearize-hashes:
 * RPC: `host`  (Default: `127.0.0.1`)

--- a/contrib/linearize/README.md
+++ b/contrib/linearize/README.md
@@ -1,33 +1,43 @@
 # Linearize
-Construct a linear, no-fork, best version of the blockchain.
+Construct a linear, no-fork, best version of the Bitcoin blockchain.
 
 ## Step 1: Download hash list
 
     $ ./linearize-hashes.py linearize.cfg > hashlist.txt
 
 Required configuration file settings for linearize-hashes:
-* RPC: rpcuser, rpcpassword
+* RPC: `rpcuser`, `rpcpassword`
 
 Optional config file setting for linearize-hashes:
-* RPC: host, port
-* Block chain: min_height, max_height
+* RPC: `host`, `port`  (Default: `127.0.0.1:8332`)
+* Blockchain: `min_height`, `max_height`
+* `rev_hash_bytes`: If true, the written block hash list will be
+byte-reversed. (In other words, the hash returned by getblockhash will have its
+bytes reversed.) False by default. Intended for generation of
+standalone hash lists but safe to use with linearize-data.py, which will output
+the same data no matter which byte format is chosen.
 
 ## Step 2: Copy local block data
 
     $ ./linearize-data.py linearize.cfg
 
 Required configuration file settings:
-* "input": bitcoind blocks/ directory containing blkNNNNN.dat
-* "hashlist": text file containing list of block hashes, linearized-hashes.py
-output.
-* "output_file": bootstrap.dat
+* `output_file`: The file that will contain the final blockchain.
       or
-* "output": output directory for linearized blocks/blkNNNNN.dat output
+* `output`: Output directory for linearized blocks/blkNNNNN.dat output.
 
 Optional config file setting for linearize-data:
-* "netmagic": network magic number
-* "max_out_sz": maximum output file size (default `1000*1000*1000`)
-* "split_timestamp": Split files when a new month is first seen, in addition to
-reaching a maximum file size.
-* "file_timestamp": Set each file's last-modified time to that of the
-most recent block in that file.
+* `file_timestamp`: Set each file's last-modified time to that of the most
+recent block in that file.
+* `genesis`: The hash of the genesis block in the blockchain.
+* `input: bitcoind blocks/ directory containing blkNNNNN.dat
+* `hashlist`: text file containing list of block hashes created by
+linearize-hashes.py.
+* `max_out_sz`: Maximum size for files created by the `output_file` option.
+(Default: `1000*1000*1000 bytes`)
+* `netmagic`: Network magic number.
+* `rev_hash_bytes`: If true, the block hash list written by linearize-hashes.py
+will be byte-reversed when read by linearize-data.py. See the linearize-hashes
+entry for more information.
+* `split_timestamp`: Split blockchain files when a new month is first seen, in
+addition to reaching a maximum file size (`max_out_sz`).

--- a/contrib/linearize/README.md
+++ b/contrib/linearize/README.md
@@ -1,5 +1,6 @@
 # Linearize
-Construct a linear, no-fork, best version of the Bitcoin blockchain.
+Construct a linear, no-fork, best version of the Bitcoin blockchain. The scripts
+run using Python 3 but are compatible with Python 2.
 
 ## Step 1: Download hash list
 
@@ -9,13 +10,17 @@ Required configuration file settings for linearize-hashes:
 * RPC: `rpcuser`, `rpcpassword`
 
 Optional config file setting for linearize-hashes:
-* RPC: `host`, `port`  (Default: `127.0.0.1:8332`)
+* RPC: `host`  (Default: `127.0.0.1`)
+* RPC: `port`  (Default: `8332`)
 * Blockchain: `min_height`, `max_height`
 * `rev_hash_bytes`: If true, the written block hash list will be
 byte-reversed. (In other words, the hash returned by getblockhash will have its
 bytes reversed.) False by default. Intended for generation of
 standalone hash lists but safe to use with linearize-data.py, which will output
 the same data no matter which byte format is chosen.
+
+The `linearize-hashes` script requires a connection, local or remote, to a
+JSON-RPC server. Running `bitcoind` or `bitcoin-qt -server` will be sufficient.
 
 ## Step 2: Copy local block data
 
@@ -24,13 +29,13 @@ the same data no matter which byte format is chosen.
 Required configuration file settings:
 * `output_file`: The file that will contain the final blockchain.
       or
-* `output`: Output directory for linearized blocks/blkNNNNN.dat output.
+* `output`: Output directory for linearized `blocks/blkNNNNN.dat` output.
 
 Optional config file setting for linearize-data:
 * `file_timestamp`: Set each file's last-modified time to that of the most
 recent block in that file.
 * `genesis`: The hash of the genesis block in the blockchain.
-* `input: bitcoind blocks/ directory containing blkNNNNN.dat
+* `input`: bitcoind blocks/ directory containing blkNNNNN.dat
 * `hashlist`: text file containing list of block hashes created by
 linearize-hashes.py.
 * `max_out_sz`: Maximum size for files created by the `output_file` option.

--- a/contrib/linearize/example-linearize.cfg
+++ b/contrib/linearize/example-linearize.cfg
@@ -1,6 +1,7 @@
 # bitcoind RPC settings (linearize-hashes)
 rpcuser=someuser
 rpcpassword=somepassword
+#datadir=~/.bitcoin
 host=127.0.0.1
 port=8332
 #port=18332

--- a/contrib/linearize/example-linearize.cfg
+++ b/contrib/linearize/example-linearize.cfg
@@ -23,7 +23,9 @@ input=/home/example/.bitcoin/blocks
 
 output_file=/home/example/Downloads/bootstrap.dat
 hashlist=hashlist.txt
-split_year=1
 
 # Maxmimum size in bytes of out-of-order blocks cache in memory
 out_of_order_cache_sz = 100000000
+
+# Do we want the reverse the hash bytes coming from getblockhash?
+rev_hash_bytes = False

--- a/contrib/linearize/example-linearize.cfg
+++ b/contrib/linearize/example-linearize.cfg
@@ -1,4 +1,3 @@
-
 # bitcoind RPC settings (linearize-hashes)
 rpcuser=someuser
 rpcpassword=somepassword
@@ -21,6 +20,9 @@ input=/home/example/.bitcoin/blocks
 #genesis=000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943
 #input=/home/example/.bitcoin/testnet3/blocks
 
+# "output" option causes blockchain files to be written to the given location,
+# with "output_file" ignored. If not used, "output_file" is used instead.
+# output=/home/example/blockchain_directory
 output_file=/home/example/Downloads/bootstrap.dat
 hashlist=hashlist.txt
 
@@ -29,3 +31,12 @@ out_of_order_cache_sz = 100000000
 
 # Do we want the reverse the hash bytes coming from getblockhash?
 rev_hash_bytes = False
+
+# On a new month, do we want to set the access and modify times of the new
+# blockchain file?
+file_timestamp = 0
+# Do we want to split the blockchain files given a new month or specific height?
+split_timestamp = 0
+
+# Do we want debug printouts?
+debug_output = False

--- a/contrib/linearize/linearize-data.py
+++ b/contrib/linearize/linearize-data.py
@@ -140,7 +140,7 @@ class BlockDataCopier:
 		if not self.fileOutput and ((self.outsz + blockSizeOnDisk) > self.maxOutSz):
 			self.outF.close()
 			if self.setFileTime:
-				os.utime(outFname, (int(time.time()), highTS))
+				os.utime(self.outFname, (int(time.time()), self.highTS))
 			self.outF = None
 			self.outFname = None
 			self.outFn = self.outFn + 1
@@ -148,12 +148,12 @@ class BlockDataCopier:
 
 		(blkDate, blkTS) = get_blk_dt(blk_hdr)
 		if self.timestampSplit and (blkDate > self.lastDate):
-			print("New month " + blkDate.strftime("%Y-%m") + " @ " + hash_str)
-			lastDate = blkDate
-			if outF:
-				outF.close()
-				if setFileTime:
-					os.utime(outFname, (int(time.time()), highTS))
+			print("New month " + blkDate.strftime("%Y-%m") + " @ " + self.hash_str)
+			self.lastDate = blkDate
+			if self.outF:
+				self.outF.close()
+				if self.setFileTime:
+					os.utime(self.outFname, (int(time.time()), self.highTS))
 				self.outF = None
 				self.outFname = None
 				self.outFn = self.outFn + 1
@@ -161,11 +161,11 @@ class BlockDataCopier:
 
 		if not self.outF:
 			if self.fileOutput:
-				outFname = self.settings['output_file']
+				self.outFname = self.settings['output_file']
 			else:
-				outFname = os.path.join(self.settings['output'], "blk%05d.dat" % self.outFn)
-			print("Output file " + outFname)
-			self.outF = open(outFname, "wb")
+				self.outFname = os.path.join(self.settings['output'], "blk%05d.dat" % self.outFn)
+			print("Output file " + self.outFname)
+			self.outF = open(self.outFname, "wb")
 
 		self.outF.write(inhdr)
 		self.outF.write(blk_hdr)
@@ -229,13 +229,16 @@ class BlockDataCopier:
 			blk_hdr = self.inF.read(80)
 			inExtent = BlockExtent(self.inFn, self.inF.tell(), inhdr, blk_hdr, inLen)
 
-			hash_str = calc_hash_str(blk_hdr)
-			if not hash_str in blkmap:
-				print("Skipping unknown block " + hash_str)
+			self.hash_str = calc_hash_str(blk_hdr)
+			if not self.hash_str in blkmap:
+				# Because blocks can be written to files out-of-order as of 0.10, the script
+				# may encounter blocks it doesn't know about. Treat as debug output.
+				if settings['debug_output'] == 'true':
+					print("Skipping unknown block " + self.hash_str)
 				self.inF.seek(inLen, os.SEEK_CUR)
 				continue
 
-			blkHeight = self.blkmap[hash_str]
+			blkHeight = self.blkmap[self.hash_str]
 			self.blkCountIn += 1
 
 			if self.blkCountOut == blkHeight:
@@ -301,12 +304,15 @@ if __name__ == '__main__':
 		settings['max_out_sz'] = 1000 * 1000 * 1000
 	if 'out_of_order_cache_sz' not in settings:
 		settings['out_of_order_cache_sz'] = 100 * 1000 * 1000
+	if 'debug_output' not in settings:
+		settings['debug_output'] = 'false'
 
 	settings['max_out_sz'] = int(settings['max_out_sz'])
 	settings['split_timestamp'] = int(settings['split_timestamp'])
 	settings['file_timestamp'] = int(settings['file_timestamp'])
 	settings['netmagic'] = unhexlify(settings['netmagic'].encode('utf-8'))
 	settings['out_of_order_cache_sz'] = int(settings['out_of_order_cache_sz'])
+	settings['debug_output'] = settings['debug_output'].lower()
 
 	if 'output_file' not in settings and 'output' not in settings:
 		print("Missing output file / directory")

--- a/contrib/linearize/linearize-data.py
+++ b/contrib/linearize/linearize-data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # linearize-data.py: Construct a linear, no-fork version of the chain.
 #
@@ -8,29 +8,33 @@
 #
 
 from __future__ import print_function, division
+try: # Python 3
+    import http.client as httplib
+except ImportError: # Python 2
+    import httplib
 import json
 import struct
 import re
 import os
 import os.path
 import base64
-import httplib
 import sys
 import hashlib
 import datetime
 import time
 from collections import namedtuple
+from binascii import hexlify, unhexlify
 
 settings = {}
 
 ##### Switch endian-ness #####
 def hex_switchEndian(s):
 	""" Switches the endianness of a hex string (in pairs of hex chars) """
-	pairList = [s[i]+s[i+1] for i in range(0,len(s),2)]
-	return ''.join(pairList[::-1])
+	pairList = [s[i:i+2].encode() for i in range(0, len(s), 2)]
+	return b''.join(pairList[::-1]).decode()
 
 def uint32(x):
-	return x & 0xffffffffL
+	return x & 0xffffffff
 
 def bytereverse(x):
 	return uint32(( ((x) << 24) | (((x) << 8) & 0x00ff0000) |
@@ -41,14 +45,14 @@ def bufreverse(in_buf):
 	for i in range(0, len(in_buf), 4):
 		word = struct.unpack('@I', in_buf[i:i+4])[0]
 		out_words.append(struct.pack('@I', bytereverse(word)))
-	return ''.join(out_words)
+	return b''.join(out_words)
 
 def wordreverse(in_buf):
 	out_words = []
 	for i in range(0, len(in_buf), 4):
 		out_words.append(in_buf[i:i+4])
 	out_words.reverse()
-	return ''.join(out_words)
+	return b''.join(out_words)
 
 def calc_hdr_hash(blk_hdr):
 	hash1 = hashlib.sha256()
@@ -65,7 +69,7 @@ def calc_hash_str(blk_hdr):
 	hash = calc_hdr_hash(blk_hdr)
 	hash = bufreverse(hash)
 	hash = wordreverse(hash)
-	hash_str = hash.encode('hex')
+	hash_str = hexlify(hash).decode('utf-8')
 	return hash_str
 
 def get_blk_dt(blk_hdr):
@@ -217,7 +221,7 @@ class BlockDataCopier:
 
 			inMagic = inhdr[:4]
 			if (inMagic != self.settings['netmagic']):
-				print("Invalid magic: " + inMagic.encode('hex'))
+				print("Invalid magic: " + hexlify(inMagic).decode('utf-8'))
 				return
 			inLenLE = inhdr[4:]
 			su = struct.unpack("<I", inLenLE)
@@ -294,14 +298,14 @@ if __name__ == '__main__':
 	if 'split_timestamp' not in settings:
 		settings['split_timestamp'] = 0
 	if 'max_out_sz' not in settings:
-		settings['max_out_sz'] = 1000L * 1000 * 1000
+		settings['max_out_sz'] = 1000 * 1000 * 1000
 	if 'out_of_order_cache_sz' not in settings:
 		settings['out_of_order_cache_sz'] = 100 * 1000 * 1000
 
-	settings['max_out_sz'] = long(settings['max_out_sz'])
+	settings['max_out_sz'] = int(settings['max_out_sz'])
 	settings['split_timestamp'] = int(settings['split_timestamp'])
 	settings['file_timestamp'] = int(settings['file_timestamp'])
-	settings['netmagic'] = settings['netmagic'].decode('hex')
+	settings['netmagic'] = unhexlify(settings['netmagic'].encode('utf-8'))
 	settings['out_of_order_cache_sz'] = int(settings['out_of_order_cache_sz'])
 
 	if 'output_file' not in settings and 'output' not in settings:

--- a/contrib/linearize/linearize-hashes.py
+++ b/contrib/linearize/linearize-hashes.py
@@ -17,6 +17,12 @@ import sys
 
 settings = {}
 
+##### Switch endian-ness #####
+def hex_switchEndian(s):
+	""" Switches the endianness of a hex string (in pairs of hex chars) """
+	pairList = [s[i]+s[i+1] for i in range(0,len(s),2)]
+	return ''.join(pairList[::-1])
+
 class BitcoinRPC:
 	def __init__(self, host, port, username, password):
 		authpair = "%s:%s" % (username, password)
@@ -70,6 +76,8 @@ def get_block_hashes(settings, max_blocks_per_call=10000):
 				print('JSON-RPC: error at height', height+x, ': ', resp_obj['error'], file=sys.stderr)
 				exit(1)
 			assert(resp_obj['id'] == x) # assume replies are in-sequence
+			if settings['rev_hash_bytes'] == 'true':
+				resp_obj['result'] = hex_switchEndian(resp_obj['result'])
 			print(resp_obj['result'])
 
 		height += num_blocks
@@ -101,6 +109,8 @@ if __name__ == '__main__':
 		settings['min_height'] = 0
 	if 'max_height' not in settings:
 		settings['max_height'] = 313000
+	if 'rev_hash_bytes' not in settings:
+		settings['rev_hash_bytes'] = 'false'
 	if 'rpcuser' not in settings or 'rpcpassword' not in settings:
 		print("Missing username and/or password in cfg file", file=stderr)
 		sys.exit(1)
@@ -109,5 +119,7 @@ if __name__ == '__main__':
 	settings['min_height'] = int(settings['min_height'])
 	settings['max_height'] = int(settings['max_height'])
 
-	get_block_hashes(settings)
+	# Force hash byte format setting to be lowercase to make comparisons easier.
+	settings['rev_hash_bytes'] = settings['rev_hash_bytes'].lower()
 
+	get_block_hashes(settings)

--- a/contrib/linearize/linearize-hashes.py
+++ b/contrib/linearize/linearize-hashes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # linearize-hashes.py:  List blocks in a linear, no-fork version of the chain.
 #
@@ -8,11 +8,14 @@
 #
 
 from __future__ import print_function
+try: # Python 3
+    import http.client as httplib
+except ImportError: # Python 2
+    import httplib
 import json
 import struct
 import re
 import base64
-import httplib
 import sys
 
 settings = {}
@@ -20,26 +23,32 @@ settings = {}
 ##### Switch endian-ness #####
 def hex_switchEndian(s):
 	""" Switches the endianness of a hex string (in pairs of hex chars) """
-	pairList = [s[i]+s[i+1] for i in range(0,len(s),2)]
-	return ''.join(pairList[::-1])
+	pairList = [s[i:i+2].encode() for i in range(0, len(s), 2)]
+	return b''.join(pairList[::-1]).decode()
 
 class BitcoinRPC:
 	def __init__(self, host, port, username, password):
 		authpair = "%s:%s" % (username, password)
-		self.authhdr = "Basic %s" % (base64.b64encode(authpair))
-		self.conn = httplib.HTTPConnection(host, port, False, 30)
+		authpair = authpair.encode('utf-8')
+		self.authhdr = b"Basic " + base64.b64encode(authpair)
+		self.conn = httplib.HTTPConnection(host, port=port, timeout=30)
 
 	def execute(self, obj):
-		self.conn.request('POST', '/', json.dumps(obj),
-			{ 'Authorization' : self.authhdr,
-			  'Content-type' : 'application/json' })
+		try:
+			self.conn.request('POST', '/', json.dumps(obj),
+				{ 'Authorization' : self.authhdr,
+				  'Content-type' : 'application/json' })
+		except ConnectionRefusedError:
+			print('RPC connection refused. Check RPC settings and the server status.',
+			      file=sys.stderr)
+			return None
 
 		resp = self.conn.getresponse()
 		if resp is None:
 			print("JSON-RPC: no response", file=sys.stderr)
 			return None
 
-		body = resp.read()
+		body = resp.read().decode('utf-8')
 		resp_obj = json.loads(body)
 		return resp_obj
 
@@ -70,6 +79,9 @@ def get_block_hashes(settings, max_blocks_per_call=10000):
 			batch.append(rpc.build_request(x, 'getblockhash', [height + x]))
 
 		reply = rpc.execute(batch)
+		if reply is None:
+			print('Cannot continue. Program will halt.')
+			return None
 
 		for x,resp_obj in enumerate(reply):
 			if rpc.response_is_error(resp_obj):

--- a/contrib/linearize/linearize-hashes.py
+++ b/contrib/linearize/linearize-hashes.py
@@ -17,6 +17,8 @@ import struct
 import re
 import base64
 import sys
+import os
+import os.path
 
 settings = {}
 
@@ -94,6 +96,14 @@ def get_block_hashes(settings, max_blocks_per_call=10000):
 
 		height += num_blocks
 
+def get_rpc_cookie():
+	# Open the cookie file
+	with open(os.path.join(os.path.expanduser(settings['datadir']), '.cookie'), 'r') as f:
+		combined = f.readline()
+		combined_split = combined.split(":")
+		settings['rpcuser'] = combined_split[0]
+		settings['rpcpassword'] = combined_split[1]
+
 if __name__ == '__main__':
 	if len(sys.argv) != 2:
 		print("Usage: linearize-hashes.py CONFIG-FILE")
@@ -123,8 +133,15 @@ if __name__ == '__main__':
 		settings['max_height'] = 313000
 	if 'rev_hash_bytes' not in settings:
 		settings['rev_hash_bytes'] = 'false'
+
+	use_userpass = True
+	use_datadir = False
 	if 'rpcuser' not in settings or 'rpcpassword' not in settings:
-		print("Missing username and/or password in cfg file", file=stderr)
+		use_userpass = False
+	if 'datadir' in settings and not use_userpass:
+		use_datadir = True
+	if not use_userpass and not use_datadir:
+		print("Missing datadir or username and/or password in cfg file", file=stderr)
 		sys.exit(1)
 
 	settings['port'] = int(settings['port'])
@@ -133,5 +150,9 @@ if __name__ == '__main__':
 
 	# Force hash byte format setting to be lowercase to make comparisons easier.
 	settings['rev_hash_bytes'] = settings['rev_hash_bytes'].lower()
+
+	# Get the rpc user and pass from the cookie if the datadir is set
+	if use_datadir:
+		get_rpc_cookie()
 
 	get_block_hashes(settings)


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/pull/6372 Update Linearize tool to support Windows paths
https://github.com/bitcoin/bitcoin/pull/9373 Support hash byte reversal, support python3
https://github.com/bitcoin/bitcoin/pull/9580 Fix various minor linearization script issues
https://github.com/bitcoin/bitcoin/pull/10104 Adds the a datadir option to the linearize configuration file

Only one trivial conflict.  Bypassed changes from broad refactorings.