### PR TITLE
Default to virtual cores and set appropriate thread scheduler

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -591,6 +591,7 @@ void CleanupBlockRevFiles()
 void ThreadImport(std::vector<boost::filesystem::path> vImportFiles)
 {
     RenameThread("bitcoin-loadblk");
+    ScheduleBatchPriority();
     CImportingNow imp;
 
     // -reindex

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -40,6 +40,7 @@
 
 #include <algorithm>
 #include <fcntl.h>
+#include <sched.h>
 #include <sys/resource.h>
 #include <sys/stat.h>
 
@@ -853,4 +854,18 @@ void SetThreadPriority(int nPriority)
 int GetNumCores()
 {
     return std::thread::hardware_concurrency();
+}
+
+int ScheduleBatchPriority(void)
+{
+#ifdef SCHED_BATCH
+    const static sched_param param{.sched_priority = 0};
+    if (int ret = pthread_setschedparam(0, SCHED_BATCH, &param)) {
+        LogPrintf("Failed to pthread_setschedparam: %s\n", strerror(errno));
+        return ret;
+    }
+    return 0;
+#else
+    return 1;
+#endif
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -859,7 +859,7 @@ int GetNumCores()
 int ScheduleBatchPriority(void)
 {
 #ifdef SCHED_BATCH
-    const static sched_param param{.sched_priority = 0};
+    const static sched_param param{0};
     if (int ret = pthread_setschedparam(pthread_self(), SCHED_BATCH, &param)) {
         LogPrintf("Failed to pthread_setschedparam: %s\n", strerror(errno));
         return ret;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -860,7 +860,7 @@ int ScheduleBatchPriority(void)
 {
 #ifdef SCHED_BATCH
     const static sched_param param{.sched_priority = 0};
-    if (int ret = pthread_setschedparam(0, SCHED_BATCH, &param)) {
+    if (int ret = pthread_setschedparam(pthread_self(), SCHED_BATCH, &param)) {
         LogPrintf("Failed to pthread_setschedparam: %s\n", strerror(errno));
         return ret;
     }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -87,6 +87,7 @@
 #include <openssl/crypto.h>
 #include <openssl/rand.h>
 #include <openssl/conf.h>
+#include <thread>
 
 // Work around clang compilation problem in Boost 1.46:
 // /usr/include/boost/program_options/detail/config_file.hpp:163:17: error: call to function 'to_internal' that is neither visible in the template definition nor found by argument-dependent lookup
@@ -851,9 +852,5 @@ void SetThreadPriority(int nPriority)
 
 int GetNumCores()
 {
-#if BOOST_VERSION >= 105600
-    return boost::thread::physical_concurrency();
-#else // Must fall back to hardware_concurrency, which unfortunately counts virtual cores
-    return boost::thread::hardware_concurrency();
-#endif
+    return std::thread::hardware_concurrency();
 }

--- a/src/util.h
+++ b/src/util.h
@@ -268,4 +268,13 @@ template <typename Callable> void TraceThread(const char* name,  Callable func)
     }
 }
 
+/**
+ * On platforms that support it, tell the kernel the calling thread is
+ * CPU-intensive and non-interactive. See SCHED_BATCH in sched(7) for details.
+ *
+ * @return The return value of sched_setschedule(), or 1 on systems without
+ * sched_setchedule().
+ */
+int ScheduleBatchPriority(void);
+
 #endif // BITCOIN_UTIL_H

--- a/src/util.h
+++ b/src/util.h
@@ -232,9 +232,8 @@ std::string HelpMessageGroup(const std::string& message);
 std::string HelpMessageOpt(const std::string& option, const std::string& message);
 
 /**
- * Return the number of physical cores available on the current system.
- * @note This does not count virtual cores, such as those provided by HyperThreading
- * when boost is newer than 1.56.
+ * Return the number of cores available on the current system.
+ * @note This does count virtual cores, such as those provided by HyperThreading.
  */
 int GetNumCores();
 


### PR DESCRIPTION
This bumps number of scriptcheck threads to # virtual cores, without re-introducing the issue that using physical core count fixed (see https://github.com/bitcoin/bitcoin/pull/6361).

This should give nice speedup to #442, which reuses the `-par` parameter.

No merge conflicts.
https://github.com/bitcoin/bitcoin/pull/10271 - Use std::thread::hardware_concurrency, instead of Boost, to determine available cores
https://github.com/bitcoin/bitcoin/pull/12618 - Set SCHED_BATCH priority on the loadblk thread.
https://github.com/bitcoin/bitcoin/pull/12923 - util: Pass pthread_self() to pthread_setschedparam instead of 0