### PR TITLE
More net cherries

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -132,6 +132,7 @@ BITCOIN_CORE_H = \
   miner.h \
   net.h \
   netbase.h \
+  netmessagemaker.h \
   nodestate.h \
   noui.h \
   options.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -102,6 +102,7 @@ BITCOIN_TESTS =\
   test/sighash_tests.cpp \
   test/sigopcount_tests.cpp \
   test/skiplist_tests.cpp \
+  test/streams_tests.cpp \
   test/test_bitcoin.cpp \
   test/test_bitcoin.h \
   test/test_random.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -65,6 +65,7 @@ BITCOIN_TESTS =\
   test/compactthin_tests.cpp \
   test/compacttxfinder_tests.cpp \
   test/compress_tests.cpp \
+  test/dummyconnman.h \
   test/crypto_tests.cpp \
   test/curl_tests.cpp \
   test/dbwrapper_tests.cpp \

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -176,8 +176,8 @@ public:
 //! the maximum number of tried addr collisions to store
 #define ADDRMAN_SET_TRIED_COLLISION_SIZE 10
 
-/** 
- * Stochastical (IP) address manager 
+/**
+ * Stochastical (IP) address manager
  */
 class CAddrMan
 {
@@ -540,23 +540,19 @@ public:
     //! Mark an entry as accessible.
     void Good(const CService &addr, bool test_before_evict = true, int64_t nTime = GetAdjustedTime())
     {
-        {
-            LOCK(cs);
-            Check();
-            Good_(addr, test_before_evict, nTime);
-            Check();
-        }
+        LOCK(cs);
+        Check();
+        Good_(addr, test_before_evict, nTime);
+        Check();
     }
 
     //! Mark an entry as connection attempted to.
     void Attempt(const CService &addr, bool fCountFailure, int64_t nTime = GetAdjustedTime())
     {
-        {
-            LOCK(cs);
-            Check();
-            Attempt_(addr, fCountFailure, nTime);
-            Check();
-        }
+        LOCK(cs);
+        Check();
+        Attempt_(addr, fCountFailure, nTime);
+        Check();
     }
 
     //! See if any to-be-evicted tried table entries have been tested and if so resolve the collisions.
@@ -612,12 +608,10 @@ public:
     //! Mark an entry as currently-connected-to.
     void Connected(const CService &addr, int64_t nTime = GetAdjustedTime())
     {
-        {
-            LOCK(cs);
-            Check();
-            Connected_(addr, nTime);
-            Check();
-        }
+        LOCK(cs);
+        Check();
+        Connected_(addr, nTime);
+        Check();
     }
 
 };

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -493,6 +493,7 @@ public:
     //! Return the number of (unique) addresses in all tables.
     size_t size() const
     {
+        LOCK(cs); // TODO: Cache this in an atomic to avoid this overhead
         return vRandom.size();
     }
 
