### PR TITLE
Replace stealth-mode with custom user agent

### DIFF
--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -129,8 +129,8 @@ std::string FormatFullVersion()
     return CLIENT_BUILD;
 }
 
-/** 
- * Format the subversion field according to BIP 14 spec (https://github.com/bitcoin/bips/blob/master/bip-0014.mediawiki) 
+/**
+ * Format the subversion field according to BIP 14 spec (https://github.com/bitcoin/bips/blob/master/bip-0014.mediawiki)
  */
 std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments, const char *releaseCharacter)
 {
@@ -154,10 +154,11 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const 
  */
 std::string XTSubVersion(uint64_t nMaxBlockSize)
 {
-    std::vector<std::string> comments = Opt().UAComment();
+    std::string customUserAgent = Opt().UserAgent();
+    if (!customUserAgent.empty())
+        return customUserAgent;
 
-    if (Opt().IsStealthMode())
-        return FormatSubVersion("Satoshi", CLIENT_VERSION, comments, "");
+    std::vector<std::string> comments = Opt().UAComment();
 
     if (!Opt().HidePlatform()) {
         std::vector<std::string> p = GetPlatformDetails();
@@ -171,4 +172,16 @@ std::string XTSubVersion(uint64_t nMaxBlockSize)
     comments.insert(end(comments), ss.str());
 
     return FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, comments, CLIENT_VERSION_XT_SUBVER);
+}
+
+void ValidateUAComments(const std::vector<std::string>& comments) {
+    for (auto& c : comments) {
+        size_t pos = c.find_first_of("/:()");
+        if (pos == std::string::npos)
+            continue;
+        std::stringstream ss;
+        ss << "User agent comment '" << c << "' uses a reserved character."
+           << "Characters reserved: / : ( )";
+        throw std::invalid_argument(ss.str());
+    }
 }

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -67,6 +67,8 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const 
 
 std::string XTSubVersion(uint64_t nMaxBlockSize);
 
+void ValidateUAComments(const std::vector<std::string>& uacomments);
+
 #endif // WINDRES_PREPROC
 
 #endif // BITCOIN_CLIENTVERSION_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -365,10 +365,10 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-proxy=<ip:port>", _("Connect through SOCKS5 proxy"));
     strUsage += HelpMessageOpt("-proxyrandomize", strprintf(_("Randomize credentials for every proxy connection. This enables Tor stream isolation (default: %u)"), 1));
     strUsage += HelpMessageOpt("-seednode=<ip>", _("Connect to a node to retrieve peer addresses, and disconnect"));
-    strUsage += HelpMessageOpt("-stealth-mode", _("Make this node act like a Bitcoin Core node from the wire perspective"));
     strUsage += HelpMessageOpt("-timeout=<n>", strprintf(_("Specify connection timeout in milliseconds (minimum: 1, default: %d)"), DEFAULT_CONNECT_TIMEOUT));
     strUsage += HelpMessageOpt("-uacomment", _("Add a comment into the user agent visible to other nodes"));
     strUsage += HelpMessageOpt("-use-thin-blocks", _("Use thin blocks (low bandwidth block relay). (enable: 1, avoid full blocks: 2)"));
+    strUsage += HelpMessageOpt("-useragent", _("Set a custom user agent. This overrides all other user agent options. See BIP14 for format."));
 #ifdef USE_UPNP
 #if USE_UPNP
     strUsage += HelpMessageOpt("-upnp", _("Use UPnP to map the listening port (default: 1 when listening)"));
@@ -1133,7 +1133,10 @@ bool AppInit2()
 
     RegisterNodeSignals(GetNodeSignals());
 
-    try { Opt().UAComment(true /* validate */); }
+    try {
+        Opt().UAComment(true /* validate */);
+        Opt().CheckRemovedOptions();
+    }
     catch (const std::invalid_argument& e) {
         return InitError(e.what());
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4779,7 +4779,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv,
             // Ignore duplicate advertisements for the same item from the same peer. This check
             // prevents a peer from constantly promising to deliver an item that it never does,
             // thus blinding us to new transactions and blocks.
-            if (!Opt().IsStealthMode() && !pfrom->AddInventoryKnown(inv) && !pfrom->fWhitelisted) {
+            if (!pfrom->AddInventoryKnown(inv) && !pfrom->fWhitelisted) {
                 LogPrint(Log::NET, "ignoring inv: %s peer=%d\n", inv.ToString(), pfrom->id);
                 continue;
             }
@@ -4959,9 +4959,6 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv,
     }
     else if (strCommand == "getutxos")
     {
-        if (Opt().IsStealthMode())
-            return true;
-
         bool fCheckMemPool;
         std::vector<COutPoint> vOutPoints;
         vRecv >> fCheckMemPool;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -434,19 +434,9 @@ void CNode::PushVersion()
     else
         LogPrint(Log::NET, "send version message: version %d, blocks=%d, us=%s, peer=%d\n", PROTOCOL_VERSION, nMyStartingHeight, addrMe.ToString(), id);
 
-    // Stealth mode: pretend to be like Bitcoin Core to hide from DoS attackers.
-    if (Opt().IsStealthMode()) {
-        uint64_t services = 0;
-        if (nLocalServices & NODE_NETWORK)
-            services = NODE_NETWORK;
-
-        PushMessage("version", 70002, services, nTime, addrYou, addrMe,
-                nLocalHostNonce, XTSubVersion(0), nMyStartingHeight, true);
-    } else {
-        int nMaxBlockSize = g_signals.GetMaxBlockSizeInsecure().get_value_or(0);
-        PushMessage("version", PROTOCOL_VERSION, nLocalServices, nTime, addrYou, addrMe,
-                nLocalHostNonce, XTSubVersion(nMaxBlockSize), nMyStartingHeight, true);
-    }
+    int nMaxBlockSize = g_signals.GetMaxBlockSizeInsecure().get_value_or(0);
+    PushMessage("version", PROTOCOL_VERSION, nLocalServices, nTime, addrYou, addrMe,
+            nLocalHostNonce, XTSubVersion(nMaxBlockSize), nMyStartingHeight, true);
 }
 
 

--- a/src/options.h
+++ b/src/options.h
@@ -8,12 +8,14 @@
 #include <vector>
 
 class Opt {
-    public:
-        Opt();
+public:
+    Opt();
 
-        bool IsStealthMode();
-        bool HidePlatform();
-        std::vector<std::string> UAComment(bool validate = false);
+    // User agent options
+    std::string UserAgent() const;
+    bool HidePlatform();
+    std::vector<std::string> UAComment(bool validate = false) const;
+
         int ScriptCheckThreads();
         int64_t CheckpointDays();
         uint64_t MaxBlockSizeVote();
@@ -28,6 +30,9 @@ class Opt {
         bool AvoidFullBlocks();
         int ThinBlocksMaxParallel();
         bool PreferXThinBlocks() const;
+
+    //! Throws invalid argument on use of options that are no longer supported.
+    void CheckRemovedOptions() const;
 };
 
 /** Maximum number of script-checking threads allowed */
@@ -51,6 +56,8 @@ class ArgGetter {
         virtual bool GetBool(const std::string& arg, bool def) = 0;
         virtual std::vector<std::string> GetMultiArgs(const std::string& arg) = 0;
         virtual int64_t GetArg(const std::string& arg, int64_t def) = 0;
+        virtual std::string GetArg(const std::string& arg,
+                                   const std::string& def) = 0;
 };
 inline ArgGetter::~ArgGetter() { }
 
@@ -72,11 +79,13 @@ class DummyArgGetter : public ArgGetter {
         bool GetBool(const std::string& arg, bool def) override;
         std::vector<std::string> GetMultiArgs(const std::string& arg) override;
         int64_t GetArg(const std::string& str, int64_t def) override;
+        std::string GetArg(const std::string& str, const std::string& def) override;
 
         void Set(const std::string& arg, int64_t val);
+        void Set(const std::string& arg, const std::string& val);
 
     private:
-        std::map<std::string, int64_t> customArgs;
+        std::map<std::string, std::string> customArgs;
 };
 
 #endif

--- a/src/respend/respenddetector.cpp
+++ b/src/respend/respenddetector.cpp
@@ -22,7 +22,7 @@ std::mutex RespendDetector::respentBeforeMutex;
 std::vector<RespendActionPtr> CreateDefaultActions(CConnman* connman) {
     std::vector<RespendActionPtr> actions;
 
-    if (connman && !Opt().IsStealthMode()) {
+    if (connman) {
         actions.push_back(RespendActionPtr(new RespendRelayer{connman}));
     }
     if (LogAcceptCategory(Log::RESPEND)) {


### PR DESCRIPTION
This removes stealth mode and replaces it with the option to set a custom user agent.

If we want to enable full stealth mode again, we can implement the options to disable specific features to more closely mimic a client (for example `-useragent="/BUCash:1.3.0.1/" -disablecompactblocks -disablebip64` etc.).

Closes #443 