@@ -512,13 +513,11 @@ public:
     //! Add a single address.
     bool Add(const CAddress &addr, const CNetAddr& source, int64_t nTimePenalty = 0)
     {
+        LOCK(cs);
         bool fRet = false;
-        {
-            LOCK(cs);
-            Check();
-            fRet |= Add_(addr, source, nTimePenalty);
-            Check();
-        }
+        Check();
+        fRet |= Add_(addr, source, nTimePenalty);
+        Check();
         if (fRet)
             LogPrint(Log::ADDRMAN, "Added %s from %s: %i tried, %i new\n", addr.ToStringIPPort(), source.ToString(), nTried, nNew);
         return fRet;
@@ -527,14 +526,12 @@ public:
     //! Add multiple addresses.
     bool Add(const std::vector<CAddress> &vAddr, const CNetAddr& source, int64_t nTimePenalty = 0)
     {
+        LOCK(cs);
         int nAdd = 0;
-        {
-            LOCK(cs);
-            Check();
-            for (std::vector<CAddress>::const_iterator it = vAddr.begin(); it != vAddr.end(); it++)
-                nAdd += Add_(*it, source, nTimePenalty) ? 1 : 0;
-            Check();
-        }
+        Check();
+        for (std::vector<CAddress>::const_iterator it = vAddr.begin(); it != vAddr.end(); it++)
+            nAdd += Add_(*it, source, nTimePenalty) ? 1 : 0;
+        Check();
         if (nAdd)
             LogPrint(Log::ADDRMAN, "Added %i addresses from %s: %i tried, %i new\n", nAdd, source.ToString(), nTried, nNew);
         return nAdd > 0;

--- a/src/blockannounce.cpp
+++ b/src/blockannounce.cpp
@@ -5,6 +5,7 @@
 #include "blocksender.h"
 #include "main.h" // for mapBlockIndex, UpdateBlockAvailability, IsInitialBlockDownload
 #include "net.h" // CConnman
+#include "netmessagemaker.h"
 #include "options.h"
 #include "timedata.h"
 #include "inflightindex.h"
@@ -97,7 +98,8 @@ BlockAnnounceReceiver::DownloadStrategy BlockAnnounceReceiver::pickDownloadStrat
 
 static void requestHeaders(CConnman& connman, CNode& from, const uint256& block) {
 
-    connman.PushMessage(&from, "getheaders", chainActive.GetLocator(pindexBestHeader), block);
+    connman.PushMessage(&from, NetMsg(&from, NetMsgType::GETHEADERS,
+                                      chainActive.GetLocator(pindexBestHeader), block));
     LogPrint(Log::NET, "getheaders (%d) %s to peer=%d\n",
             pindexBestHeader->nHeight, block.ToString(), from.id);
 }
@@ -303,7 +305,7 @@ bool BlockAnnounceSender::announceWithHeaders() {
             headers.front().GetHash().ToString(),
             headers.back().GetHash().ToString(), to.id);
 
-    connman.PushMessage(&to, "headers", headers);
+    connman.PushMessage(&to, NetMsg(&to, NetMsgType::HEADERS, headers));
     UpdateBestHeaderSent(to, best);
 
     return true;

--- a/src/blockannounce.h
+++ b/src/blockannounce.h
@@ -10,6 +10,7 @@
 class BlockSender;
 class CInv;
 class CNode;
+class CConnman;
 class ThinBlockManager;
 class InFlightIndex;
 
@@ -17,9 +18,9 @@ class InFlightIndex;
 class BlockAnnounceReceiver {
 
     public:
-        BlockAnnounceReceiver(uint256 block,
+        BlockAnnounceReceiver(uint256 block, CConnman& c,
                 CNode& from, ThinBlockManager& thinmg, InFlightIndex& inFlightIndex) :
-            block(block), from(from), thinmg(thinmg), blocksInFlight(inFlightIndex)
+            block(block), connman(c), from(from), thinmg(thinmg), blocksInFlight(inFlightIndex)
         {
         }
 	virtual ~BlockAnnounceReceiver() { }
@@ -45,6 +46,7 @@ class BlockAnnounceReceiver {
 
     private:
         uint256 block;
+        CConnman& connman;
         CNode& from;
         ThinBlockManager& thinmg;
         InFlightIndex& blocksInFlight;
@@ -59,7 +61,7 @@ static const unsigned int MAX_BLOCKS_TO_ANNOUNCE = 8;
 class BlockAnnounceSender {
 
     public:
-        BlockAnnounceSender(CNode& to) : to(to) { }
+        BlockAnnounceSender(CConnman& c, CNode& to) : connman(c), to(to) { }
         virtual ~BlockAnnounceSender() { }
 
         void announce();
@@ -75,6 +77,7 @@ class BlockAnnounceSender {
     private:
         bool peerHasHeader(const class CBlockIndex*) const;
 
+        CConnman& connman;
         CNode& to;
 };
 

--- a/src/blockheaderprocessor.cpp
+++ b/src/blockheaderprocessor.cpp
@@ -22,12 +22,12 @@ bool headerConnects(const CBlockHeader& h) {
     return mapBlockIndex.find(h.hashPrevBlock) != mapBlockIndex.end();
 }
 
-DefaultHeaderProcessor::DefaultHeaderProcessor(CNode* pfrom,
+DefaultHeaderProcessor::DefaultHeaderProcessor(CConnman& connman, CNode* pfrom,
         InFlightIndex& i,
         ThinBlockManager& mg,
         BlockInFlightMarker& inFlight,
         std::function<void()> checkBlockIndex) :
-    pfrom(pfrom), blocksInFlight(i), thinmg(mg), markAsInFlight(inFlight),
+    connman(connman), pfrom(pfrom), blocksInFlight(i), thinmg(mg), markAsInFlight(inFlight),
     checkBlockIndex(checkBlockIndex)
 {
 }
@@ -49,7 +49,7 @@ CBlockIndex* DefaultHeaderProcessor::operator()(const std::vector<CBlockHeader>&
         // TODO: optimize: if pindexLast is an ancestor of chainActive.Tip or pindexBestHeader, continue
         // from there instead.
         LogPrint(Log::NET, "more getheaders (%d) to end to peer=%d (startheight:%d)\n", pindexLast->nHeight, pfrom->id, pfrom->nStartingHeight);
-        pfrom->PushMessage("getheaders", chainActive.GetLocator(pindexLast), uint256());
+        connman.PushMessage(pfrom, "getheaders", chainActive.GetLocator(pindexLast), uint256());
     }
 
     if (pindexLast && maybeAnnouncement && hasEqualOrMoreWork(pindexLast)) {
@@ -137,7 +137,7 @@ void DefaultHeaderProcessor::suggestDownload(const std::vector<CBlockIndex*>& to
     for (auto b : boost::adaptors::reverse(toFetch)) {
 
         BlockAnnounceReceiver ann(b->GetBlockHash(),
-                *pfrom, thinmg, blocksInFlight);
+                                  connman, *pfrom, thinmg, blocksInFlight);
 
         // Stop if we don't want to download this block now.
         // Won't want next.
@@ -151,7 +151,7 @@ void DefaultHeaderProcessor::suggestDownload(const std::vector<CBlockIndex*>& to
     if (!toGet.empty()) {
         LogPrint(Log::NET, "Downloading blocks toward %s (%d) via headers direct fetch\n",
                 last->GetBlockHash().ToString(), last->nHeight);
-        pfrom->PushMessage("getdata", toGet);
+        connman.PushMessage(pfrom, "getdata", toGet);
     }
 }
 
@@ -161,7 +161,7 @@ void DefaultHeaderProcessor::suggestDownload(const std::vector<CBlockIndex*>& to
 // Return: If header request was needed. In this case,
 // the current header cannot be processed.
 bool DefaultHeaderProcessor::requestConnectHeaders(const CBlockHeader& h,
-                                                   CNode& from,
+                                                   CConnman& connman, CNode& from,
                                                    bool bumpUnconnecting)
 {
     if (headerConnects(h))
@@ -173,7 +173,7 @@ bool DefaultHeaderProcessor::requestConnectHeaders(const CBlockHeader& h,
             h.GetHash().ToString(), h.hashPrevBlock.ToString(), from.id);
 
 
-    from.PushMessage("getheaders",
+    connman.PushMessage(&from, "getheaders",
             chainActive.GetLocator(pindexBestHeader), uint256());
 
     if (!bumpUnconnecting)

--- a/src/blockheaderprocessor.h
+++ b/src/blockheaderprocessor.h
@@ -5,6 +5,7 @@
 #include <tuple>
 #include <stdexcept>
 
+class CConnman;
 class CNode;
 class CBlockHeader;
 class CBlockIndex;
@@ -23,7 +24,8 @@ class BlockHeaderProcessor {
                 bool peerSentMax,
                 bool maybeAnnouncement) = 0;
         virtual ~BlockHeaderProcessor() = 0;
-        virtual bool requestConnectHeaders(const CBlockHeader& h, CNode& from,
+        virtual bool requestConnectHeaders(const CBlockHeader& h,
+                                           CConnman&, CNode& from,
                                            bool bumpUnconnecting) = 0;
 };
 inline BlockHeaderProcessor::~BlockHeaderProcessor() { }
@@ -31,8 +33,7 @@ inline BlockHeaderProcessor::~BlockHeaderProcessor() { }
 /// Process a block header received from another peer on the network.
 class DefaultHeaderProcessor : public BlockHeaderProcessor {
     public:
-
-        DefaultHeaderProcessor(CNode* pfrom,
+        DefaultHeaderProcessor(CConnman&, CNode* pfrom,
                 InFlightIndex&, ThinBlockManager&, BlockInFlightMarker&,
                 std::function<void()> checkBlockIndex);
 
@@ -40,7 +41,8 @@ class DefaultHeaderProcessor : public BlockHeaderProcessor {
                 bool peerSentMax,
                 bool maybeAnnouncement) override;
 
-        bool requestConnectHeaders(const CBlockHeader& h, CNode& from,
+        bool requestConnectHeaders(const CBlockHeader& h,
+                                   CConnman&, CNode& from,
                                    bool bumpUnconnecting) override;
 
     protected:
@@ -55,6 +57,7 @@ class DefaultHeaderProcessor : public BlockHeaderProcessor {
         void suggestDownload(
                 const std::vector<CBlockIndex*>& toFetch, CBlockIndex* last);
 
+        CConnman& connman;
         CNode* pfrom;
         InFlightIndex& blocksInFlight;
         ThinBlockManager& thinmg;

--- a/src/blockprocessor.cpp
+++ b/src/blockprocessor.cpp
@@ -2,6 +2,7 @@
 #include "blockheaderprocessor.h"
 #include "consensus/validation.h"
 #include "main.h" // Misbehaving
+#include "netmessagemaker.h"
 #include "thinblock.h"
 #include "util.h"
 #include "utilprocessmsg.h"
@@ -16,8 +17,8 @@ void BlockProcessor::rejectBlock(
     LogPrintf("rejecting %s from peer=%d - %s\n",
         netcmd, from.id, reason);
 
-    connman.PushMessage(&from, "reject", netcmd, REJECT_MALFORMED,
-                     reason.substr(0, MAX_REJECT_MESSAGE_LENGTH), block);
+    connman.PushMessage(&from, NetMsg(&from, NetMsgType::REJECT, netcmd, REJECT_MALFORMED,
+                                      reason.substr(0, MAX_REJECT_MESSAGE_LENGTH), block));
 
     this->misbehave(misbehave, "block rejected " + reason);
     worker.stopWork(block);

--- a/src/blockprocessor.cpp
+++ b/src/blockprocessor.cpp
@@ -16,7 +16,7 @@ void BlockProcessor::rejectBlock(
     LogPrintf("rejecting %s from peer=%d - %s\n",
         netcmd, from.id, reason);
 
-    from.PushMessage("reject", netcmd, REJECT_MALFORMED,
+    connman.PushMessage(&from, "reject", netcmd, REJECT_MALFORMED,
                      reason.substr(0, MAX_REJECT_MESSAGE_LENGTH), block);
 
     this->misbehave(misbehave, "block rejected " + reason);
@@ -80,7 +80,7 @@ bool BlockProcessor::setToWork(const CBlockHeader& header, int activeChainHeight
 }
 
 bool BlockProcessor::requestConnectHeaders(const CBlockHeader& header, bool bumpUnconnecting) {
-    bool needPrevHeaders = headerProcessor.requestConnectHeaders(header, from, bumpUnconnecting);
+    bool needPrevHeaders = headerProcessor.requestConnectHeaders(header, connman, from, bumpUnconnecting);
 
     if (needPrevHeaders) {
         // We don't have previous block. We can't connect it to the chain.

--- a/src/blockprocessor.h
+++ b/src/blockprocessor.h
@@ -2,6 +2,7 @@
 #define BLOCKPROCESSOR_H
 
 #include <string>
+class CConnman;
 class CNode;
 class ThinBlockWorker;
 class BlockHeaderProcessor;
@@ -12,9 +13,9 @@ class CBlockIndex;
 class BlockProcessor {
 
     public:
-        BlockProcessor(CNode& f, ThinBlockWorker& w,
+        BlockProcessor(CConnman& c, CNode& f, ThinBlockWorker& w,
                 const std::string& netcmd, BlockHeaderProcessor& h) :
-            from(f), worker(w), netcmd(netcmd), headerProcessor(h)
+            connman(c), from(f), worker(w), netcmd(netcmd), headerProcessor(h)
         {
         }
 
@@ -23,6 +24,7 @@ class BlockProcessor {
         bool setToWork(const CBlockHeader& hash, int activeChainHeight);
 
     protected:
+        CConnman& connman;
         CNode& from;
         ThinBlockWorker& worker;
         virtual void misbehave(int howmuch, const std::string& what);

--- a/src/blocksender.h
+++ b/src/blocksender.h
@@ -5,6 +5,7 @@
 #define BITCOIN_BLOCKSENDER_H
 
 class CChain;
+class CConnman;
 class CBlockIndex;
 class CInv;
 class CNode;
@@ -24,24 +25,24 @@ class BlockSender {
         bool canSend(const CChain& activeChain, const CBlockIndex& block,
             CBlockIndex *pindexBestHeader);
 
-        void send(const CChain& activeChain, CNode& node,
+        void send(const CChain& activeChain, CConnman&, CNode& node,
             CBlockIndex& blockIndex, const CInv& inv);
 
-        virtual void sendBlock(CNode& node,
+        virtual void sendBlock(CConnman&, CNode& node,
             const CBlockIndex& blockIndex, int invType, int activeChainHeight);
 
         // Creates a response for a re-request for transactions missing
         // from a thin block.
-        void sendReReqReponse(CNode& node, const CBlockIndex& blockIndex,
+        void sendReReqReponse(CConnman&, CNode& node, const CBlockIndex& blockIndex,
             const XThinReRequest& req, int activeChainHeight);
 
         // Creates a response for a re-request for transactions missing
         // from a compact thin block.
-        void sendReReqReponse(CNode& node, const CBlockIndex& blockIndex,
+        void sendReReqReponse(CConnman&, CNode& node, const CBlockIndex& blockIndex,
             const CompactReRequest& req, int activeChainHeight);
 
     protected: // used in unit tests
-        void triggerNextRequest(const CChain& activeChain, const CInv& inv, CNode& node);
+        virtual void triggerNextRequest(const CChain& activeChain, const CInv& inv, CConnman&, CNode& node);
         virtual bool readBlockFromDisk(CBlock& block, const CBlockIndex* pindex);
 };
 

--- a/src/compactblockprocessor.cpp
+++ b/src/compactblockprocessor.cpp
@@ -49,7 +49,7 @@ void CompactBlockProcessor::operator()(CDataStream& vRecv, const CTxMemPool& mem
                 block.shorttxidk0, block.shorttxidk1);
 
         stub.reset(new CompactStub(block));
-        worker.buildStub(*stub, txfinder, from);
+        worker.buildStub(*stub, txfinder, connman, from);
     }
     catch (const thinblock_error& e) {
         rejectBlock(hash, e.what(), 10);
@@ -73,5 +73,5 @@ void CompactBlockProcessor::operator()(CDataStream& vRecv, const CTxMemPool& mem
 
     LogPrint(Log::BLOCK, "re-requesting %d compact txs for %s peer=%d\n",
             req.indexes.size(), hash.ToString(), from.id);
-    from.PushMessage("getblocktxn", req);
+    connman.PushMessage(&from, "getblocktxn", req);
 }

--- a/src/compactblockprocessor.cpp
+++ b/src/compactblockprocessor.cpp
@@ -5,6 +5,7 @@
 #include "streams.h"
 #include "util.h" // LogPrintf
 #include "net.h"
+#include "netmessagemaker.h"
 #include "utilprocessmsg.h"
 #include "consensus/validation.h"
 #include "compacttxfinder.h"
@@ -73,5 +74,5 @@ void CompactBlockProcessor::operator()(CDataStream& vRecv, const CTxMemPool& mem
 
     LogPrint(Log::BLOCK, "re-requesting %d compact txs for %s peer=%d\n",
             req.indexes.size(), hash.ToString(), from.id);
-    connman.PushMessage(&from, "getblocktxn", req);
+    connman.PushMessage(&from, NetMsg(&from, NetMsgType::GETBLOCKTXN, req));
 }

--- a/src/compactblockprocessor.h
+++ b/src/compactblockprocessor.h
@@ -8,9 +8,8 @@ class CTxMemPool;
 
 class CompactBlockProcessor : public BlockProcessor {
     public:
-
-        CompactBlockProcessor(CNode& f, ThinBlockWorker& w, BlockHeaderProcessor& h) :
-            BlockProcessor(f, w, "cmpctblock", h)
+        CompactBlockProcessor(CConnman& c, CNode& f, ThinBlockWorker& w, BlockHeaderProcessor& h) :
+            BlockProcessor(c, f, w, "cmpctblock", h)
         {
         }
 

--- a/src/compactthin.cpp
+++ b/src/compactthin.cpp
@@ -16,19 +16,20 @@ CompactWorker::CompactWorker(ThinBlockManager& m, NodeId n) :
 }
 
 void CompactWorker::requestBlock(const uint256& block,
-        std::vector<CInv>& getDataReq, CNode& node) {
+                                 std::vector<CInv>& getDataReq,
+                                 CConnman&, CNode&) {
 
     getDataReq.push_back(CInv(MSG_CMPCT_BLOCK, block));
 }
 
 class CompactAnn : public BlockAnnHandle {
     public:
-        CompactAnn(CNode& n) : node(&n) {
+        CompactAnn(CConnman& c, CNode& n) : connman(c), node(&n) {
 
             LogPrint(Log::ANN, "requesting compact block announcements "
                     "peer=%d\n", nodeID());
 
-            enableCompactBlocks(*node, true);
+            enableCompactBlocks(connman, *node, true);
 
             finalizeCallb = [=](NodeId id, bool) {
                 if (id != nodeID())
@@ -45,7 +46,7 @@ class CompactAnn : public BlockAnnHandle {
             LogPrint(Log::ANN, "un-requesting compact block announcements "
                     "peer=%d\n", nodeID());
 
-            enableCompactBlocks(*node, false);
+            enableCompactBlocks(connman, *node, false);
         }
 
         void onNodeDestroyed(NodeId id) {
@@ -58,13 +59,14 @@ class CompactAnn : public BlockAnnHandle {
             return node ? node->id : -1;
         }
 
+        CConnman& connman;
         CNode* node;
         std::function<void(NodeId, bool)> finalizeCallb;
         boost::signals2::connection finalizeCallbConn;
 };
 
-std::unique_ptr<BlockAnnHandle> CompactWorker::requestBlockAnnouncements(CNode& n) {
-    return std::unique_ptr<BlockAnnHandle>(new CompactAnn(n));
+std::unique_ptr<BlockAnnHandle> CompactWorker::requestBlockAnnouncements(CConnman& c, CNode& n) {
+    return std::unique_ptr<BlockAnnHandle>(new CompactAnn(c, n));
 }
 
 std::vector<ThinTx> CompactStub::allTransactions() const {
@@ -100,7 +102,7 @@ std::vector<ThinTx> CompactStub::allTransactions() const {
     return all;
 }
 
-void enableCompactBlocks(CNode& node, bool highBandwidth) {
+void enableCompactBlocks(CConnman& connman, CNode& node, bool highBandwidth) {
     uint64_t version = 1;
-    node.PushMessage("sendcmpct", highBandwidth, version);
+    connman.PushMessage(&node, "sendcmpct", highBandwidth, version);
 }

--- a/src/compactthin.cpp
+++ b/src/compactthin.cpp
@@ -5,6 +5,7 @@
 #include "compactthin.h"
 #include "blockencodings.h"
 #include "net.h"
+#include "netmessagemaker.h"
 #include "protocol.h"
 #include "util.h"
 
@@ -104,5 +105,5 @@ std::vector<ThinTx> CompactStub::allTransactions() const {
 
 void enableCompactBlocks(CConnman& connman, CNode& node, bool highBandwidth) {
     uint64_t version = 1;
-    connman.PushMessage(&node, "sendcmpct", highBandwidth, version);
+    connman.PushMessage(&node, NetMsg(&node, NetMsgType::SENDCMPCT, highBandwidth, version));
 }

--- a/src/compactthin.h
+++ b/src/compactthin.h
@@ -8,6 +8,8 @@
 #include "thinblock.h"
 #include "util.h"
 
+class CConnman;
+
 // Core also wanted to make their own thin
 // blocks solution; Compact Blocks (BIP152)
 //
@@ -19,8 +21,10 @@ class CompactWorker : public ThinBlockWorker {
         CompactWorker(ThinBlockManager&, NodeId);
 
         void requestBlock(const uint256& block,
-                std::vector<CInv>& getDataReq, CNode& node) override;
-        std::unique_ptr<BlockAnnHandle> requestBlockAnnouncements(CNode& n) override;
+                          std::vector<CInv>& getDataReq,
+                          CConnman&, CNode& node) override;
+
+        std::unique_ptr<BlockAnnHandle> requestBlockAnnouncements(CConnman&, CNode& n) override;
 };
 
 
@@ -51,6 +55,6 @@ struct CompactStub : public StubData {
         CompactBlock block;
 };
 
-void enableCompactBlocks(CNode& node, bool highBandwidth);
+void enableCompactBlocks(CConnman&, CNode& node, bool highBandwidth);
 
 #endif

--- a/src/dummythin.h
+++ b/src/dummythin.h
@@ -15,13 +15,14 @@ class DummyThinWorker : public ThinBlockWorker {
 
         bool addTx(const uint256&, const CTransaction& tx) override { return false; }
 
-        void buildStub(const StubData&, const TxFinder&, CNode& from) override { }
+        void buildStub(const StubData&, const TxFinder&, CConnman&, CNode&) override { }
         void addWork(const uint256& block) override { }
         void stopWork(const uint256& block) override { }
         void stopAllWork() override { }
 
         void requestBlock(const uint256& block,
-                std::vector<CInv>& getDataReq, CNode& node) override { }
+                          std::vector<CInv>& getDataReq,
+                          CConnman&, CNode& node) override { }
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5549,7 +5549,6 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv,
     return true;
 }
 
-// requires LOCK(cs_vRecvMsg)
 bool ProcessMessages(CNode* pfrom, CConnman* connman, std::atomic<bool>& interruptMsgProc)
 {
     //

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4530,7 +4530,6 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv,
         throw std::invalid_argument(std::string(__func__ )+ " requires connection manager");
 
     RandAddSeedPerfmon();
-    unsigned int nMaxSendBufferSize = connman->GetSendBufferSize();
 
     LogPrint(Log::NET, "received: %s (%u bytes) peer=%d\n", SanitizeString(strCommand), vRecv.size(), pfrom->id);
     if (mapArgs.count("-dropmessagestest") && GetRand(atoi(mapArgs["-dropmessagestest"])) == 0)
@@ -4832,11 +4831,6 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv,
 
             // Track requests for our stuff
             GetMainSignals().Inventory(inv.hash);
-
-            if (pfrom->nSendSize > (nMaxSendBufferSize * 2)) {
-                Misbehaving(pfrom->GetId(), 50, "send buffer size exceeded");
-                return error("send buffer size() = %u", pfrom->nSendSize);
-            }
         }
 
         if (!vToFetch.empty())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,7 +77,7 @@ CBlockIndex *pindexBestHeader = NULL;
 int64_t nTimeBestReceived = 0;
 CWaitableCriticalSection csBestBlock;
 CConditionVariable cvBlockChange;
-bool fImporting = false;
+std::atomic_bool fImporting(false);
 bool fReindex = false;
 bool fTxIndex = false;
 bool fHavePruned = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2664,7 +2664,7 @@ bool ActivateBestChain(CValidationState &state, CBlock *pblock, const BlockSourc
                     for (auto h : hashesToAnnounce)
                         pnode->PushBlockHash(h);
                 });
-            // Notify external listeners about the new tip.
+            connman->WakeMessageHandler();
         }
         if (nStopAtHeight && pindexNewTip && pindexNewTip->nHeight >= nStopAtHeight) StartShutdown();
     } while(pindexNewTip != pindexMostWork);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5892,7 +5892,7 @@ bool SendMessages(CNode* pto, CConnman* connman, std::atomic<bool>& interruptMsg
 
         // Detect whether we're stalling
         nNow = GetTimeMicros();
-        if (!pto->fDisconnect && statePtr->nStallingSince && statePtr->nStallingSince < nNow - 1000000 * BLOCK_STALLING_TIMEOUT) {
+        if (statePtr->nStallingSince && statePtr->nStallingSince < nNow - 1000000 * BLOCK_STALLING_TIMEOUT) {
             // Stalling only triggers when the block download window cannot move. During normal steady state,
             // the download window should be much larger than the to-be-downloaded set of blocks, so disconnection
             // should only happen during initial block download.
@@ -5910,7 +5910,7 @@ bool SendMessages(CNode* pto, CConnman* connman, std::atomic<bool>& interruptMsg
         // only looking at this peer's oldest request).  This way a large queue in the past doesn't result in a
         // permanently large window for this block to be delivered (ie if the number of blocks in flight is decreasing
         // more quickly than once every 5 minutes, then we'll shorten the download window for this block).
-        if (!pto->fDisconnect && statePtr->vBlocksInFlight.size() > 0) {
+        if (statePtr->vBlocksInFlight.size() > 0) {
             QueuedBlock &queuedBlock = statePtr->vBlocksInFlight.front();
             int64_t nTimeoutIfRequestedNow = GetBlockTimeout(nNow, nQueuedValidatedHeaders - statePtr->nBlocksInFlightValidHeaders, consensusParams);
             if (queuedBlock.nTimeDisconnect > nTimeoutIfRequestedNow) {
@@ -5930,7 +5930,7 @@ bool SendMessages(CNode* pto, CConnman* connman, std::atomic<bool>& interruptMsg
         ThinBlockWorker& worker = *(statePtr->thinblock);
         bool fetchData = WillDownloadFromNode(pto, worker);
         vector<CInv> vGetData;
-        if (fetchData && !pto->fDisconnect && !pto->fClient && (fFetch || !IsInitialBlockDownload()) && statePtr->nBlocksInFlight < MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
+        if (fetchData && !pto->fClient && (fFetch || !IsInitialBlockDownload()) && statePtr->nBlocksInFlight < MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
             vector<const CBlockIndex*> vToDownload;
             std::set<NodeId> stallers;
             FindNextBlocksToDownload(pto->GetId(), MAX_BLOCKS_IN_TRANSIT_PER_PEER - statePtr->nBlocksInFlight, vToDownload, stallers);
@@ -5965,7 +5965,7 @@ bool SendMessages(CNode* pto, CConnman* connman, std::atomic<bool>& interruptMsg
         //
         // Message: getdata (non-blocks)
         //
-        while (!pto->fDisconnect && !pto->mapAskFor.empty() && (*pto->mapAskFor.begin()).first <= nNow)
+        while (!pto->mapAskFor.empty() && (*pto->mapAskFor.begin()).first <= nNow)
         {
             const CInv& inv = (*pto->mapAskFor.begin()).second;
             if (!AlreadyHave(inv))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5554,8 +5554,6 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv,
 bool ProcessMessages(CNode* pfrom, CConnman* connman, std::atomic<bool>& interruptMsgProc)
 {
     unsigned int nMaxSendBufferSize = connman->GetSendBufferSize();
-    //if (fDebug)
-    //    LogPrintf("%s(%u messages)\n", __func__, pfrom->vRecvMsg.size());
 
     //
     // Message format
@@ -5581,11 +5579,6 @@ bool ProcessMessages(CNode* pfrom, CConnman* connman, std::atomic<bool>& interru
 
         // get next message
         CNetMessage& msg = *it;
-
-        //if (fDebug)
-        //    LogPrintf("%s(message %u msgsz, %u bytes, complete:%s)\n", __func__,
-        //            msg.hdr.nMessageSize, msg.vRecv.size(),
-        //            msg.complete() ? "Y" : "N");
 
         // end, if an incomplete message is found
         if (!msg.complete())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5594,6 +5594,7 @@ bool ProcessMessages(CNode* pfrom, CConnman* connman, std::atomic<bool>& interru
         // at this point, any failure means we can delete the current message
         it++;
 
+        msg.SetVersion(pfrom->GetRecvVersion());
         // Scan for message start
         if (memcmp(msg.hdr.pchMessageStart, Params().NetworkMagic(), MESSAGE_START_SIZE) != 0) {
             LogPrintf("PROCESSMESSAGE: INVALID MESSAGESTART %s peer=%d\n", SanitizeString(msg.hdr.GetCommand()), pfrom->id);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5578,22 +5578,15 @@ bool ProcessMessages(CNode* pfrom, CConnman* connman, std::atomic<bool>& interru
         if (pfrom->nSendSize >= nMaxSendBufferSize)
             return false;
 
-        // get next message
-        auto it = pfrom->vRecvMsg.begin();
-        if (it == pfrom->vRecvMsg.end())
-            return false;
-
-        // end, if an incomplete message is found
-        if (!it->complete())
-            return false;
-
-        // get next message
-        CNetMessage msg = std::move(*it);
-
-        // at this point, any failure means we can delete the current message
-        pfrom->vRecvMsg.erase(pfrom->vRecvMsg.begin());
-
-        fMoreWork = !pfrom->vRecvMsg.empty() && pfrom->vRecvMsg.front().complete();
+        std::list<CNetMessage> msgs;
+        {
+            LOCK(pfrom->cs_vProcessMsg);
+            if (pfrom->vProcessMsg.empty())
+                return false;
+            // Just take one message
+            msgs.splice(msgs.begin(), pfrom->vProcessMsg, pfrom->vProcessMsg.begin());
+        }
+        CNetMessage& msg(msgs.front());
 
         msg.SetVersion(pfrom->GetRecvVersion());
         // Scan for message start

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5585,6 +5585,8 @@ bool ProcessMessages(CNode* pfrom, CConnman* connman, std::atomic<bool>& interru
                 return false;
             // Just take one message
             msgs.splice(msgs.begin(), pfrom->vProcessMsg, pfrom->vProcessMsg.begin());
+            pfrom->nProcessQueueSize -= msgs.front().vRecv.size() + CMessageHeader::HEADER_SIZE;
+            pfrom->fPauseRecv = pfrom->nProcessQueueSize > connman->GetReceiveFloodSize();
         }
         CNetMessage& msg(msgs.front());
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4702,7 +4702,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv,
         pfrom->SetRecvVersion(min(pfrom->nVersion, PROTOCOL_VERSION));
 
         // Mark this node as currently connected, so we update its timestamp later.
-        if (pfrom->fNetworkNode) {
+        if (!pfrom->fInbound) {
             NodeStatePtr(pfrom->GetId())->fCurrentlyConnected = true;
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4620,7 +4620,6 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv,
         // Change version
         pfrom->SetSendVersion(nSendVersion);
         pfrom->nVersion = nVersion;
-        pfrom->fSuccessfullyConnected = true;
 
         {
             LOCK(cs_main);
@@ -4731,6 +4730,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv,
                 && !(pfrom->SupportsXThinBlocks() && Opt().PreferXThinBlocks())) {
             enableCompactBlocks(*connman, *pfrom, false);
         }
+        pfrom->fSuccessfullyConnected = true;
     }
 
 
@@ -5742,7 +5742,7 @@ bool SendMessages(CNode* pto, CConnman* connman, std::atomic<bool>& interruptMsg
     const Consensus::Params& consensusParams = Params().GetConsensus();
     {
         // Don't send anything until we get its version message
-        if (pto->nVersion == 0 || pto->fDisconnect)
+        if (!pto->fSuccessfullyConnected || pto->fDisconnect)
             return true;
 
         // If we get here, the outgoing message serialization version is set and can't change.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5563,29 +5563,37 @@ bool ProcessMessages(CNode* pfrom, CConnman* connman, std::atomic<bool>& interru
     //  (4) checksum
     //  (x) data
     //
-    bool fOk = true;
+    bool fMoreWork = true;
 
     if (!pfrom->vRecvGetData.empty())
         ProcessGetData(pfrom, connman, interruptMsgProc);
 
-    // this maintains the order of responses
-    if (!pfrom->vRecvGetData.empty()) return fOk;
+    if (pfrom->fDisconnect)
+        return false;
 
-    auto it = pfrom->vRecvMsg.begin();
-    while (!pfrom->fDisconnect && it != pfrom->vRecvMsg.end()) {
+    // this maintains the order of responses
+    if (!pfrom->vRecvGetData.empty()) return true;
+
         // Don't bother if send buffer is too full to respond anyway
         if (pfrom->nSendSize >= nMaxSendBufferSize)
-            break;
+            return false;
 
         // get next message
-        CNetMessage& msg = *it;
+        auto it = pfrom->vRecvMsg.begin();
+        if (it == pfrom->vRecvMsg.end())
+            return false;
 
         // end, if an incomplete message is found
-        if (!msg.complete())
-            break;
+        if (!it->complete())
+            return false;
+
+        // get next message
+        CNetMessage msg = std::move(*it);
 
         // at this point, any failure means we can delete the current message
-        it++;
+        pfrom->vRecvMsg.erase(pfrom->vRecvMsg.begin());
+
+        fMoreWork = !pfrom->vRecvMsg.empty() && pfrom->vRecvMsg.front().complete();
 
         msg.SetVersion(pfrom->GetRecvVersion());
         // Scan for message start
@@ -5601,7 +5609,7 @@ bool ProcessMessages(CNode* pfrom, CConnman* connman, std::atomic<bool>& interru
         if (!hdr.IsValid(Params().NetworkMagic()))
         {
             LogPrintf("PROCESSMESSAGE: ERRORS IN HEADER %s peer=%d\n", SanitizeString(hdr.GetCommand()), pfrom->id);
-            continue;
+            return fMoreWork;
         }
         string strCommand = hdr.GetCommand();
 
@@ -5617,7 +5625,7 @@ bool ProcessMessages(CNode* pfrom, CConnman* connman, std::atomic<bool>& interru
                SanitizeString(strCommand), nMessageSize,
                HexStr(hash.begin(), hash.begin()+CMessageHeader::CHECKSUM_SIZE),
                HexStr(hdr.pchChecksum, hdr.pchChecksum+CMessageHeader::CHECKSUM_SIZE));
-            continue;
+            return fMoreWork;
         }
 
         // Process message
@@ -5626,7 +5634,9 @@ bool ProcessMessages(CNode* pfrom, CConnman* connman, std::atomic<bool>& interru
         {
             fRet = ProcessMessage(pfrom, strCommand, vRecv, msg.nTime, connman, interruptMsgProc);
             if (interruptMsgProc)
-                return true;
+                return false;
+            if (!pfrom->vRecvGetData.empty())
+                fMoreWork = true;
         }
         catch (const std::ios_base::failure& e)
         {
@@ -5660,14 +5670,7 @@ bool ProcessMessages(CNode* pfrom, CConnman* connman, std::atomic<bool>& interru
         if (!fRet)
             LogPrint(Log::NET, "%s(%s, %u bytes) FAILED peer=%d\n", __func__, SanitizeString(strCommand), nMessageSize, pfrom->id);
 
-        break;
-    }
-
-    // In case the connection got shut down, its receive buffer was wiped
-    if (!pfrom->fDisconnect)
-        pfrom->vRecvMsg.erase(pfrom->vRecvMsg.begin(), it);
-
-    return fOk;
+    return fMoreWork;
 }
 
 // If node is configured to avoid full block downloads,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5579,7 +5579,7 @@ bool ProcessMessages(CNode* pfrom, CConnman* connman, std::atomic<bool>& interru
     // this maintains the order of responses
     if (!pfrom->vRecvGetData.empty()) return fOk;
 
-    std::deque<CNetMessage>::iterator it = pfrom->vRecvMsg.begin();
+    auto it = pfrom->vRecvMsg.begin();
     while (!pfrom->fDisconnect && it != pfrom->vRecvMsg.end()) {
         // Don't bother if send buffer is too full to respond anyway
         if (pfrom->nSendSize >= nMaxSendBufferSize)

--- a/src/main.h
+++ b/src/main.h
@@ -112,7 +112,7 @@ extern uint64_t nLastBlockSize;
 extern const std::string strMessageMagic;
 extern CWaitableCriticalSection csBestBlock;
 extern CConditionVariable cvBlockChange;
-extern bool fImporting;
+extern std::atomic_bool fImporting;
 extern bool fReindex;
 extern bool fTxIndex;
 extern bool fIsBareMultisigStd;

--- a/src/main.h
+++ b/src/main.h
@@ -228,6 +228,7 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv,
  * @param[in]   pto             The node which we are sending messages to.
  * @param[in]   connman         The connection manager for that node.
  * @param[in]   interrupt       Interrupt condition for processing threads
+ * @return                      True if there is more work to be done
  */
 bool SendMessages(CNode* pto, CConnman* connman, std::atomic<bool>& interrupt);
 /** Run an instance of the script checking thread */

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -384,7 +384,7 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
         NodeId id = GetNewNodeId();
         uint64_t nonce = GetDeterministicRandomizer(RANDOMIZER_ID_LOCALHOSTNONCE).Write(id).Finalize();
         CNode* pnode = new CNode(id, nLocalServices, GetBestHeight(), hSocket, addrConnect, nonce, pszDest ? pszDest : "", false);
-        pnode->nTimeConnected = GetTime();
+        pnode->nTimeConnected = GetSystemTimeInSeconds();
 
         pnode->AddRef();
 
@@ -623,7 +623,7 @@ size_t CConnman::SocketSendData(CNode *pnode)
             nBytes = send(pnode->hSocket, reinterpret_cast<const char*>(data.data()) + pnode->nSendOffset, amt2Send, MSG_NOSIGNAL | MSG_DONTWAIT);
         }
         if (nBytes > 0) {
-            pnode->nLastSend = GetTime();
+            pnode->nLastSend = GetSystemTimeInSeconds();
             pnode->nSendBytes += nBytes;
             pnode->nSendOffset += nBytes;
             bool empty = !sendShaper.consume(nBytes);
@@ -1029,7 +1029,7 @@ void CConnman::ThreadSocketHandler()
             //
             // Inactivity checking
             //
-            int64_t nTime = GetTime();
+            int64_t nTime = GetSystemTimeInSeconds();
             if (nTime - pnode->nTimeConnected > 60)
             {
                 if (pnode->nLastRecv == 0 || pnode->nLastSend == 0)
@@ -2112,7 +2112,7 @@ CNode::CNode(NodeId idIn, uint64_t nLocalServicesIn, int nMyStartingHeightIn, SO
     nLastRecv = 0;
     nSendBytes = 0;
     nRecvBytes = 0;
-    nTimeConnected = GetTime();
+    nTimeConnected = GetSystemTimeInSeconds();
     nTimeOffset = 0;
     addrName = addrNameIn == "" ? addr.ToStringIPPort() : addrNameIn;
     nVersion = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -892,9 +892,7 @@ void CConnman::ThreadSocketHandler()
                 }
                 {
                     TRY_LOCK(pnode->cs_vRecvMsg, lockRecv);
-                    if (lockRecv && (
-                        pnode->vRecvMsg.empty() || !pnode->vRecvMsg.front().complete() ||
-                        pnode->GetTotalRecvSize() <= GetReceiveFloodSize()))
+                    if (lockRecv && !pnode->fPauseRecv)
                         FD_SET(pnode->hSocket, &fdsetRecv);
                 }
             }
@@ -986,14 +984,18 @@ void CConnman::ThreadSocketHandler()
                                 pnode->CloseSocketDisconnect();
                             RecordBytesRecv(nBytes);
                             if (notify) {
+                                size_t nSizeAdded = 0;
                                 auto it(pnode->vRecvMsg.begin());
                                 for (; it != pnode->vRecvMsg.end(); ++it) {
                                     if (!it->complete())
                                         break;
+                                    nSizeAdded += it->vRecv.size() + CMessageHeader::HEADER_SIZE;
                                 }
                                 {
                                     LOCK(pnode->cs_vProcessMsg);
                                     pnode->vProcessMsg.splice(pnode->vProcessMsg.end(), pnode->vRecvMsg, pnode->vRecvMsg.begin(), it);
+                                    pnode->nProcessQueueSize += nSizeAdded;
+                                    pnode->fPauseRecv = pnode->nProcessQueueSize > nReceiveFloodSize;
                                 }
                                 WakeMessageHandler();
                             }
@@ -2156,6 +2158,8 @@ CNode::CNode(NodeId idIn, uint64_t nLocalServicesIn, int nMyStartingHeightIn, SO
     ipgroupSlot = AssignIPGroupSlot(CNetAddr(addr.ToStringIP()));
     CIPGroupData ipgroup = ipgroupSlot->Group();
     std::string strIpGroup = tfm::format("(group %s)", ipgroup.name);
+    fPauseRecv = false;
+    nProcessQueueSize = 0;
 
     if (fLogIPs)
         LogPrint(Log::NET, "Added connection to %s peer=%d %s\n", addrName, id, strIpGroup);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -365,15 +365,13 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
             // In that case, drop the connection that was just created, and return the existing CNode instead.
             // Also store the name we used to connect in that CNode, so that future FindNode() calls to that
             // name catch this early.
+            LOCK(cs_vNodes);
             CNode* pnode = FindNode((CService)addrConnect);
             if (pnode)
             {
                 pnode->AddRef();
-                {
-                    LOCK(cs_vNodes);
-                    if (pnode->addrName.empty()) {
-                        pnode->addrName = std::string(pszDest);
-                    }
+                if (pnode->addrName.empty()) {
+                    pnode->addrName = std::string(pszDest);
                 }
                 CloseSocket(hSocket);
                 return pnode;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -599,7 +599,7 @@ const uint256& CNetMessage::GetMessageHash() const
 
 
 // requires LOCK(cs_vSend)
-size_t CConnman::SocketSendData(CNode *pnode)
+size_t CConnman::SocketSendData(CNode *pnode) const
 {
     auto it = pnode->vSendMsg.begin();
     size_t nSentSize = 0;
@@ -2267,7 +2267,7 @@ int64_t PoissonNextSend(int64_t nNow, int average_interval_seconds) {
     return nNow + (int64_t)(log1p(GetRand(1ULL << 48) * -0.0000000000000035527136788 /* -1/2^48 */) * average_interval_seconds * -1000000.0 + 0.5);
 }
 
-CSipHasher CConnman::GetDeterministicRandomizer(uint64_t id)
+CSipHasher CConnman::GetDeterministicRandomizer(uint64_t id) const
 {
     return CSipHasher(nSeed0, nSeed1).Write(id);
 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -534,6 +534,33 @@ bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes, bool& complete
     return true;
 }
 
+void CNode::SetSendVersion(int nVersionIn)
+{
+    // Send version may only be changed in the version message, and
+    // only one version message is allowed per session. We can therefore
+    // treat this value as const and even atomic as long as it's only used
+    // once a version message has been successfully processed. Any attempt to
+    // set this twice is an error.
+    if (nSendVersion != 0) {
+        error("Send version already set for node: %i. Refusing to change from %i to %i", id, nSendVersion, nVersionIn);
+    } else {
+        nSendVersion = nVersionIn;
+    }
+}
+
+int CNode::GetSendVersion() const
+{
+    // The send version should always be explicitly set to
+    // INIT_PROTO_VERSION rather than using this value until SetSendVersion
+    // has been called.
+    if (nSendVersion == 0) {
+        error("Requesting unset send version for node: %i. Using %i", id, INIT_PROTO_VERSION);
+        return INIT_PROTO_VERSION;
+    }
+    return nSendVersion;
+}
+
+
 int CNetMessage::readHeader(const char *pch, unsigned int nBytes)
 {
     // copy data to temporary parsing buffer

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -505,6 +505,9 @@ void CNode::copyStats(CNodeStats &stats)
 bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes, bool& complete)
 {
     complete = false;
+    int64_t nTimeMicros = GetTimeMicros();
+    nLastRecv = nTimeMicros / 1000000;
+    nRecvBytes += nBytes;
     while (nBytes > 0) {
 
         // get current incomplete message, or create a new one
@@ -531,7 +534,7 @@ bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes, bool& complete
         nBytes -= handled;
 
         if (msg.complete()) {
-            msg.nTime = GetTimeMicros();
+            msg.nTime = nTimeMicros;
             complete = true;
         }
     }
@@ -983,8 +986,6 @@ void CConnman::ThreadSocketHandler()
                                 pnode->CloseSocketDisconnect();
                             if(notify)
                                 condMsgProc.notify_one();
-                            pnode->nLastRecv = GetTime();
-                            pnode->nRecvBytes += nBytes;
                             RecordBytesRecv(nBytes);
                         }
                         else if (nBytes == 0)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1774,7 +1774,7 @@ bool CConnman::Start(CScheduler& scheduler, std::string& strNodeError, Options c
     nMaxFeeler = connOptions.nMaxFeeler;
 
     nSendBufferMaxSize = connOptions.nSendBufferMaxSize;
-    nReceiveFloodSize = connOptions.nSendBufferMaxSize;
+    nReceiveFloodSize = connOptions.nReceiveFloodSize;
 
     SetBestHeight(connOptions.nBestHeight);
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1566,9 +1566,8 @@ void CConnman::ThreadMessageHandler()
 
             // Send messages
             {
-                TRY_LOCK(pnode->cs_sendProcessing, lockSend);
-                if (lockSend)
-                    GetNodeSignals().SendMessages(pnode, this, flagInterruptMsgProc);
+                LOCK(pnode->cs_sendProcessing);
+                GetNodeSignals().SendMessages(pnode, this, flagInterruptMsgProc);
             }
             if (flagInterruptMsgProc)
                 return;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -875,8 +875,8 @@ void CConnman::ThreadSocketHandler()
                 // * Hand off all complete messages to the processor, to be handled without
                 //   blocking here.
                 {
-                    TRY_LOCK(pnode->cs_vSend, lockSend);
-                    if (lockSend && !pnode->vSendMsg.empty()) {
+                    LOCK(pnode->cs_vSend);
+                    if (!pnode->vSendMsg.empty()) {
                         FD_SET(pnode->hSocket, &fdsetSend);
                         continue;
                     }
@@ -1019,8 +1019,8 @@ void CConnman::ThreadSocketHandler()
             //
             if (sendSet)
             {
-                TRY_LOCK(pnode->cs_vSend, lockSend);
-                if (lockSend && sendShaper.try_consume(0))
+                LOCK(pnode->cs_vSend);
+                if (sendShaper.try_consume(0))
                 {
                     progress++;
                     size_t nBytes = SocketSendData(pnode);
@@ -1566,7 +1566,7 @@ void CConnman::ThreadMessageHandler()
 
             // Send messages
             {
-                TRY_LOCK(pnode->cs_vSend, lockSend);
+                TRY_LOCK(pnode->cs_sendProcessing, lockSend);
                 if (lockSend)
                     GetNodeSignals().SendMessages(pnode, this, flagInterruptMsgProc);
             }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -985,8 +985,8 @@ void CConnman::ThreadSocketHandler()
                             if (!pnode->ReceiveMsgBytes(pchBuf, nBytes, notify))
                                 pnode->CloseSocketDisconnect();
                             RecordBytesRecv(nBytes);
-                            if(notify)
-                                condMsgProc.notify_one();
+                            if (notify)
+                                WakeMessageHandler();
                         }
                         else if (nBytes == 0)
                         {
@@ -1066,8 +1066,10 @@ void CConnman::ThreadSocketHandler()
     }
 }
 
-
-
+void CConnman::WakeMessageHandler()
+{
+    condMsgProc.notify_one();
+}
 
 
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2194,6 +2194,11 @@ void CNode::AskFor(const CInv& inv)
     mapAskFor.insert(std::make_pair(nRequestTime, inv));
 }
 
+bool CConnman::NodeFullyConnected(const CNode* pnode)
+{
+    return pnode && pnode->fSuccessfullyConnected && !pnode->fDisconnect;
+}
+
 void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
 {
     size_t nMessageSize = msg.data.size();
@@ -2242,7 +2247,7 @@ bool CConnman::ForNode(NodeId id, std::function<bool(CNode* pnode)> func)
             break;
         }
     }
-    return found != nullptr && func(found);
+    return found != nullptr && NodeFullyConnected(found) && func(found);
 }
 
 void CConnman::AddTestNode(CNode* n) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -510,7 +510,7 @@ bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes, bool& complete
         // get current incomplete message, or create a new one
         if (vRecvMsg.empty() ||
             vRecvMsg.back().complete())
-            vRecvMsg.push_back(CNetMessage(Params().NetworkMagic(), SER_NETWORK, nRecvVersion));
+            vRecvMsg.push_back(CNetMessage(Params().NetworkMagic(), SER_NETWORK, INIT_PROTO_VERSION));
 
         CNetMessage& msg = vRecvMsg.back();
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1531,11 +1531,11 @@ bool CConnman::OpenNetworkConnection(const CAddress& addrConnect, bool fCountFai
     if (fFeeler)
         pnode->fFeeler = true;
 
+    GetNodeSignals().InitializeNode(pnode, *this);
     {
         LOCK(cs_vNodes);
         vNodes.push_back(pnode);
     }
-    GetNodeSignals().InitializeNode(pnode, *this);
 
     return true;
 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -70,7 +70,6 @@ CCriticalSection cs_mapLocalHost;
 map<CNetAddr, LocalServiceInfo> mapLocalHost;
 static bool vfReachable[NET_MAX] = {};
 static bool vfLimited[NET_MAX] = {};
-static CNode* pnodeLocalHost = NULL;
 
 map<CInv, CDataStream> mapRelay;
 deque<pair<int64_t, CInv> > vRelayExpiration;
@@ -1806,14 +1805,6 @@ bool CConnman::Start(CScheduler& scheduler, std::string& strNodeError, Options c
         semOutbound = new CSemaphore(std::min((nMaxOutbound + nMaxFeeler), nMaxConnections));
     }
 
-    if (pnodeLocalHost == NULL) {
-        NodeId id = GetNewNodeId();
-        uint64_t nonce = GetDeterministicRandomizer(RANDOMIZER_ID_LOCALHOSTNONCE).Write(id).Finalize();
-
-        pnodeLocalHost = new CNode(id, nLocalServices, GetBestHeight(), INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), nLocalServices), nonce);
-        GetNodeSignals().InitializeNode(pnodeLocalHost, *this);
-    }
-
     //
     // Start threads
     //
@@ -1914,9 +1905,6 @@ void CConnman::Stop()
     vhListenSocket.clear();
     delete semOutbound;
     semOutbound = NULL;
-    if(pnodeLocalHost)
-        DeleteNode(pnodeLocalHost);
-    pnodeLocalHost = NULL;
 }
 
 void CConnman::DeleteNode(CNode* pnode)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -984,9 +984,9 @@ void CConnman::ThreadSocketHandler()
                             bool notify = false;
                             if (!pnode->ReceiveMsgBytes(pchBuf, nBytes, notify))
                                 pnode->CloseSocketDisconnect();
+                            RecordBytesRecv(nBytes);
                             if(notify)
                                 condMsgProc.notify_one();
-                            RecordBytesRecv(nBytes);
                         }
                         else if (nBytes == 0)
                         {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -829,8 +829,13 @@ void CConnman::ThreadSocketHandler()
                 }
             }
         }
-        if(vNodes.size() != nPrevNodeCount) {
-            nPrevNodeCount = vNodes.size();
+        size_t vNodesSize;
+        {
+            LOCK(cs_vNodes);
+            vNodesSize = vNodes.size();
+        }
+        if(vNodesSize != nPrevNodeCount) {
+            nPrevNodeCount = vNodesSize;
             if(clientInterface)
                 clientInterface->NotifyNumConnectionsChanged(nPrevNodeCount);
         }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -779,8 +779,7 @@ void CConnman::ThreadSocketHandler()
             vector<CNode*> vNodesCopy = vNodes;
             BOOST_FOREACH(CNode* pnode, vNodesCopy)
             {
-                if (pnode->fDisconnect ||
-                    (pnode->GetRefCount() <= 0 && pnode->vRecvMsg.empty() && pnode->nSendSize == 0))
+                if (pnode->fDisconnect)
                 {
                     // remove from vNodes
                     vNodes.erase(remove(vNodes.begin(), vNodes.end(), pnode), vNodes.end());

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1564,7 +1564,7 @@ void CConnman::ThreadMessageHandler()
 
                     if (pnode->nSendSize < GetSendBufferSize())
                     {
-                        if (!pnode->vRecvGetData.empty() || (!pnode->vRecvMsg.empty() && pnode->vRecvMsg[0].complete()))
+                        if (!pnode->vRecvGetData.empty() || (!pnode->vRecvMsg.empty() && pnode->vRecvMsg.front().complete()))
                         {
                             fSleep = false;
                         }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -414,11 +414,6 @@ void CNode::CloseSocketDisconnect()
         LogPrint(Log::NET, "disconnecting peer=%d\n", id);
         CloseSocket(hSocket);
     }
-
-    // in case this fails, we'll empty the recv buffer when the CNode is deleted
-    TRY_LOCK(cs_vRecvMsg, lockRecv);
-    if (lockRecv)
-        vRecvMsg.clear();
 }
 
 void CConnman::ClearBanned()

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -793,8 +793,7 @@ void CConnman::ThreadSocketHandler()
                     pnode->CloseSocketDisconnect();
 
                     // hold in disconnected pool until all refs are released
-                    if (pnode->fNetworkNode || pnode->fInbound)
-                        pnode->Release();
+                    pnode->Release();
                     vNodesDisconnected.push_back(pnode);
                 }
             }
@@ -1528,7 +1527,6 @@ bool CConnman::OpenNetworkConnection(const CAddress& addrConnect, bool fCountFai
         return false;
     if (grantOutbound)
         grantOutbound->MoveTo(pnode->grantOutbound);
-    pnode->fNetworkNode = true;
     if (fOneShot)
         pnode->fOneShot = true;
     if (fFeeler)
@@ -2138,7 +2136,6 @@ CNode::CNode(NodeId idIn, uint64_t nLocalServicesIn, int nMyStartingHeightIn, SO
     fOneShot = false;
     fClient = false; // set by version message
     fFeeler = false;
-    fNetworkNode = false;
     fSuccessfullyConnected = false;
     fDisconnect = false;
     nRefCount = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -985,8 +985,18 @@ void CConnman::ThreadSocketHandler()
                             if (!pnode->ReceiveMsgBytes(pchBuf, nBytes, notify))
                                 pnode->CloseSocketDisconnect();
                             RecordBytesRecv(nBytes);
-                            if (notify)
+                            if (notify) {
+                                auto it(pnode->vRecvMsg.begin());
+                                for (; it != pnode->vRecvMsg.end(); ++it) {
+                                    if (!it->complete())
+                                        break;
+                                }
+                                {
+                                    LOCK(pnode->cs_vProcessMsg);
+                                    pnode->vProcessMsg.splice(pnode->vProcessMsg.end(), pnode->vRecvMsg, pnode->vRecvMsg.begin(), it);
+                                }
                                 WakeMessageHandler();
+                            }
                         }
                         else if (nBytes == 0)
                         {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -804,7 +804,7 @@ void CConnman::ThreadSocketHandler()
             BOOST_FOREACH(CNode* pnode, vNodesCopy)
             {
                 if (pnode->fDisconnect ||
-                    (pnode->GetRefCount() <= 0 && pnode->vRecvMsg.empty() && pnode->nSendSize == 0 && pnode->ssSend.empty()))
+                    (pnode->GetRefCount() <= 0 && pnode->vRecvMsg.empty() && pnode->nSendSize == 0))
                 {
                     // remove from vNodes
                     vNodes.erase(remove(vNodes.begin(), vNodes.end(), pnode), vNodes.end());
@@ -2126,46 +2126,10 @@ int CConnman::GetBestHeight() const
     return nBestHeight.load(std::memory_order_acquire);
 }
 
-void CNode::Fuzz(int nChance)
-{
-    if (!fSuccessfullyConnected) return; // Don't fuzz initial handshake
-    if (GetRand(nChance) != 0) return; // Fuzz 1 of every nChance messages
-
-    switch (GetRand(3))
-    {
-    case 0:
-        // xor a random byte with a random value:
-        if (!ssSend.empty()) {
-            CDataStream::size_type pos = GetRand(ssSend.size());
-            ssSend[pos] ^= (unsigned char)(GetRand(256));
-        }
-        break;
-    case 1:
-        // delete a random byte:
-        if (!ssSend.empty()) {
-            CDataStream::size_type pos = GetRand(ssSend.size());
-            ssSend.erase(ssSend.begin()+pos);
-        }
-        break;
-    case 2:
-        // insert a random byte at a random position
-        {
-            CDataStream::size_type pos = GetRand(ssSend.size());
-            char ch = (char)GetRand(256);
-            ssSend.insert(ssSend.begin()+pos, ch);
-        }
-        break;
-    }
-    // Chance of more than one change half the time:
-    // (more changes exponentially less likely):
-    Fuzz(2);
-}
-
 unsigned int CConnman::GetReceiveFloodSize() const { return nReceiveFloodSize; }
 unsigned int CConnman::GetSendBufferSize() const{ return nSendBufferMaxSize; }
 
 CNode::CNode(NodeId idIn, uint64_t nLocalServicesIn, int nMyStartingHeightIn, SOCKET hSocketIn, const CAddress& addrIn, uint64_t nLocalHostNonceIn, const std::string& addrNameIn, bool fInboundIn) :
-    ssSend(SER_NETWORK, INIT_PROTO_VERSION),
     addr(addrIn),
     fInbound(fInboundIn),
     id(idIn),

--- a/src/net.h
+++ b/src/net.h
@@ -630,25 +630,8 @@ public:
     {
         return nRecvVersion;
     }
-    void SetSendVersion(int nVersionIn)
-    {
-        // Send version may only be changed in the version message, and
-        // only one version message is allowed per session. We can therefore
-        // treat this value as const and even atomic as long as it's only used
-        // once the handshake is complete. Any attempt to set this twice is an
-        // error.
-        assert(nSendVersion == 0);
-        nSendVersion = nVersionIn;
-    }
-
-    int GetSendVersion() const
-    {
-        // The send version should always be explicitly set to
-        // INIT_PROTO_VERSION rather than using this value until the handshake
-        // is complete.
-        assert(nSendVersion != 0);
-        return nSendVersion;
-    }
+    void SetSendVersion(int nVersionIn);
+    int GetSendVersion() const;
 
     CNode* AddRef()
     {

--- a/src/net.h
+++ b/src/net.h
@@ -548,8 +548,6 @@ public:
     size_t nProcessQueueSize;
 
     std::deque<CInv> vRecvGetData;
-    std::list<CNetMessage> vRecvMsg;
-    CCriticalSection cs_vRecvMsg;
     uint64_t nRecvBytes;
     std::atomic<int> nRecvVersion;
 
@@ -635,6 +633,8 @@ private:
     const uint64_t nLocalServices;
     const int nMyStartingHeight;
     int nSendVersion;
+public: // for unittest only! consider this private
+    std::list<CNetMessage> vRecvMsg;  // Used only by SocketHandler thread
 public:
 
     NodeId GetId() const {
@@ -655,7 +655,6 @@ public:
         return nRefCount;
     }
 
-    // requires LOCK(cs_vRecvMsg)
     bool ReceiveMsgBytes(const char *pch, unsigned int nBytes, bool& complete);
 
     void SetRecvVersion(int nVersionIn)

--- a/src/net.h
+++ b/src/net.h
@@ -541,7 +541,7 @@ public:
     std::list<CNetMessage> vRecvMsg;
     CCriticalSection cs_vRecvMsg;
     uint64_t nRecvBytes;
-    int nRecvVersion;
+    std::atomic<int> nRecvVersion;
 
     int64_t nLastSend;
     int64_t nLastRecv;
@@ -654,12 +654,13 @@ public:
     // requires LOCK(cs_vRecvMsg)
     bool ReceiveMsgBytes(const char *pch, unsigned int nBytes, bool& complete);
 
-    // requires LOCK(cs_vRecvMsg)
     void SetRecvVersion(int nVersionIn)
     {
         nRecvVersion = nVersionIn;
-        BOOST_FOREACH(CNetMessage &msg, vRecvMsg)
-            msg.SetVersion(nVersionIn);
+    }
+    int GetRecvVersion()
+    {
+        return nRecvVersion;
     }
     void SetSendVersion(int nVersionIn)
     {

--- a/src/net.h
+++ b/src/net.h
@@ -278,6 +278,7 @@ public:
     /** Get a unique deterministic randomizer. */
     CSipHasher GetDeterministicRandomizer(uint64_t id);
 
+    unsigned int GetReceiveFloodSize() const;
 private:
     struct ListenSocket {
         SOCKET socket;
@@ -308,8 +309,6 @@ private:
     NodeId GetNewNodeId();
 
     void DumpAddresses();
-
-    unsigned int GetReceiveFloodSize() const;
 
     // Network stats
     void RecordBytesRecv(uint64_t bytes);

--- a/src/net.h
+++ b/src/net.h
@@ -124,6 +124,36 @@ public:
 
     bool ForNode(NodeId id, std::function<bool(CNode* pnode)> func);
 
+    template <typename... Args>
+    void PushMessageWithVersionAndFlag(CNode* pnode, int nVersion, int flag, const std::string& sCommand, Args&&... args)
+    {
+        auto msg(BeginMessage(pnode, nVersion, flag, sCommand));
+        ::SerializeMany(msg, std::forward<Args>(args)...);
+        EndMessage(msg);
+        PushMessage(pnode, msg, sCommand);
+    }
+
+    template <typename... Args>
+    void PushMessageWithFlag(CNode* pnode, int flag, const std::string& sCommand, Args&&... args)
+    {
+        PushMessageWithVersionAndFlag(pnode, 0, flag, sCommand, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    void PushMessageWithVersion(CNode* pnode, int nVersion, const std::string& sCommand, Args&&... args)
+    {
+        PushMessageWithVersionAndFlag(pnode, nVersion, 0, sCommand, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    void PushMessage(CNode* pnode, const std::string& sCommand, Args&&... args)
+    {
+        PushMessageWithVersionAndFlag(pnode, 0, 0, sCommand, std::forward<Args>(args)...);
+    }
+
+    void PushVersion(CNode* pnode, int64_t nTime);
+
+
     template<typename Callable>
     bool ForEachNodeContinueIf(Callable&& func)
     {
@@ -294,6 +324,10 @@ private:
     void DumpAddresses();
 
     unsigned int GetReceiveFloodSize() const;
+
+    CDataStream BeginMessage(CNode* node, int nVersion, int flags, const std::string& sCommand);
+    void PushMessage(CNode* pnode, CDataStream& strm, const std::string& sCommand);
+    void EndMessage(CDataStream& strm);
 
     // Network stats
     void RecordBytesRecv(uint64_t bytes);
@@ -513,6 +547,7 @@ public:
 /** Information about a peer */
 class CNode
 {
+    friend class CConnman;
 public:
     // socket
     uint64_t nServices;
@@ -614,6 +649,7 @@ private:
     const uint64_t nLocalHostNonce;
     const uint64_t nLocalServices;
     const int nMyStartingHeight;
+    int nSendVersion;
 public:
 
     NodeId GetId() const {
@@ -648,6 +684,25 @@ public:
         nRecvVersion = nVersionIn;
         BOOST_FOREACH(CNetMessage &msg, vRecvMsg)
             msg.SetVersion(nVersionIn);
+    }
+    void SetSendVersion(int nVersionIn)
+    {
+        // Send version may only be changed in the version message, and
+        // only one version message is allowed per session. We can therefore
+        // treat this value as const and even atomic as long as it's only used
+        // once the handshake is complete. Any attempt to set this twice is an
+        // error.
+        assert(nSendVersion == 0);
+        nSendVersion = nVersionIn;
+    }
+
+    int GetSendVersion() const
+    {
+        // The send version should always be explicitly set to
+        // INIT_PROTO_VERSION rather than using this value until the handshake
+        // is complete. See PushMessageWithVersion().
+        assert(nSendVersion != 0);
+        return nSendVersion;
     }
 
     CNode* AddRef()
@@ -720,9 +775,6 @@ public:
 
     // TODO: Document the precondition of this function.  Is cs_vSend locked?
     void EndMessage() UNLOCK_FUNCTION(cs_vSend);
-
-    void PushVersion();
-
 
     void PushMessage(const char* pszCommand)
     {

--- a/src/net.h
+++ b/src/net.h
@@ -151,9 +151,6 @@ public:
         PushMessageWithVersionAndFlag(pnode, 0, 0, sCommand, std::forward<Args>(args)...);
     }
 
-    void PushVersion(CNode* pnode, int64_t nTime);
-
-
     template<typename Callable>
     bool ForEachNodeContinueIf(Callable&& func)
     {
@@ -422,7 +419,7 @@ struct CNodeSignals
     boost::signals2::signal<bool (CNode*, const CNetMessage&), CombinerAll> SanityCheckMessages;
     boost::signals2::signal<bool (CNode*, CConnman*, std::atomic<bool>&), CombinerAll> ProcessMessages;
     boost::signals2::signal<bool (CNode*, CConnman*, std::atomic<bool>&), CombinerAll> SendMessages;
-    boost::signals2::signal<void (NodeId, const CNode*)> InitializeNode;
+    boost::signals2::signal<void (CNode*, CConnman&)> InitializeNode;
     boost::signals2::signal<void (NodeId, bool&)> FinalizeNode;
     boost::signals2::signal<uint64_t ()> GetMaxBlockSizeInsecure;
 };
@@ -652,6 +649,10 @@ public:
 
     uint64_t GetLocalNonce() const {
       return nLocalHostNonce;
+    }
+
+    int GetMyStartingHeight() const {
+      return nMyStartingHeight;
     }
 
     int GetRefCount()

--- a/src/net.h
+++ b/src/net.h
@@ -547,6 +547,8 @@ public:
     std::list<CNetMessage> vProcessMsg;
     size_t nProcessQueueSize;
 
+    CCriticalSection cs_sendProcessing;
+
     std::deque<CInv> vRecvGetData;
     uint64_t nRecvBytes;
     std::atomic<int> nRecvVersion;

--- a/src/net.h
+++ b/src/net.h
@@ -543,6 +543,9 @@ public:
     CCriticalSection cs_vSend;
     CCriticalSection cs_hSocket;
 
+    CCriticalSection cs_vProcessMsg;
+    std::list<CNetMessage> vProcessMsg;
+
     std::deque<CInv> vRecvGetData;
     std::list<CNetMessage> vRecvMsg;
     CCriticalSection cs_vRecvMsg;

--- a/src/net.h
+++ b/src/net.h
@@ -279,6 +279,8 @@ public:
     CSipHasher GetDeterministicRandomizer(uint64_t id);
 
     unsigned int GetReceiveFloodSize() const;
+
+    void WakeMessageHandler();
 private:
     struct ListenSocket {
         SOCKET socket;
@@ -294,8 +296,6 @@ private:
     void AcceptConnection(const ListenSocket& hListenSocket);
     void ThreadSocketHandler();
     void ThreadDNSAddressSeed();
-
-    void WakeMessageHandler();
 
     CNode* FindNode(const CNetAddr& ip);
     CNode* FindNode(const CSubNet& subNet);

--- a/src/net.h
+++ b/src/net.h
@@ -276,7 +276,7 @@ public:
     void RemoveTestNode(CNode*);
 
     /** Get a unique deterministic randomizer. */
-    CSipHasher GetDeterministicRandomizer(uint64_t id);
+    CSipHasher GetDeterministicRandomizer(uint64_t id) const;
 
     unsigned int GetReceiveFloodSize() const;
 
@@ -310,7 +310,7 @@ private:
 
     NodeId GetNewNodeId();
 
-    size_t SocketSendData(CNode *pnode);
+    size_t SocketSendData(CNode *pnode) const;
     void DumpAddresses();
 
     // Network stats

--- a/src/net.h
+++ b/src/net.h
@@ -91,6 +91,20 @@ class CTransaction;
 class CNodeStats;
 class CClientUIInterface;
 
+struct CSerializedNetMsg
+{
+    CSerializedNetMsg() = default;
+    CSerializedNetMsg(CSerializedNetMsg&&) = default;
+    CSerializedNetMsg& operator=(CSerializedNetMsg&&) = default;
+    // No copying, only moves.
+    CSerializedNetMsg(const CSerializedNetMsg& msg) = delete;
+    CSerializedNetMsg& operator=(const CSerializedNetMsg&) = delete;
+
+    std::vector<unsigned char> data;
+    std::string command;
+};
+
+
 class CConnman
 {
 public:

--- a/src/net.h
+++ b/src/net.h
@@ -562,7 +562,6 @@ public:
     bool fOneShot;
     bool fClient;
     const bool fInbound;
-    bool fNetworkNode;
     bool fSuccessfullyConnected;
     std::atomic_bool fDisconnect;
     // We use fRelayTxes for two purposes -

--- a/src/net.h
+++ b/src/net.h
@@ -560,7 +560,7 @@ public:
     CAddress addr;
     std::string addrName;
     CService addrLocal;
-    int nVersion;
+    std::atomic<int> nVersion;
     // strSubVer is whatever byte array we read from the wire. However, this field is intended
     // to be printed out, displayed to humans in various forms and so on. So we sanitize it and
     // store the sanitized version in cleanSubVer. The original should be used when dealing with
@@ -571,7 +571,7 @@ public:
     bool fOneShot;
     bool fClient;
     const bool fInbound;
-    bool fSuccessfullyConnected;
+    std::atomic_bool fSuccessfullyConnected;
     std::atomic_bool fDisconnect;
     // We use fRelayTxes for two purposes -
     // a) it allows us to not relay tx invs before receiving the peer's version message

--- a/src/net.h
+++ b/src/net.h
@@ -564,7 +564,7 @@ public:
     const bool fInbound;
     bool fNetworkNode;
     bool fSuccessfullyConnected;
-    bool fDisconnect;
+    std::atomic_bool fDisconnect;
     // We use fRelayTxes for two purposes -
     // a) it allows us to not relay tx invs before receiving the peer's version message
     // b) the peer may tell us in its version message that we should not relay tx invs

--- a/src/net.h
+++ b/src/net.h
@@ -310,6 +310,7 @@ private:
 
     NodeId GetNewNodeId();
 
+    size_t SocketSendData(CNode *pnode);
     void DumpAddresses();
 
     // Network stats
@@ -380,7 +381,6 @@ void InitNetworkShapers();
 void MapPort(bool fUseUPnP);
 unsigned short GetListenPort();
 bool BindListenPort(const CService &bindAddr, std::string& strError, bool fWhitelisted = false);
-size_t SocketSendData(CNode *pnode);
 
 
 struct CombinerAll
@@ -587,6 +587,7 @@ public:
     const NodeId id;
 
     std::atomic_bool fPauseRecv;
+    std::atomic_bool fPauseSend;
 
 public:
     uint256 hashContinue;

--- a/src/net.h
+++ b/src/net.h
@@ -358,6 +358,10 @@ private:
 
     /** SipHasher seeds for deterministic randomness */
     const uint64_t nSeed0, nSeed1;
+
+    /** flag for waking the message processor. */
+    bool fMsgProcWake;
+
     std::condition_variable condMsgProc;
     std::mutex mutexMsgProc;
     std::atomic<bool> flagInterruptMsgProc;

--- a/src/net.h
+++ b/src/net.h
@@ -545,6 +545,7 @@ public:
 
     CCriticalSection cs_vProcessMsg;
     std::list<CNetMessage> vProcessMsg;
+    size_t nProcessQueueSize;
 
     std::deque<CInv> vRecvGetData;
     std::list<CNetMessage> vRecvMsg;
@@ -584,6 +585,8 @@ public:
     std::unique_ptr<CBloomFilter> xthinFilter;
     int nRefCount;
     const NodeId id;
+
+    std::atomic_bool fPauseRecv;
 
 public:
     uint256 hashContinue;
@@ -649,15 +652,6 @@ public:
     {
         assert(nRefCount >= 0);
         return nRefCount;
-    }
-
-    // requires LOCK(cs_vRecvMsg)
-    unsigned int GetTotalRecvSize()
-    {
-        unsigned int total = 0;
-        BOOST_FOREACH(const CNetMessage &msg, vRecvMsg)
-            total += msg.vRecv.size() + 24;
-        return total;
     }
 
     // requires LOCK(cs_vRecvMsg)

--- a/src/net.h
+++ b/src/net.h
@@ -325,9 +325,11 @@ private:
 
     unsigned int GetReceiveFloodSize() const;
 
-    CDataStream BeginMessage(CNode* node, int nVersion, int flags, const std::string& sCommand);
+protected: // protected instead of private for unit tests
+    virtual CDataStream BeginMessage(CNode* node, int nVersion, int flags, const std::string& sCommand);
+    virtual void EndMessage(CDataStream& strm);
+private:
     void PushMessage(CNode* pnode, CDataStream& strm, const std::string& sCommand);
-    void EndMessage(CDataStream& strm);
 
     // Network stats
     void RecordBytesRecv(uint64_t bytes);
@@ -520,9 +522,6 @@ public:
         nDataPos = 0;
         nTime = 0;
     }
-
-    // Called by CNode::EndMessage() and unit tests: modify stream to set size/checksum of header
-    static unsigned int FinalizeHeader(CDataStream& s);
 
     bool complete() const
     {
@@ -766,173 +765,6 @@ public:
     }
 
     void AskFor(const CInv& inv);
-
-    // TODO: Document the postcondition of this function.  Is cs_vSend locked?
-    virtual void BeginMessage(const char* pszCommand) EXCLUSIVE_LOCK_FUNCTION(cs_vSend);
-
-    // TODO: Document the precondition of this function.  Is cs_vSend locked?
-    void AbortMessage() UNLOCK_FUNCTION(cs_vSend);
-
-    // TODO: Document the precondition of this function.  Is cs_vSend locked?
-    void EndMessage() UNLOCK_FUNCTION(cs_vSend);
-
-    void PushMessage(const char* pszCommand)
-    {
-        try
-        {
-            BeginMessage(pszCommand);
-            EndMessage();
-        }
-        catch (...)
-        {
-            AbortMessage();
-            throw;
-        }
-    }
-
-    template<typename T1>
-    void PushMessage(const char* pszCommand, const T1& a1)
-    {
-        try
-        {
-            BeginMessage(pszCommand);
-            ssSend << a1;
-            EndMessage();
-        }
-        catch (...)
-        {
-            AbortMessage();
-            throw;
-        }
-    }
-
-    template<typename T1, typename T2>
-    void PushMessage(const char* pszCommand, const T1& a1, const T2& a2)
-    {
-        try
-        {
-            BeginMessage(pszCommand);
-            ssSend << a1 << a2;
-            EndMessage();
-        }
-        catch (...)
-        {
-            AbortMessage();
-            throw;
-        }
-    }
-
-    template<typename T1, typename T2, typename T3>
-    void PushMessage(const char* pszCommand, const T1& a1, const T2& a2, const T3& a3)
-    {
-        try
-        {
-            BeginMessage(pszCommand);
-            ssSend << a1 << a2 << a3;
-            EndMessage();
-        }
-        catch (...)
-        {
-            AbortMessage();
-            throw;
-        }
-    }
-
-    template<typename T1, typename T2, typename T3, typename T4>
-    void PushMessage(const char* pszCommand, const T1& a1, const T2& a2, const T3& a3, const T4& a4)
-    {
-        try
-        {
-            BeginMessage(pszCommand);
-            ssSend << a1 << a2 << a3 << a4;
-            EndMessage();
-        }
-        catch (...)
-        {
-            AbortMessage();
-            throw;
-        }
-    }
-
-    template<typename T1, typename T2, typename T3, typename T4, typename T5>
-    void PushMessage(const char* pszCommand, const T1& a1, const T2& a2, const T3& a3, const T4& a4, const T5& a5)
-    {
-        try
-        {
-            BeginMessage(pszCommand);
-            ssSend << a1 << a2 << a3 << a4 << a5;
-            EndMessage();
-        }
-        catch (...)
-        {
-            AbortMessage();
-            throw;
-        }
-    }
-
-    template<typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
-    void PushMessage(const char* pszCommand, const T1& a1, const T2& a2, const T3& a3, const T4& a4, const T5& a5, const T6& a6)
-    {
-        try
-        {
-            BeginMessage(pszCommand);
-            ssSend << a1 << a2 << a3 << a4 << a5 << a6;
-            EndMessage();
-        }
-        catch (...)
-        {
-            AbortMessage();
-            throw;
-        }
-    }
-
-    template<typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7>
-    void PushMessage(const char* pszCommand, const T1& a1, const T2& a2, const T3& a3, const T4& a4, const T5& a5, const T6& a6, const T7& a7)
-    {
-        try
-        {
-            BeginMessage(pszCommand);
-            ssSend << a1 << a2 << a3 << a4 << a5 << a6 << a7;
-            EndMessage();
-        }
-        catch (...)
-        {
-            AbortMessage();
-            throw;
-        }
-    }
-
-    template<typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
-    void PushMessage(const char* pszCommand, const T1& a1, const T2& a2, const T3& a3, const T4& a4, const T5& a5, const T6& a6, const T7& a7, const T8& a8)
-    {
-        try
-        {
-            BeginMessage(pszCommand);
-            ssSend << a1 << a2 << a3 << a4 << a5 << a6 << a7 << a8;
-            EndMessage();
-        }
-        catch (...)
-        {
-            AbortMessage();
-            throw;
-        }
-    }
-
-    template<typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9>
-    void PushMessage(const char* pszCommand, const T1& a1, const T2& a2, const T3& a3, const T4& a4, const T5& a5, const T6& a6, const T7& a7, const T8& a8, const T9& a9)
-    {
-        try
-        {
-            BeginMessage(pszCommand);
-            ssSend << a1 << a2 << a3 << a4 << a5 << a6 << a7 << a8 << a9;
-            EndMessage();
-        }
-        catch (...)
-        {
-            AbortMessage();
-            throw;
-        }
-    }
 
     void CloseSocketDisconnect();
 

--- a/src/net.h
+++ b/src/net.h
@@ -295,6 +295,8 @@ private:
     void ThreadSocketHandler();
     void ThreadDNSAddressSeed();
 
+    void WakeMessageHandler();
+
     CNode* FindNode(const CNetAddr& ip);
     CNode* FindNode(const CSubNet& subNet);
     CNode* FindNode(const std::string& addrName);

--- a/src/net.h
+++ b/src/net.h
@@ -141,75 +141,33 @@ public:
     virtual void PushMessage(CNode* pnode, CSerializedNetMsg&& msg);
 
     template<typename Callable>
-    bool ForEachNodeContinueIf(Callable&& func)
-    {
-        LOCK(cs_vNodes);
-        for (auto&& node : vNodes)
-            if(!func(node))
-                return false;
-        return true;
-    };
-
-    template<typename Callable>
-    bool ForEachNodeContinueIf(Callable&& func) const
-    {
-        LOCK(cs_vNodes);
-        for (const auto& node : vNodes)
-            if(!func(node))
-                return false;
-        return true;
-    };
-
-    template<typename Callable, typename CallableAfter>
-    bool ForEachNodeContinueIfThen(Callable&& pre, CallableAfter&& post)
-    {
-        bool ret = true;
-        LOCK(cs_vNodes);
-        for (auto&& node : vNodes)
-            if(!pre(node)) {
-                ret = false;
-                break;
-            }
-        post();
-        return ret;
-    };
-
-    template<typename Callable, typename CallableAfter>
-    bool ForEachNodeContinueIfThen(Callable&& pre, CallableAfter&& post) const
-    {
-        bool ret = true;
-        LOCK(cs_vNodes);
-        for (const auto& node : vNodes)
-            if(!pre(node)) {
-                ret = false;
-                break;
-            }
-        post();
-        return ret;
-    };
-
-    template<typename Callable>
     void ForEachNode(Callable&& func)
     {
         LOCK(cs_vNodes);
-        for (auto&& node : vNodes)
-            func(node);
+        for (auto&& node : vNodes) {
+            if (NodeFullyConnected(node))
+                func(node);
+        }
     };
 
     template<typename Callable>
     void ForEachNode(Callable&& func) const
     {
         LOCK(cs_vNodes);
-        for (const auto& node : vNodes)
-            func(node);
+        for (auto&& node : vNodes) {
+            if (NodeFullyConnected(node))
+                func(node);
+        }
     };
 
     template<typename Callable, typename CallableAfter>
     void ForEachNodeThen(Callable&& pre, CallableAfter&& post)
     {
         LOCK(cs_vNodes);
-        for (auto&& node : vNodes)
-            pre(node);
+        for (auto&& node : vNodes) {
+            if (NodeFullyConnected(node))
+                pre(node);
+        }
         post();
     };
 
@@ -217,8 +175,10 @@ public:
     void ForEachNodeThen(Callable&& pre, CallableAfter&& post) const
     {
         LOCK(cs_vNodes);
-        for (const auto& node : vNodes)
-            pre(node);
+        for (auto&& node : vNodes) {
+            if (NodeFullyConnected(node))
+                pre(node);
+        }
         post();
     };
 
@@ -316,6 +276,9 @@ private:
     // Network stats
     void RecordBytesRecv(uint64_t bytes);
     void RecordBytesSent(uint64_t bytes);
+
+    // Whether the node should be passed out in ForEach* callbacks
+    static bool NodeFullyConnected(const CNode* pnode);
 
     // Network usage totals
     CCriticalSection cs_totalBytesRecv;

--- a/src/net.h
+++ b/src/net.h
@@ -539,7 +539,7 @@ public:
     CCriticalSection cs_hSocket;
 
     std::deque<CInv> vRecvGetData;
-    std::deque<CNetMessage> vRecvMsg;
+    std::list<CNetMessage> vRecvMsg;
     CCriticalSection cs_vRecvMsg;
     uint64_t nRecvBytes;
     int nRecvVersion;

--- a/src/net.h
+++ b/src/net.h
@@ -551,7 +551,6 @@ public:
     // socket
     uint64_t nServices;
     SOCKET hSocket;
-    CDataStream ssSend;
     size_t nSendSize; // total size of all vSendMsg entries
     size_t nSendOffset; // offset inside the first vSendMsg already sent
     uint64_t nSendBytes;
@@ -598,10 +597,6 @@ public:
     std::unique_ptr<CBloomFilter> xthinFilter;
     int nRefCount;
     const NodeId id;
-
-protected:
-    // Basic fuzz-testing
-    void Fuzz(int nChance); // modifies ssSend
 
 public:
     uint256 hashContinue;

--- a/src/netmessagemaker.h
+++ b/src/netmessagemaker.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NETMESSAGEMAKER_H
+#define BITCOIN_NETMESSAGEMAKER_H
+
+#include "net.h"
+#include "serialize.h"
+
+class CNetMsgMaker
+{
+public:
+    CNetMsgMaker(int nVersionIn) : nVersion(nVersionIn){}
+
+    template <typename... Args>
+    CSerializedNetMsg Make(int nFlags, std::string sCommand, Args&&... args)
+    {
+        CSerializedNetMsg msg;
+        msg.command = std::move(sCommand);
+        CVectorWriter{ SER_NETWORK, nFlags | nVersion, msg.data, 0, std::forward<Args>(args)... };
+        return msg;
+    }
+
+    template <typename... Args>
+    CSerializedNetMsg Make(std::string sCommand, Args&&... args)
+    {
+        return Make(0, std::move(sCommand), std::forward<Args>(args)...);
+    }
+
+private:
+    const int nVersion;
+};
+
+#endif // BITCOIN_NETMESSAGEMAKER_H

--- a/src/netmessagemaker.h
+++ b/src/netmessagemaker.h
@@ -33,4 +33,12 @@ private:
     const int nVersion;
 };
 
+template <typename... Args>
+CSerializedNetMsg NetMsg(CNode* to, Args&&... args) {
+    if (to == nullptr) {
+        throw std::invalid_argument("NetMsg: to == nullptr");
+    }
+    return CNetMsgMaker(to->GetSendVersion()).Make(std::forward<Args>(args)...);
+}
+
 #endif // BITCOIN_NETMESSAGEMAKER_H

--- a/src/nodestate.cpp
+++ b/src/nodestate.cpp
@@ -4,7 +4,10 @@
 #include "thinblock.h"
 #include <utility>
 
-CNodeState::CNodeState(NodeId id, ThinBlockManager& thinblockmg) {
+CNodeState::CNodeState(NodeId id, ThinBlockManager& thinblockmg,
+                       const CService& addr, const std::string& name)
+    : address(addr), name(name)
+{
     fCurrentlyConnected = false;
     nMisbehavior = 0;
     fShouldBan = false;
@@ -29,10 +32,8 @@ std::map<NodeId, CNodeState> NodeStatePtr::mapNodeState;
 
 void NodeStatePtr::insert(NodeId nodeid, const CNode *pnode, ThinBlockManager& thinblockmg) {
     LOCK(cs_mapNodeState);
-    CNodeState &state = mapNodeState.insert(std::make_pair(
-                nodeid, CNodeState(nodeid, thinblockmg))).first->second;
-    state.name = pnode->addrName;
-    state.address = pnode->addr;
+    mapNodeState.insert({nodeid,
+                CNodeState(nodeid, thinblockmg, pnode->addr, pnode->addrName)});
 }
 
 CNodeState::~CNodeState()

--- a/src/nodestate.h
+++ b/src/nodestate.h
@@ -36,7 +36,7 @@ struct CBlockReject {
  */
 struct CNodeState {
     //! The peer's address
-    CService address;
+    const CService address;
     //! Whether we have a fully established connection.
     bool fCurrentlyConnected;
     //! Accumulated misbehaviour score for this peer.
@@ -44,7 +44,7 @@ struct CNodeState {
     //! Whether this peer should be disconnected and banned (unless whitelisted).
     bool fShouldBan;
     //! String name of this peer (debugging/logging purposes).
-    std::string name;
+    const std::string name;
     //! List of asynchronously-determined block rejections to notify this peer about.
     std::vector<CBlockReject> rejects;
     //! The best known block we know this peer has announced.
@@ -77,7 +77,7 @@ struct CNodeState {
     //! the thin block the node is currently providing to us
     std::shared_ptr<ThinBlockWorker> thinblock;
 
-    CNodeState(NodeId id, ThinBlockManager&);
+    CNodeState(NodeId id, ThinBlockManager&, const CService& addr, const std::string& name);
     ~CNodeState();
 };
 

--- a/src/process_xthinblock.cpp
+++ b/src/process_xthinblock.cpp
@@ -3,6 +3,7 @@
 #include "consensus/validation.h"
 #include "main.h" // Misbehaving, mapBlockIndex
 #include "net.h"
+#include "netmessagemaker.h"
 #include "streams.h"
 #include "thinblock.h"
 #include "util.h"
@@ -68,5 +69,5 @@ void XThinBlockProcessor::operator()(
     LogPrintf("re-requesting xthin %d missing transactions for %s from peer=%d\n",
             missing.size(), hash.ToString(), from.id);
 
-    connman.PushMessage(&from, "get_xblocktx", req);
+    connman.PushMessage(&from, NetMsg(&from, NetMsgType::GET_XBLOCKTX, req));
 }

--- a/src/process_xthinblock.cpp
+++ b/src/process_xthinblock.cpp
@@ -43,7 +43,7 @@ void XThinBlockProcessor::operator()(
 
     try {
         XThinStub stub(block);
-        worker.buildStub(stub, txfinder, from);
+        worker.buildStub(stub, txfinder, connman, from);
     }
     catch (const thinblock_error& e) {
         rejectBlock(hash, e.what(), 10);
@@ -68,5 +68,5 @@ void XThinBlockProcessor::operator()(
     LogPrintf("re-requesting xthin %d missing transactions for %s from peer=%d\n",
             missing.size(), hash.ToString(), from.id);
 
-    from.PushMessage("get_xblocktx", req);
+    connman.PushMessage(&from, "get_xblocktx", req);
 }

--- a/src/process_xthinblock.h
+++ b/src/process_xthinblock.h
@@ -8,8 +8,8 @@ class TxFinder;
 
 class XThinBlockProcessor : private BlockProcessor {
     public:
-        XThinBlockProcessor(CNode& f, ThinBlockWorker& w, BlockHeaderProcessor& h) :
-            BlockProcessor(f, w, "xthinblock", h)
+        XThinBlockProcessor(CConnman& c, CNode& f, ThinBlockWorker& w, BlockHeaderProcessor& h) :
+            BlockProcessor(c, f, w, "xthinblock", h)
         {
         }
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -35,6 +35,15 @@ const char *FILTERADD="filteradd";
 const char *FILTERCLEAR="filterclear";
 const char *REJECT="reject";
 const char *SENDHEADERS="sendheaders";
+const char *GETBLOCKTXN="getblocktxn";
+const char *SENDCMPCT="sendcmpct";
+const char *GET_XTHIN="get_xthin";
+const char *XTHINBLOCK="xthinblock";
+const char *GET_XBLOCKTX="get_xblocktx";
+const char *CMPCTBLOCK="cmpctblock";
+const char *XBLOCKTX="xblocktx";
+const char *BLOCKTXN="blocktxn";
+const char *UTXOS="utxos";
 };
 
 static const char* ppszTypeName[] =
@@ -72,7 +81,16 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::FILTERADD,
     NetMsgType::FILTERCLEAR,
     NetMsgType::REJECT,
-    NetMsgType::SENDHEADERS
+    NetMsgType::SENDHEADERS,
+    NetMsgType::GETBLOCKTXN,
+    NetMsgType::SENDCMPCT,
+    NetMsgType::GET_XTHIN,
+    NetMsgType::XTHINBLOCK,
+    NetMsgType::GET_XBLOCKTX,
+    NetMsgType::CMPCTBLOCK,
+    NetMsgType::XBLOCKTX,
+    NetMsgType::BLOCKTXN,
+    NetMsgType::UTXOS
 };
 const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes, allNetMessageTypes+ARRAYLEN(allNetMessageTypes));
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -12,15 +12,69 @@
 # include <arpa/inet.h>
 #endif
 
+namespace NetMsgType {
+const char *VERSION="version";
+const char *VERACK="verack";
+const char *ADDR="addr";
+const char *INV="inv";
+const char *GETDATA="getdata";
+const char *MERKLEBLOCK="merkleblock";
+const char *GETBLOCKS="getblocks";
+const char *GETHEADERS="getheaders";
+const char *TX="tx";
+const char *HEADERS="headers";
+const char *BLOCK="block";
+const char *GETADDR="getaddr";
+const char *MEMPOOL="mempool";
+const char *PING="ping";
+const char *PONG="pong";
+const char *ALERT="alert";
+const char *NOTFOUND="notfound";
+const char *FILTERLOAD="filterload";
+const char *FILTERADD="filteradd";
+const char *FILTERCLEAR="filterclear";
+const char *REJECT="reject";
+const char *SENDHEADERS="sendheaders";
+};
+
 static const char* ppszTypeName[] =
 {
-    "ERROR",
-    "tx",
-    "block",
-    "filtered block",
+    "ERROR", // Should never occur
+    NetMsgType::TX,
+    NetMsgType::BLOCK,
+    "filtered block", // Should never occur
     "cmpctblock", // or thinblock
     "xthinblock"
 };
+
+/** All known message types. Keep this in the same order as the list of
+ * messages above and in protocol.h.
+ */
+const static std::string allNetMessageTypes[] = {
+    NetMsgType::VERSION,
+    NetMsgType::VERACK,
+    NetMsgType::ADDR,
+    NetMsgType::INV,
+    NetMsgType::GETDATA,
+    NetMsgType::MERKLEBLOCK,
+    NetMsgType::GETBLOCKS,
+    NetMsgType::GETHEADERS,
+    NetMsgType::TX,
+    NetMsgType::HEADERS,
+    NetMsgType::BLOCK,
+    NetMsgType::GETADDR,
+    NetMsgType::MEMPOOL,
+    NetMsgType::PING,
+    NetMsgType::PONG,
+    NetMsgType::ALERT,
+    NetMsgType::NOTFOUND,
+    NetMsgType::FILTERLOAD,
+    NetMsgType::FILTERADD,
+    NetMsgType::FILTERCLEAR,
+    NetMsgType::REJECT,
+    NetMsgType::SENDHEADERS
+};
+const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes, allNetMessageTypes+ARRAYLEN(allNetMessageTypes));
 
 CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn)
 {
@@ -141,4 +195,9 @@ const char* CInv::GetCommand() const
 std::string CInv::ToString() const
 {
     return strprintf("%s %s", GetCommand(), hash.ToString());
+}
+
+const std::vector<std::string> &getAllNetMessageTypes()
+{
+    return allNetMessageTypesVec;
 }

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -65,6 +65,165 @@ public:
     uint8_t pchChecksum[CHECKSUM_SIZE];
 };
 
+/**
+ * Bitcoin protocol message types. When adding new message types, don't forget
+ * to update allNetMessageTypes in protocol.cpp.
+ */
+namespace NetMsgType {
+
+/**
+ * The version message provides information about the transmitting node to the
+ * receiving node at the beginning of a connection.
+ * @see https://bitcoin.org/en/developer-reference#version
+ */
+extern const char *VERSION;
+/**
+ * The verack message acknowledges a previously-received version message,
+ * informing the connecting node that it can begin to send other messages.
+ * @see https://bitcoin.org/en/developer-reference#verack
+ */
+extern const char *VERACK;
+/**
+ * The addr (IP address) message relays connection information for peers on the
+ * network.
+ * @see https://bitcoin.org/en/developer-reference#addr
+ */
+extern const char *ADDR;
+/**
+ * The inv message (inventory message) transmits one or more inventories of
+ * objects known to the transmitting peer.
+ * @see https://bitcoin.org/en/developer-reference#inv
+ */
+extern const char *INV;
+/**
+ * The getdata message requests one or more data objects from another node.
+ * @see https://bitcoin.org/en/developer-reference#getdata
+ */
+extern const char *GETDATA;
+/**
+ * The merkleblock message is a reply to a getdata message which requested a
+ * block using the inventory type MSG_MERKLEBLOCK.
+ * @since protocol version 70001 as described by BIP37.
+ * @see https://bitcoin.org/en/developer-reference#merkleblock
+ */
+extern const char *MERKLEBLOCK;
+/**
+ * The getblocks message requests an inv message that provides block header
+ * hashes starting from a particular point in the block chain.
+ * @see https://bitcoin.org/en/developer-reference#getblocks
+ */
+extern const char *GETBLOCKS;
+/**
+ * The getheaders message requests a headers message that provides block
+ * headers starting from a particular point in the block chain.
+ * @since protocol version 31800.
+ * @see https://bitcoin.org/en/developer-reference#getheaders
+ */
+extern const char *GETHEADERS;
+/**
+ * The tx message transmits a single transaction.
+ * @see https://bitcoin.org/en/developer-reference#tx
+ */
+extern const char *TX;
+/**
+ * The headers message sends one or more block headers to a node which
+ * previously requested certain headers with a getheaders message.
+ * @since protocol version 31800.
+ * @see https://bitcoin.org/en/developer-reference#headers
+ */
+extern const char *HEADERS;
+/**
+ * The block message transmits a single serialized block.
+ * @see https://bitcoin.org/en/developer-reference#block
+ */
+extern const char *BLOCK;
+/**
+ * The getaddr message requests an addr message from the receiving node,
+ * preferably one with lots of IP addresses of other receiving nodes.
+ * @see https://bitcoin.org/en/developer-reference#getaddr
+ */
+extern const char *GETADDR;
+/**
+ * The mempool message requests the TXIDs of transactions that the receiving
+ * node has verified as valid but which have not yet appeared in a block.
+ * @since protocol version 60002.
+ * @see https://bitcoin.org/en/developer-reference#mempool
+ */
+extern const char *MEMPOOL;
+/**
+ * The ping message is sent periodically to help confirm that the receiving
+ * peer is still connected.
+ * @see https://bitcoin.org/en/developer-reference#ping
+ */
+extern const char *PING;
+/**
+ * The pong message replies to a ping message, proving to the pinging node that
+ * the ponging node is still alive.
+ * @since protocol version 60001 as described by BIP31.
+ * @see https://bitcoin.org/en/developer-reference#pong
+ */
+extern const char *PONG;
+/**
+ * The alert message warns nodes of problems that may affect them or the rest
+ * of the network.
+ * @since protocol version 311.
+ * @see https://bitcoin.org/en/developer-reference#alert
+ */
+extern const char *ALERT;
+/**
+ * The notfound message is a reply to a getdata message which requested an
+ * object the receiving node does not have available for relay.
+ * @ince protocol version 70001.
+ * @see https://bitcoin.org/en/developer-reference#notfound
+ */
+extern const char *NOTFOUND;
+/**
+ * The filterload message tells the receiving peer to filter all relayed
+ * transactions and requested merkle blocks through the provided filter.
+ * @since protocol version 70001 as described by BIP37.
+ *   Only available with service bit NODE_BLOOM since protocol version
+ *   70011 as described by BIP111.
+ * @see https://bitcoin.org/en/developer-reference#filterload
+ */
+extern const char *FILTERLOAD;
+/**
+ * The filteradd message tells the receiving peer to add a single element to a
+ * previously-set bloom filter, such as a new public key.
+ * @since protocol version 70001 as described by BIP37.
+ *   Only available with service bit NODE_BLOOM since protocol version
+ *   70011 as described by BIP111.
+ * @see https://bitcoin.org/en/developer-reference#filteradd
+ */
+extern const char *FILTERADD;
+/**
+ * The filterclear message tells the receiving peer to remove a previously-set
+ * bloom filter.
+ * @since protocol version 70001 as described by BIP37.
+ *   Only available with service bit NODE_BLOOM since protocol version
+ *   70011 as described by BIP111.
+ * @see https://bitcoin.org/en/developer-reference#filterclear
+ */
+extern const char *FILTERCLEAR;
+/**
+ * The reject message informs the receiving node that one of its previous
+ * messages has been rejected.
+ * @since protocol version 70002 as described by BIP61.
+ * @see https://bitcoin.org/en/developer-reference#reject
+ */
+extern const char *REJECT;
+/**
+ * Indicates that a node prefers to receive new block announcements via a
+ * "headers" message rather than an "inv".
+ * @since protocol version 70012 as described by BIP130.
+ * @see https://bitcoin.org/en/developer-reference#sendheaders
+ */
+extern const char *SENDHEADERS;
+
+};
+
+/* Get a vector of all valid message types (see above) */
+const std::vector<std::string> &getAllNetMessageTypes();
+
 /** nServices flags */
 enum {
     // NODE_NETWORK means that the node is capable of serving the block chain. It is currently

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -218,7 +218,15 @@ extern const char *REJECT;
  * @see https://bitcoin.org/en/developer-reference#sendheaders
  */
 extern const char *SENDHEADERS;
-
+extern const char *GETBLOCKTXN;
+extern const char *SENDCMPCT;
+extern const char *GET_XTHIN;
+extern const char *XTHINBLOCK;
+extern const char *GET_XBLOCKTX;
+extern const char *CMPCTBLOCK;
+extern const char *XBLOCKTX;
+extern const char *BLOCKTXN;
+extern const char *UTXOS;
 };
 
 /* Get a vector of all valid message types (see above) */

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -645,11 +645,11 @@ void RPCConsole::updateNodeDetail(const CNodeCombinedStats *stats)
         peerAddrDetails += "<br />" + tr("via %1").arg(QString::fromStdString(stats->nodeStats.addrLocal));
     ui->peerHeading->setText(peerAddrDetails);
     ui->peerServices->setText(GUIUtil::formatServicesStr(stats->nodeStats.nServices));
-    ui->peerLastSend->setText(stats->nodeStats.nLastSend ? GUIUtil::formatDurationStr(GetTime() - stats->nodeStats.nLastSend) : tr("never"));
-    ui->peerLastRecv->setText(stats->nodeStats.nLastRecv ? GUIUtil::formatDurationStr(GetTime() - stats->nodeStats.nLastRecv) : tr("never"));
+    ui->peerLastSend->setText(stats->nodeStats.nLastSend ? GUIUtil::formatDurationStr(GetSystemTimeInSeconds() - stats->nodeStats.nLastSend) : tr("never"));
+    ui->peerLastRecv->setText(stats->nodeStats.nLastRecv ? GUIUtil::formatDurationStr(GetSystemTimeInSeconds() - stats->nodeStats.nLastRecv) : tr("never"));
     ui->peerBytesSent->setText(FormatBytes(stats->nodeStats.nSendBytes));
     ui->peerBytesRecv->setText(FormatBytes(stats->nodeStats.nRecvBytes));
-    ui->peerConnTime->setText(GUIUtil::formatDurationStr(GetTime() - stats->nodeStats.nTimeConnected));
+    ui->peerConnTime->setText(GUIUtil::formatDurationStr(GetSystemTimeInSeconds() - stats->nodeStats.nTimeConnected));
     ui->peerPingTime->setText(GUIUtil::formatPingTime(stats->nodeStats.dPingTime));
     ui->timeoffset->setText(GUIUtil::formatTimeOffset(stats->nodeStats.nTimeOffset));
     ui->peerVersion->setText(QString("%1").arg(stats->nodeStats.nVersion));

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -383,21 +383,15 @@ UniValue setmocktime(const JSONRPCRequest& request)
     if (!Params().MineBlocksOnDemand())
         throw runtime_error("setmocktime for regression testing (-regtest mode) only");
 
-    // cs_vNodes is locked and node send/receive times are updated
-    // atomically with the time change to prevent peers from being
-    // disconnected because we think we haven't communicated with them
-    // in a long time.
+    // For now, don't change mocktime if we're in the middle of validation, as
+    // this could have an effect on mempool time-based eviction, as well as
+    // IsCurrentForFeeEstimation() and IsInitialBlockDownload().
+    // TODO: figure out the right way to synchronize around mocktime, and
+    // ensure all callsites of GetTime() are accessing this safely.
     LOCK(cs_main);
 
     RPCTypeCheck(request.params, boost::assign::list_of(UniValue::VNUM));
     SetMockTime(request.params[0].get_int64());
-
-    uint64_t t = GetTime();
-    if(g_connman) {
-        g_connman->ForEachNode([t](CNode* pnode) {
-            pnode->nLastSend = pnode->nLastRecv = t;
-        });
-    }
 
     return NullUniValue;
 }

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -163,6 +163,7 @@ enum
 };
 
 #define READWRITE(obj)      (::SerReadWrite(s, (obj), ser_action))
+#define READWRITEMANY(...)      (::SerReadWriteMany(s, ser_action, __VA_ARGS__))
 
 /**
  * Implement three methods for serializable objects. These are actually wrappers over
@@ -793,6 +794,54 @@ template <typename S, typename T>
 size_t GetSerializeSize(const S& s, const T& t)
 {
     return (CSizeComputer(s.GetType(), s.GetVersion()) << t).size();
+}
+
+template<typename Stream>
+void SerializeMany(Stream& s)
+{
+}
+
+template<typename Stream, typename Arg>
+void SerializeMany(Stream& s, Arg&& arg)
+{
+    ::Serialize(s, std::forward<Arg>(arg));
+}
+
+template<typename Stream, typename Arg, typename... Args>
+void SerializeMany(Stream& s, Arg&& arg, Args&&... args)
+{
+    ::Serialize(s, std::forward<Arg>(arg));
+    ::SerializeMany(s, std::forward<Args>(args)...);
+}
+
+template<typename Stream>
+inline void UnserializeMany(Stream& s)
+{
+}
+
+template<typename Stream, typename Arg>
+inline void UnserializeMany(Stream& s, Arg& arg)
+{
+    ::Unserialize(s, arg);
+}
+
+template<typename Stream, typename Arg, typename... Args>
+inline void UnserializeMany(Stream& s, Arg& arg, Args&... args)
+{
+    ::Unserialize(s, arg);
+    ::UnserializeMany(s, args...);
+}
+
+template<typename Stream, typename... Args>
+inline void SerReadWriteMany(Stream& s,CSerActionSerialize ser_action, Args&&... args)
+{
+    ::SerializeMany(s, std::forward<Args>(args)...);
+}
+
+template<typename Stream, typename... Args>
+inline void SerReadWriteMany(Stream& s, CSerActionUnserialize ser_action, Args&... args)
+{
+    ::UnserializeMany(s, args...);
 }
 
 #endif // BITCOIN_SERIALIZE_H

--- a/src/streams.h
+++ b/src/streams.h
@@ -22,6 +22,75 @@
 #include <utility>
 #include <vector>
 
+/* Minimal stream for overwriting and/or appending to an existing byte vector
+ *
+ * The referenced vector will grow as necessary
+ */
+class CVectorWriter
+{
+ public:
+
+/*
+ * @param[in]  nTypeIn Serialization Type
+ * @param[in]  nVersionIn Serialization Version (including any flags)
+ * @param[in]  vchDataIn  Referenced byte vector to overwrite/append
+ * @param[in]  nPosIn Starting position. Vector index where writes should start. The vector will initially
+ *                    grow as necessary to  max(index, vec.size()). So to append, use vec.size().
+*/
+    CVectorWriter(int nTypeIn, int nVersionIn, std::vector<unsigned char>& vchDataIn, size_t nPosIn) : nType(nTypeIn), nVersion(nVersionIn), vchData(vchDataIn), nPos(nPosIn)
+    {
+        if(nPos > vchData.size())
+            vchData.resize(nPos);
+    }
+/*
+ * (other params same as above)
+ * @param[in]  args  A list of items to serialize starting at nPos.
+*/
+    template <typename... Args>
+    CVectorWriter(int nTypeIn, int nVersionIn, std::vector<unsigned char>& vchDataIn, size_t nPosIn, Args&&... args) : CVectorWriter(nTypeIn, nVersionIn, vchDataIn, nPosIn)
+    {
+        ::SerializeMany(*this, std::forward<Args>(args)...);
+    }
+    void write(const char* pch, size_t nSize)
+    {
+        assert(nPos <= vchData.size());
+        size_t nOverwrite = std::min(nSize, vchData.size() - nPos);
+        if (nOverwrite) {
+            memcpy(vchData.data() + nPos, reinterpret_cast<const unsigned char*>(pch), nOverwrite);
+        }
+        if (nOverwrite < nSize) {
+            vchData.insert(vchData.end(), reinterpret_cast<const unsigned char*>(pch) + nOverwrite, reinterpret_cast<const unsigned char*>(pch) + nSize);
+        }
+        nPos += nSize;
+    }
+    template<typename T>
+    CVectorWriter& operator<<(const T& obj)
+    {
+        // Serialize to this stream
+        ::Serialize(*this, obj);
+        return (*this);
+    }
+    int GetVersion() const
+    {
+        return nVersion;
+    }
+    int GetType() const
+    {
+        return nType;
+    }
+    void seek(size_t nSize)
+    {
+        nPos += nSize;
+        if(nPos > vchData.size())
+            vchData.resize(nPos);
+    }
+private:
+    const int nType;
+    const int nVersion;
+    std::vector<unsigned char>& vchData;
+    size_t nPos;
+};
+
 /** Double ended buffer combining vector and stream-like interfaces.
  *
  * >> and << read and write unformatted data using the above serialization templates.

--- a/src/streams.h
+++ b/src/streams.h
@@ -78,6 +78,13 @@ public:
         Init(nTypeIn, nVersionIn);
     }
 
+    template <typename... Args>
+    CDataStream(int nTypeIn, int nVersionIn, Args&&... args)
+    {
+        Init(nTypeIn, nVersionIn);
+        ::SerializeMany(*this, std::forward<Args>(args)...);
+    }
+
     void Init(int nTypeIn, int nVersionIn)
     {
         nReadPos = 0;
@@ -312,7 +319,7 @@ private:
     const int nType;
     const int nVersion;
 
-    FILE* file;	
+    FILE* file;
 
 public:
     CAutoFile(FILE* filenew, int nTypeIn, int nVersionIn) : nType(nTypeIn), nVersion(nVersionIn)

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     CAddress addr1(ip(0xa0b0c001));
     CNode dummyNode1(id++, NODE_NETWORK, 0, INVALID_SOCKET, addr1, 0, "", true);
     dummyNode1.SetSendVersion(PROTOCOL_VERSION);
-    GetNodeSignals().InitializeNode(dummyNode1.GetId(), &dummyNode1);
+    GetNodeSignals().InitializeNode(&dummyNode1, *connman);
     dummyNode1.nVersion = 1;
     Misbehaving(dummyNode1.GetId(), 100, ""); // Should get banned
     SendMessages(&dummyNode1, connman, interruptDummy);
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     CAddress addr2(ip(0xa0b0c002));
     CNode dummyNode2(id++, NODE_NETWORK, 0, INVALID_SOCKET, addr2, 1, "", true);
     dummyNode2.SetSendVersion(PROTOCOL_VERSION);
-    GetNodeSignals().InitializeNode(dummyNode2.GetId(), &dummyNode2);
+    GetNodeSignals().InitializeNode(&dummyNode2, *connman);
     dummyNode2.nVersion = 1;
     Misbehaving(dummyNode2.GetId(), 50, "");
     SendMessages(&dummyNode2, connman, interruptDummy);
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     CAddress addr1(ip(0xa0b0c001));
     CNode dummyNode1(id++, NODE_NETWORK, 0, INVALID_SOCKET, addr1, 1, "", true);
     dummyNode1.SetSendVersion(PROTOCOL_VERSION);
-    GetNodeSignals().InitializeNode(dummyNode1.GetId(), &dummyNode1);
+    GetNodeSignals().InitializeNode(&dummyNode1, *connman);
     dummyNode1.nVersion = 1;
     Misbehaving(dummyNode1.GetId(), 100, "");
     SendMessages(&dummyNode1, connman, interruptDummy);
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     CAddress addr(ip(0xa0b0c001));
     CNode dummyNode(id++, NODE_NETWORK, 0, INVALID_SOCKET, addr, 4, "", true);
     dummyNode.SetSendVersion(PROTOCOL_VERSION);
-    GetNodeSignals().InitializeNode(dummyNode.GetId(), &dummyNode);
+    GetNodeSignals().InitializeNode(&dummyNode, *connman);
     dummyNode.nVersion = 1;
 
     Misbehaving(dummyNode.GetId(), 100, "");

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -57,6 +57,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     dummyNode1.SetSendVersion(PROTOCOL_VERSION);
     GetNodeSignals().InitializeNode(&dummyNode1, *connman);
     dummyNode1.nVersion = 1;
+    dummyNode1.fSuccessfullyConnected = true;
     Misbehaving(dummyNode1.GetId(), 100, ""); // Should get banned
     SendMessages(&dummyNode1, connman, interruptDummy);
     BOOST_CHECK(connman->IsBanned(addr1));
@@ -67,6 +68,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     dummyNode2.SetSendVersion(PROTOCOL_VERSION);
     GetNodeSignals().InitializeNode(&dummyNode2, *connman);
     dummyNode2.nVersion = 1;
+    dummyNode2.fSuccessfullyConnected = true;
     Misbehaving(dummyNode2.GetId(), 50, "");
     SendMessages(&dummyNode2, connman, interruptDummy);
     BOOST_CHECK(!connman->IsBanned(addr2)); // 2 not banned yet...
@@ -87,6 +89,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     dummyNode1.SetSendVersion(PROTOCOL_VERSION);
     GetNodeSignals().InitializeNode(&dummyNode1, *connman);
     dummyNode1.nVersion = 1;
+    dummyNode1.fSuccessfullyConnected = true;
     Misbehaving(dummyNode1.GetId(), 100, "");
     SendMessages(&dummyNode1, connman, interruptDummy);
     BOOST_CHECK(!connman->IsBanned(addr1));
@@ -112,6 +115,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     dummyNode.SetSendVersion(PROTOCOL_VERSION);
     GetNodeSignals().InitializeNode(&dummyNode, *connman);
     dummyNode.nVersion = 1;
+    dummyNode.fSuccessfullyConnected = true;
 
     Misbehaving(dummyNode.GetId(), 100, "");
     SendMessages(&dummyNode, connman, interruptDummy);

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -54,6 +54,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     connman->ClearBanned();
     CAddress addr1(ip(0xa0b0c001));
     CNode dummyNode1(id++, NODE_NETWORK, 0, INVALID_SOCKET, addr1, 0, "", true);
+    dummyNode1.SetSendVersion(PROTOCOL_VERSION);
     GetNodeSignals().InitializeNode(dummyNode1.GetId(), &dummyNode1);
     dummyNode1.nVersion = 1;
     Misbehaving(dummyNode1.GetId(), 100, ""); // Should get banned
@@ -63,6 +64,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
 
     CAddress addr2(ip(0xa0b0c002));
     CNode dummyNode2(id++, NODE_NETWORK, 0, INVALID_SOCKET, addr2, 1, "", true);
+    dummyNode2.SetSendVersion(PROTOCOL_VERSION);
     GetNodeSignals().InitializeNode(dummyNode2.GetId(), &dummyNode2);
     dummyNode2.nVersion = 1;
     Misbehaving(dummyNode2.GetId(), 50, "");
@@ -82,6 +84,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     mapArgs["-banscore"] = "111"; // because 11 is my favorite number
     CAddress addr1(ip(0xa0b0c001));
     CNode dummyNode1(id++, NODE_NETWORK, 0, INVALID_SOCKET, addr1, 1, "", true);
+    dummyNode1.SetSendVersion(PROTOCOL_VERSION);
     GetNodeSignals().InitializeNode(dummyNode1.GetId(), &dummyNode1);
     dummyNode1.nVersion = 1;
     Misbehaving(dummyNode1.GetId(), 100, "");
@@ -106,6 +109,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
 
     CAddress addr(ip(0xa0b0c001));
     CNode dummyNode(id++, NODE_NETWORK, 0, INVALID_SOCKET, addr, 4, "", true);
+    dummyNode.SetSendVersion(PROTOCOL_VERSION);
     GetNodeSignals().InitializeNode(dummyNode.GetId(), &dummyNode);
     dummyNode.nVersion = 1;
 

--- a/src/test/ReceiveMsgBytes_tests.cpp
+++ b/src/test/ReceiveMsgBytes_tests.cpp
@@ -44,8 +44,6 @@ BOOST_AUTO_TEST_CASE(FullMessages)
     s << (uint64_t)11; // ping nonce
     EndMessage(s);
 
-    LOCK(testNode.cs_vRecvMsg);
-
     // Receive a full 'ping' message
     {
         bool complete;

--- a/src/test/ReceiveMsgBytes_tests.cpp
+++ b/src/test/ReceiveMsgBytes_tests.cpp
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(FullMessages)
         bool complete;
         BOOST_CHECK(testNode.ReceiveMsgBytes(&s[0], s.size(), complete));
         BOOST_CHECK_EQUAL(testNode.vRecvMsg.size(),1UL);
-        CNetMessage& msg = testNode.vRecvMsg[0];
+        CNetMessage& msg = testNode.vRecvMsg.front();
         BOOST_CHECK(msg.complete());
         BOOST_CHECK_EQUAL(msg.hdr.GetCommand(), "ping");
         uint64_t nonce;
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(FullMessages)
             BOOST_CHECK(testNode.ReceiveMsgBytes(&s[i], 1, complete));
         }
         BOOST_CHECK_EQUAL(testNode.vRecvMsg.size(),1UL);
-        CNetMessage& msg = testNode.vRecvMsg[0];
+        CNetMessage& msg = testNode.vRecvMsg.front();
         BOOST_CHECK(msg.complete());
         BOOST_CHECK_EQUAL(msg.hdr.GetCommand(), "ping");
         uint64_t nonce;

--- a/src/test/compactthin_tests.cpp
+++ b/src/test/compactthin_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include <boost/test/unit_test.hpp>
 
+#include "test/dummyconnman.h"
 #include "test/thinblockutil.h"
 #include "compactthin.h"
 #include "chainparams.h"
@@ -84,19 +85,20 @@ BOOST_AUTO_TEST_CASE(ids_are_correct) {
 BOOST_AUTO_TEST_CASE(request_block_announcements) {
     auto mg = GetDummyThinBlockMg();
 
+    DummyConnman connman;
     DummyNode node(42, mg.get());
     CompactWorker w(*mg, node.id);
     {
-        auto h = w.requestBlockAnnouncements(node);
+        auto h = w.requestBlockAnnouncements(connman, node);
 
         // Should send a request for header announcements
-        BOOST_CHECK_EQUAL(size_t(1), node.messages.size());
-        BOOST_CHECK_EQUAL("sendcmpct", node.messages.at(0));
+        BOOST_CHECK_EQUAL(size_t(1), connman.NumMessagesSent(node));
+        BOOST_CHECK(connman.MsgWasSent(node, "sendcmpct", 0));
     }
     // hande goes out of scope,
     // should send a request to disable header announcements
-    BOOST_CHECK_EQUAL(size_t(2), node.messages.size());
-    BOOST_CHECK_EQUAL("sendcmpct", node.messages.at(1));
+    BOOST_CHECK_EQUAL(size_t(2), connman.NumMessagesSent(node));
+    BOOST_CHECK(connman.MsgWasSent(node, "sendcmpct", 1));
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/test/dummyconnman.h
+++ b/src/test/dummyconnman.h
@@ -1,0 +1,55 @@
+#ifndef BITCOIN_DUMMYCONNMAN_H
+#define BITCOIN_DUMMYCONNMAN_H
+
+#include "net.h"
+
+#include <vector>
+#include <map>
+
+// Mockup of CConnman for use with unit tests.
+class DummyConnman : public CConnman {
+public:
+    DummyConnman() : CConnman(11, 42) {
+    }
+
+    // inherit to make public
+    void EndMessage(CDataStream& strm) override {
+        return CConnman::EndMessage(strm);
+    }
+
+    bool MsgWasSent(CNode& n, const std::string msg, int sequence = -1) {
+        auto f = messages.find(&n);
+        if (f == end(messages)) {
+            return false;
+        }
+        auto& nodemsg = f->second;
+        if (sequence == -1) {
+            auto m = std::find(begin(nodemsg), end(nodemsg), msg);
+            return m != end(nodemsg);
+        }
+        return nodemsg.at(sequence) == msg;
+    }
+    size_t NumMessagesSent(CNode& n) {
+        auto f = messages.find(&n);
+        if (f == end(messages)) {
+            return 0;
+        }
+        return f->second.size();
+    }
+
+    void ClearMessages(CNode& n) {
+        auto f = messages.find(&n);
+        if (f != end(messages))
+            f->second.clear();
+    }
+private:
+    std::map<CNode*, std::vector<std::string> > messages;
+
+    CDataStream BeginMessage(CNode* node, int nVersion, int flags, const std::string& sCommand) override {
+        messages[node].push_back(sCommand);
+        return CConnman::BeginMessage(node, nVersion, flags, sCommand);
+    }
+
+};
+
+#endif

--- a/src/test/dummyconnman.h
+++ b/src/test/dummyconnman.h
@@ -12,11 +12,6 @@ public:
     DummyConnman() : CConnman(11, 42) {
     }
 
-    // inherit to make public
-    void EndMessage(CDataStream& strm) override {
-        return CConnman::EndMessage(strm);
-    }
-
     bool MsgWasSent(CNode& n, const std::string msg, int sequence = -1) {
         auto f = messages.find(&n);
         if (f == end(messages)) {
@@ -44,10 +39,9 @@ public:
     }
 private:
     std::map<CNode*, std::vector<std::string> > messages;
-
-    CDataStream BeginMessage(CNode* node, int nVersion, int flags, const std::string& sCommand) override {
-        messages[node].push_back(sCommand);
-        return CConnman::BeginMessage(node, nVersion, flags, sCommand);
+    void PushMessage(CNode* pnode, CSerializedNetMsg&& msg) override {
+        messages[pnode].push_back(msg.command);
+        CConnman::PushMessage(pnode, std::forward<CSerializedNetMsg&&>(msg));
     }
 
 };

--- a/src/test/p2p_protocol_tests.cpp
+++ b/src/test/p2p_protocol_tests.cpp
@@ -27,7 +27,7 @@ protected:
 
 BOOST_AUTO_TEST_CASE(MaxSizeVersionMessage)
 {
-    DummyNode n;
+    DummyNode n(1, nullptr, 0);
     n.nVersion = 0;
     CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
     uint64_t nLocalHostNonce = 2;

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -10,10 +10,53 @@
 #include <stdint.h>
 
 #include <boost/test/unit_test.hpp>
-
 using namespace std;
 
 BOOST_FIXTURE_TEST_SUITE(serialize_tests, BasicTestingSetup)
+
+class CSerializeMethodsTestSingle
+{
+protected:
+    int intval;
+    bool boolval;
+    std::string stringval;
+    const char* charstrval;
+    CTransaction txval;
+public:
+    CSerializeMethodsTestSingle() = default;
+    CSerializeMethodsTestSingle(int intvalin, bool boolvalin, std::string stringvalin, const char* charstrvalin, CTransaction txvalin) : intval(intvalin), boolval(boolvalin), stringval(std::move(stringvalin)), charstrval(charstrvalin), txval(txvalin){}
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(intval);
+        READWRITE(boolval);
+        READWRITE(stringval);
+        READWRITE(FLATDATA(charstrval));
+        READWRITE(txval);
+    }
+
+    bool operator==(const CSerializeMethodsTestSingle& rhs)
+    {
+        return  intval == rhs.intval && \
+                boolval == rhs.boolval && \
+                stringval == rhs.stringval && \
+                strcmp(charstrval, rhs.charstrval) == 0 && \
+                txval == rhs.txval;
+    }
+};
+
+class CSerializeMethodsTestMany : public CSerializeMethodsTestSingle
+{
+public:
+    using CSerializeMethodsTestSingle::CSerializeMethodsTestSingle;
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITEMANY(intval, boolval, stringval, FLATDATA(charstrval), txval);
+    }
+};
 
 BOOST_AUTO_TEST_CASE(sizes)
 {
@@ -274,6 +317,32 @@ BOOST_AUTO_TEST_CASE(insert_delete)
     CSerializeData d;
     ss.GetAndClear(d);
     BOOST_CHECK_EQUAL(ss.size(), 0u);
+}
+
+BOOST_AUTO_TEST_CASE(class_methods)
+{
+    int intval(100);
+    bool boolval(true);
+    std::string stringval("testing");
+    const char* charstrval("testing charstr");
+    CMutableTransaction txval;
+    CSerializeMethodsTestSingle methodtest1(intval, boolval, stringval, charstrval, txval);
+    CSerializeMethodsTestMany methodtest2(intval, boolval, stringval, charstrval, txval);
+    CSerializeMethodsTestSingle methodtest3;
+    CSerializeMethodsTestMany methodtest4;
+    CDataStream ss(SER_DISK, PROTOCOL_VERSION);
+    BOOST_CHECK(methodtest1 == methodtest2);
+    ss << methodtest1;
+    ss >> methodtest4;
+    ss << methodtest2;
+    ss >> methodtest3;
+    BOOST_CHECK(methodtest1 == methodtest2);
+    BOOST_CHECK(methodtest2 == methodtest3);
+    BOOST_CHECK(methodtest3 == methodtest4);
+
+    CDataStream ss2(SER_DISK, PROTOCOL_VERSION, intval, boolval, stringval, FLATDATA(charstrval), txval);
+    ss2 >> methodtest3;
+    BOOST_CHECK(methodtest3 == methodtest4);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -1,0 +1,76 @@
+// Copyright (c) 2012-2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "streams.h"
+#include "support/allocators/zeroafterfree.h"
+#include "test/test_bitcoin.h"
+
+#include <boost/assign/std/vector.hpp> // for 'operator+=()'
+#include <boost/assert.hpp>
+#include <boost/test/unit_test.hpp>
+
+using namespace std;
+using namespace boost::assign; // bring 'operator+=()' into scope
+
+BOOST_FIXTURE_TEST_SUITE(streams_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(streams_vector_writer)
+{
+    unsigned char a(1);
+    unsigned char b(2);
+    unsigned char bytes[] = { 3, 4, 5, 6 };
+    std::vector<unsigned char> vch;
+
+    // Each test runs twice. Serializing a second time at the same starting
+    // point should yield the same results, even if the first test grew the
+    // vector.
+
+    CVectorWriter(SER_NETWORK, INIT_PROTO_VERSION, vch, 0, a, b);
+    BOOST_CHECK((vch == std::vector<unsigned char>{{1, 2}}));
+    CVectorWriter(SER_NETWORK, INIT_PROTO_VERSION, vch, 0, a, b);
+    BOOST_CHECK((vch == std::vector<unsigned char>{{1, 2}}));
+    vch.clear();
+
+    CVectorWriter(SER_NETWORK, INIT_PROTO_VERSION, vch, 2, a, b);
+    BOOST_CHECK((vch == std::vector<unsigned char>{{0, 0, 1, 2}}));
+    CVectorWriter(SER_NETWORK, INIT_PROTO_VERSION, vch, 2, a, b);
+    BOOST_CHECK((vch == std::vector<unsigned char>{{0, 0, 1, 2}}));
+    vch.clear();
+
+    vch.resize(5, 0);
+    CVectorWriter(SER_NETWORK, INIT_PROTO_VERSION, vch, 2, a, b);
+    BOOST_CHECK((vch == std::vector<unsigned char>{{0, 0, 1, 2, 0}}));
+    CVectorWriter(SER_NETWORK, INIT_PROTO_VERSION, vch, 2, a, b);
+    BOOST_CHECK((vch == std::vector<unsigned char>{{0, 0, 1, 2, 0}}));
+    vch.clear();
+
+    vch.resize(4, 0);
+    CVectorWriter(SER_NETWORK, INIT_PROTO_VERSION, vch, 3, a, b);
+    BOOST_CHECK((vch == std::vector<unsigned char>{{0, 0, 0, 1, 2}}));
+    CVectorWriter(SER_NETWORK, INIT_PROTO_VERSION, vch, 3, a, b);
+    BOOST_CHECK((vch == std::vector<unsigned char>{{0, 0, 0, 1, 2}}));
+    vch.clear();
+
+    vch.resize(4, 0);
+    CVectorWriter(SER_NETWORK, INIT_PROTO_VERSION, vch, 4, a, b);
+    BOOST_CHECK((vch == std::vector<unsigned char>{{0, 0, 0, 0, 1, 2}}));
+    CVectorWriter(SER_NETWORK, INIT_PROTO_VERSION, vch, 4, a, b);
+    BOOST_CHECK((vch == std::vector<unsigned char>{{0, 0, 0, 0, 1, 2}}));
+    vch.clear();
+
+    CVectorWriter(SER_NETWORK, INIT_PROTO_VERSION, vch, 0, FLATDATA(bytes));
+    BOOST_CHECK((vch == std::vector<unsigned char>{{3, 4, 5, 6}}));
+    CVectorWriter(SER_NETWORK, INIT_PROTO_VERSION, vch, 0, FLATDATA(bytes));
+    BOOST_CHECK((vch == std::vector<unsigned char>{{3, 4, 5, 6}}));
+    vch.clear();
+
+    vch.resize(4, 8);
+    CVectorWriter(SER_NETWORK, INIT_PROTO_VERSION, vch, 2, a, FLATDATA(bytes), b);
+    BOOST_CHECK((vch == std::vector<unsigned char>{{8, 8, 1, 3, 4, 5, 6, 2}}));
+    CVectorWriter(SER_NETWORK, INIT_PROTO_VERSION, vch, 2, a, FLATDATA(bytes), b);
+    BOOST_CHECK((vch == std::vector<unsigned char>{{8, 8, 1, 3, 4, 5, 6, 2}}));
+    vch.clear();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/thinblockconcluder_tests.cpp
+++ b/src/test/thinblockconcluder_tests.cpp
@@ -1,5 +1,6 @@
 #include <boost/test/unit_test_suite.hpp>
 #include <boost/test/test_tools.hpp>
+#include "test/dummyconnman.h"
 #include "test/thinblockutil.h"
 #include "blockencodings.h"
 #include "chainparams.h"
@@ -33,6 +34,7 @@ struct ConcluderSetup {
     CBlock block;
     CMerkleBlock mblock;
     CDataStream mstream;
+    DummyConnman connman;
     DummyNode pfrom;
     ThinBlockManager tmgr;
     uint64_t nonce;
@@ -64,18 +66,18 @@ BOOST_AUTO_TEST_CASE(xthin_concluder) {
     XThinBlockConcluder conclude;
     // Should ignore since worker is not working
     // on anything.
-    conclude(resp, pfrom, worker, markInFlight);
+    conclude(resp, connman, pfrom, worker, markInFlight);
     BOOST_CHECK(!worker.addTxCalled);
 
     // Should ignore since worker is assigned to a
     // different block.
     worker.addWork(uint256S("0xf00d"));
-    conclude(resp, pfrom, worker, markInFlight);
+    conclude(resp, connman, pfrom, worker, markInFlight);
     BOOST_CHECK(!worker.addTxCalled);
 
     // Should add tx.
     worker.addWork(resp.block);
-    conclude(resp, pfrom, worker, markInFlight);
+    conclude(resp, connman, pfrom, worker, markInFlight);
     BOOST_CHECK(worker.addTxCalled);
 }
 
@@ -101,18 +103,18 @@ BOOST_AUTO_TEST_CASE(compact_concluder) {
     CompactBlockConcluder conclude;
     // Should ignore since worker is not working
     // on anything.
-    conclude(resp, pfrom, worker, markInFlight);
+    conclude(resp, connman, pfrom, worker, markInFlight);
     BOOST_CHECK(!worker.addTxCalled);
 
     // Should ignore since worker is assigned to a
     // different block.
     worker.addWork(uint256S("0xf00d"));
-    conclude(resp, pfrom, worker, markInFlight);
+    conclude(resp, connman, pfrom, worker, markInFlight);
     BOOST_CHECK(!worker.addTxCalled);
 
     // Should add tx.
     worker.addWork(resp.blockhash);
-    conclude(resp, pfrom, worker, markInFlight);
+    conclude(resp, connman, pfrom, worker, markInFlight);
     BOOST_CHECK(worker.addTxCalled);
 };
 

--- a/src/test/thinblockutil.h
+++ b/src/test/thinblockutil.h
@@ -24,8 +24,10 @@ struct NullFinder : public TxFinder {
 };
 
 struct DummyNode : public CNode {
-    DummyNode(NodeId myid = insecure_rand(), ThinBlockManager* mgr = nullptr) : CNode(
-            myid, NODE_NETWORK, 0, INVALID_SOCKET, CAddress(), insecure_rand())
+    DummyNode(NodeId myid = insecure_rand(),
+              ThinBlockManager* mgr = nullptr,
+              int sendVersion = PROTOCOL_VERSION) :
+        CNode(myid, NODE_NETWORK, 0, INVALID_SOCKET, CAddress(), insecure_rand())
     {
         static auto staticmgr = GetDummyThinBlockMg();
         if (!mgr)
@@ -33,18 +35,14 @@ struct DummyNode : public CNode {
 
         NodeStatePtr::insert(id, this, *mgr);
         nVersion = PROTOCOL_VERSION;
+        SetSendVersion(sendVersion);
+
     }
     virtual ~DummyNode() {
         bool fUpdateConnectionTime;
         GetNodeSignals().FinalizeNode(id, fUpdateConnectionTime);
         NodeStatePtr(id).erase();
     }
-    virtual void BeginMessage(const char* pszCommand) EXCLUSIVE_LOCK_FUNCTION(cs_vSend) {
-        messages.push_back(pszCommand);
-        CNode::BeginMessage(pszCommand);
-    }
-
-    std::vector<std::string> messages;
 };
 
 struct DummyFinishedCallb : public ThinBlockFinishedCallb {

--- a/src/test/xthin_tests.cpp
+++ b/src/test/xthin_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include <boost/test/unit_test.hpp>
 
+#include "test/dummyconnman.h"
 #include "test/thinblockutil.h"
 #include "bloom.h"
 #include "uint256.h"
@@ -105,16 +106,17 @@ struct NullProvider : public TxHashProvider {
 BOOST_AUTO_TEST_CASE(requestBlock) {
     ThinBlockMgDummy mg;
     DummyNode node;
+    DummyConnman connman;
     XThinWorker w(mg, node.id, std::unique_ptr<TxHashProvider>(new NullProvider));
 
     std::vector<CInv> reqs;
-    w.requestBlock(uint256S("0xfafafa"), reqs, node);
+    w.requestBlock(uint256S("0xfafafa"), reqs, connman, node);
 
     // xthin does not add a generic CInv getdata request
     BOOST_CHECK(reqs.empty());
 
     // ... it pushes its own custom message
-    BOOST_CHECK_EQUAL("get_xthin", node.messages.at(0));
+    BOOST_CHECK(connman.MsgWasSent(node, "get_xthin", 0));
 }
 
 BOOST_AUTO_TEST_CASE(xthin_stub_self_validate) {

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -107,9 +107,11 @@ ThinBlockWorker::~ThinBlockWorker() {
     stopAllWork();
 }
 
-void ThinBlockWorker::buildStub(const StubData& d, const TxFinder& f, CNode& from) {
+void ThinBlockWorker::buildStub(const StubData& d, const TxFinder& f,
+                                CConnman& connman, CNode& from)
+{
     assert(isWorkingOn(d.header().GetHash()));
-    return mg.buildStub(d, f, *this, from);
+    return mg.buildStub(d, f, *this, connman, from);
 }
 
 bool ThinBlockWorker::isStubBuilt(const uint256& block) const {

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -11,6 +11,7 @@
 #include <memory>
 
 class CNode;
+class CConnman;
 class CInv;
 class CTransaction;
 class ThinBlockManager;
@@ -109,7 +110,7 @@ class ThinBlockWorker : boost::noncopyable {
 
         virtual std::vector<std::pair<int, ThinTx> > getTxsMissing(const uint256&) const;
 
-        virtual void buildStub(const StubData&, const TxFinder&, CNode& from);
+        virtual void buildStub(const StubData&, const TxFinder&, CConnman& connman, CNode& from);
         virtual bool isStubBuilt(const uint256& block) const;
         virtual void addWork(const uint256& block);
         virtual void stopWork(const uint256& block);
@@ -120,7 +121,8 @@ class ThinBlockWorker : boost::noncopyable {
         // getDataReq or implement a more specialized behavour.
         // Method is called during ProcessGetData.
         virtual void requestBlock(const uint256& block,
-                std::vector<CInv>& getDataReq, CNode& node) = 0;
+                                  std::vector<CInv>& getDataReq,
+                                  CConnman&, CNode& node) = 0;
 
         bool isReRequesting(const uint256& block) const;
         void setReRequesting(const uint256& block, bool);
@@ -138,7 +140,7 @@ class ThinBlockWorker : boost::noncopyable {
         // Enables block announcements with thin blocks.
         // Returns a RAII object that disables them on destruct.
         // Returns nullptr if peer does ont support this.
-        virtual std::unique_ptr<BlockAnnHandle> requestBlockAnnouncements(CNode&)
+        virtual std::unique_ptr<BlockAnnHandle> requestBlockAnnouncements(CConnman&, CNode&)
         {
             return nullptr;
         }

--- a/src/thinblockconcluder.cpp
+++ b/src/thinblockconcluder.cpp
@@ -1,5 +1,6 @@
 #include "blockencodings.h"
 #include "net.h"
+#include "netmessagemaker.h"
 #include "thinblockbuilder.h"
 #include "thinblockconcluder.h"
 #include "util.h"
@@ -18,7 +19,7 @@ static void fallbackDownload(CConnman& connman, CNode& from,
             block.ToString(), from.id);
 
     CInv req(MSG_BLOCK, block);
-    connman.PushMessage(&from, "getdata", std::vector<CInv>(1, req));
+    connman.PushMessage(&from, NetMsg(&from, NetMsgType::GETDATA, std::vector<CInv>(1, req)));
     markInFlight(from.id, block, Params().GetConsensus(), NULL);
 }
 

--- a/src/thinblockconcluder.h
+++ b/src/thinblockconcluder.h
@@ -13,13 +13,15 @@ class BlockInFlightMarker;
 // Finishes a block using response from a transaction re-request.
 struct XThinBlockConcluder {
     void operator()(const XThinReReqResponse& resp,
-        CNode& pfrom, ThinBlockWorker&, BlockInFlightMarker&);
+                    CConnman&, CNode& pfrom,
+                    ThinBlockWorker&, BlockInFlightMarker&);
 };
 
 // Finishes a block using response from a transaction re-request.
 struct CompactBlockConcluder {
     void operator()(const CompactReReqResponse& resp,
-        CNode& pfrom, ThinBlockWorker&, BlockInFlightMarker&);
+                    CConnman&, CNode& pfrom,
+                    ThinBlockWorker&, BlockInFlightMarker&);
 };
 
 #endif

--- a/src/thinblockmanager.cpp
+++ b/src/thinblockmanager.cpp
@@ -63,7 +63,7 @@ struct WrappedFinder : public TxFinder {
 };
 
 void ThinBlockManager::buildStub(const StubData& s, const TxFinder& txFinder,
-        ThinBlockWorker& worker, CNode& from)
+                                 ThinBlockWorker& worker, CConnman& connman, CNode& from)
 {
     uint256 h = s.header().GetHash();
     assert(builders.count(h));
@@ -96,7 +96,7 @@ void ThinBlockManager::buildStub(const StubData& s, const TxFinder& txFinder,
 
         // Node was first to provide us
         // a thin block. Select for block announcements with thin blocks.
-        requestBlockAnnouncements(worker, from);
+        requestBlockAnnouncements(worker, connman, from);
     }
 
     if (builders[h].builder->numTxsMissing() == 0)
@@ -188,8 +188,9 @@ void ThinBlockManager::finishBlock(const uint256& h, ThinBlockBuilder& builder) 
 
 // We ask for announcements with blocks from the
 // last 3 peers to provide a thin block first.
-void ThinBlockManager::requestBlockAnnouncements(ThinBlockWorker& w, CNode& node) {
-
+void ThinBlockManager::requestBlockAnnouncements(ThinBlockWorker& w,
+                                                 CConnman& connman, CNode& node)
+{
     typedef std::unique_ptr<BlockAnnHandle> annh;
     auto it = std::find_if(
             begin(announcers), end(announcers), [&w](const annh& h) {
@@ -203,7 +204,7 @@ void ThinBlockManager::requestBlockAnnouncements(ThinBlockWorker& w, CNode& node
         return;
     }
 
-    auto handle = w.requestBlockAnnouncements(node);
+    auto handle = w.requestBlockAnnouncements(connman, node);
     if (!bool(handle)) {
         // Peer cannot provide block announcements
         // with thin blocks.

--- a/src/thinblockmanager.h
+++ b/src/thinblockmanager.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 class CBlock;
+class CConnman;
 class CNode;
 class TxFinder;
 struct ThinBloomStub;
@@ -51,7 +52,8 @@ class ThinBlockManager : boost::noncopyable {
         void delWorker(const uint256& block, ThinBlockWorker& w);
         int numWorkers(const uint256& block) const;
 
-        void buildStub(const StubData&, const TxFinder&, ThinBlockWorker&, CNode& from);
+        void buildStub(const StubData&, const TxFinder&, ThinBlockWorker&,
+                       CConnman&, CNode& from);
         bool isStubBuilt(const uint256& block);
 
         bool addTx(const uint256& block, const CTransaction& tx);
@@ -59,7 +61,7 @@ class ThinBlockManager : boost::noncopyable {
         std::vector<std::pair<int, ThinTx> > getTxsMissing(const uint256& block) const;
 
         // public for unittest
-        void requestBlockAnnouncements(ThinBlockWorker& w, CNode& n);
+        void requestBlockAnnouncements(ThinBlockWorker& w, CConnman&, CNode& n);
 
     private:
         struct ActiveBuilder {

--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -40,6 +40,11 @@ int64_t GetTimeMicros()
             boost::posix_time::ptime(boost::gregorian::date(1970,1,1))).total_microseconds();
 }
 
+int64_t GetSystemTimeInSeconds()
+{
+    return GetTimeMicros()/1000000;
+}
+
 void MilliSleep(int64_t n)
 {
 

--- a/src/utiltime.h
+++ b/src/utiltime.h
@@ -9,9 +9,20 @@
 #include <stdint.h>
 #include <string>
 
+/**
+ * GetTimeMicros() and GetTimeMillis() both return the system time, but in
+ * different units. GetTime() returns the sytem time in seconds, but also
+ * supports mocktime, where the time can be specified by the user, eg for
+ * testing (eg with the setmocktime rpc, or -mocktime argument).
+ *
+ * TODO: Rework these functions to be type-safe (so that we don't inadvertently
+ * compare numbers with different units, or compare a mocktime to system time).
+ */
+
 int64_t GetTime();
 int64_t GetTimeMillis();
 int64_t GetTimeMicros();
+int64_t GetSystemTimeInSeconds(); // Like GetTime(), but not mockable
 void SetMockTime(int64_t nMockTimeIn);
 void MilliSleep(int64_t n);
 

--- a/src/xthin.cpp
+++ b/src/xthin.cpp
@@ -6,6 +6,7 @@
 #include "bloom.h"
 #include "chainparams.h"
 #include "net.h"
+#include "netmessagemaker.h"
 #include "pow.h"
 #include "protocol.h"
 #include "blockencodings.h"
@@ -121,7 +122,7 @@ void XThinWorker::requestBlock(const uint256& block,
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
     ss << inv;
     ss << dontWant;
-    connman.PushMessage(&node, "get_xthin", ss);
+    connman.PushMessage(&node, NetMsg(&node, NetMsgType::GET_XTHIN, ss));
 }
 
 

--- a/src/xthin.cpp
+++ b/src/xthin.cpp
@@ -112,7 +112,8 @@ XThinWorker::XThinWorker(ThinBlockManager& m, NodeId n) : ThinBlockWorker(m, n) 
 }
 
 void XThinWorker::requestBlock(const uint256& block,
-        std::vector<CInv>& getDataReq, CNode& node)
+                               std::vector<CInv>& getDataReq,
+                               CConnman& connman, CNode& node)
 {
     CBloomFilter dontWant = createDontWantFilter(*HashProvider);
 
@@ -120,7 +121,7 @@ void XThinWorker::requestBlock(const uint256& block,
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
     ss << inv;
     ss << dontWant;
-    node.PushMessage("get_xthin", ss);
+    connman.PushMessage(&node, "get_xthin", ss);
 }
 
 

--- a/src/xthin.h
+++ b/src/xthin.h
@@ -60,7 +60,8 @@ class XThinWorker : public ThinBlockWorker {
         XThinWorker(ThinBlockManager&, NodeId);
 
         void requestBlock(const uint256& block,
-                std::vector<CInv>& getDataReq, CNode& node) override;
+                std::vector<CInv>& getDataReq,
+                          CConnman&, CNode& node) override;
 
     private:
         std::unique_ptr<struct TxHashProvider> HashProvider;


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/pull/8708 - net: have CConnman handle message sending
* b98c14c (serialization: teach serializers variadics)
    * handled nVersion, nType conflicts
* 3e32cd0 (connman is in charge of pushing messages)
    * to simplify merge, removed stealth mode from PushVersion
* ea33268 (net: switch all callers to connman for pushing messages)
    * this needed massive patching because of we have split up the networking ocde and added unittests.
* 5c2169cc skipped, we didn't have the "optimistic write counter hack"
* 7588b85 (net: construct CNodeStates in place)
    * manually applied, our nodestate interface differs
* 9027680 (net: handle version push in InitializeNode)
    * mostly trivial

Skipped workaround PR https://github.com/bitcoin/bitcoin/pull/8862 because this is fixed in https://github.com/bitcoin/bitcoin/pull/9128

https://github.com/bitcoin/bitcoin/pull/7181 - net: Add and document network messages in protocol.h
* Only partial cherry-pick to get the constants, to reduce merge work

https://github.com/bitcoin/bitcoin/pull/9128 
* d74e352 (net: Set feelers to disconnect at the end of the version message)
    * skipped, we already have it
* fedea8a (net: don't send any messages before handshake or after requested disconnect)
    * moved reject/ban into separate function to avoid holding the nodestate lock, also removed needless scopes
* c7be56d (net: push only raw data into CConnman)
    * this also touches PushMessage and thus needed massive patching

https://github.com/bitcoin/bitcoin/pull/9225 - Fix some benign races

https://github.com/bitcoin/bitcoin/pull/9441 - Net: Massive speedup. Net locks overhaul

https://github.com/bitcoin/bitcoin/pull/9561 - Wake message handling thread when we receive a new block

https://github.com/bitcoin/bitcoin/pull/9535 - Split CNode::cs_vSend: message processing and message sending
* Discovered earlier merge issue after applying this. Fixed in separate commit.

https://github.com/bitcoin/bitcoin/pull/9626 - Clean up a few CConnman cs_vNodes/CNode things
* 5be0190 - skipped, relaytransactions is not useless and we didn't have the others


https://github.com/bitcoin/bitcoin/pull/9606 - net: Consistently use GetTimeMicros() for inactivity checks
https://github.com/bitcoin/bitcoin/pull/9659 - Net: Turn some methods and params/variables const
https://github.com/bitcoin/bitcoin/pull/9671 - Fix super-unlikely race introduced in 236618061a445d2cb11e72

https://github.com/bitcoin/bitcoin/pull/9609: net: fix remaining net assertions

All changes that originated in `net_process.cpp` had to be manually applied to `main.cpp`