### PR TITLE
Easy to use gitian building script

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -40,12 +40,15 @@ for Debian-based Linux systems. If you compile bitcoind/bitcoin-qt yourself, the
 Gavin's notes on getting gitian builds up and running using KVM.
 
 ### [Gitian-downloader](/contrib/gitian-downloader)
-Various PGP files of core developers. 
+Various PGP files of core developers.
 
 ### [MacDeploy](/contrib/macdeploy) ###
-Scripts and notes for Mac builds. 
+Scripts and notes for Mac builds.
 
-Test and Verify Tools 
+### [Gitian-build](/contrib/gitian-build.sh) ###
+Script for running full gitian builds.
+
+Test and Verify Tools
 ---------------------
 
 ### [TestGen](/contrib/testgen) ###

--- a/contrib/gitian-build.sh
+++ b/contrib/gitian-build.sh
@@ -166,6 +166,13 @@ then
     sudo ifconfig lxcbr0 up 10.0.2.2
 fi
 
+# Check for OSX SDK
+if [[ ! -e "gitian-builder/inputs/MacOSX10.11.sdk.tar.gz" && $osx == true ]]
+then
+    echo "Cannot build for OSX, SDK does not exist. Will build for other OSes"
+    osx=false
+fi
+
 # Get signer
 if [[ -n"$1" ]]
 then

--- a/contrib/gitian-build.sh
+++ b/contrib/gitian-build.sh
@@ -73,7 +73,7 @@ while :; do
         -S|--signer)
 	    if [ -n "$2" ]
 	    then
-		SIGNER=$2
+		SIGNER="$2"
 		shift
 	    else
 		echo 'Error: "--signer" requires a non-empty argument.'
@@ -186,7 +186,7 @@ fi
 # Get signer
 if [[ -n "$1" ]]
 then
-    SIGNER=$1
+    SIGNER="$1"
     shift
 fi
 
@@ -199,7 +199,7 @@ then
 fi
 
 # Check that a signer is specified
-if [[ $SIGNER == "" ]]
+if [[ "$SIGNER" == "" ]]
 then
     echo "$scriptName: Missing signer."
     echo "Try $scriptName --help for more information"
@@ -268,7 +268,7 @@ then
 	    echo "Compiling ${VERSION} Linux"
 	    echo ""
 	    ./bin/gbuild -j ${proc} -m ${mem} --commit bitcoin=${COMMIT} --url bitcoin=${url} ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
-	    ./bin/gsign -p $signProg --signer $SIGNER --release ${VERSION}-linux --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
+	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}-linux --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
 	    mv build/out/bitcoin-*.tar.gz build/out/src/bitcoin-*.tar.gz ../bitcoin-binaries/${VERSION}
 	fi
 	# Windows
@@ -278,7 +278,7 @@ then
 	    echo "Compiling ${VERSION} Windows"
 	    echo ""
 	    ./bin/gbuild -j ${proc} -m ${mem} --commit bitcoin=${COMMIT} --url bitcoin=${url} ../bitcoin/contrib/gitian-descriptors/gitian-win.yml
-	    ./bin/gsign -p $signProg --signer $SIGNER --release ${VERSION}-win-unsigned --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-win.yml
+	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}-win-unsigned --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-win.yml
 	    mv build/out/bitcoin-*-win-unsigned.tar.gz inputs/bitcoin-win-unsigned.tar.gz
 	    mv build/out/bitcoin-*.zip build/out/bitcoin-*.exe ../bitcoin-binaries/${VERSION}
 	fi
@@ -289,7 +289,7 @@ then
 	    echo "Compiling ${VERSION} Mac OSX"
 	    echo ""
 	    ./bin/gbuild -j ${proc} -m ${mem} --commit bitcoin=${COMMIT} --url bitcoin=${url} ../bitcoin/contrib/gitian-descriptors/gitian-osx.yml
-	    ./bin/gsign -p $signProg --signer $SIGNER --release ${VERSION}-osx-unsigned --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-osx.yml
+	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}-osx-unsigned --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-osx.yml
 	    mv build/out/bitcoin-*-osx-unsigned.tar.gz inputs/bitcoin-osx-unsigned.tar.gz
 	    mv build/out/bitcoin-*.tar.gz build/out/bitcoin-*.dmg ../bitcoin-binaries/${VERSION}
 	fi
@@ -302,9 +302,9 @@ then
             echo "Committing ${VERSION} Unsigned Sigs"
             echo ""
             pushd gitian.sigs
-            git add ${VERSION}-linux/${SIGNER}
-            git add ${VERSION}-win-unsigned/${SIGNER}
-            git add ${VERSION}-osx-unsigned/${SIGNER}
+            git add ${VERSION}-linux/"${SIGNER}"
+            git add ${VERSION}-win-unsigned/"${SIGNER}"
+            git add ${VERSION}-osx-unsigned/"${SIGNER}"
             git commit -a -m "Add ${VERSION} unsigned sigs for ${SIGNER}"
             popd
         fi
@@ -354,7 +354,7 @@ then
 	    echo "Signing ${VERSION} Windows"
 	    echo ""
 	    ./bin/gbuild -i --commit signature=${COMMIT} ../bitcoin/contrib/gitian-descriptors/gitian-win-signer.yml
-	    ./bin/gsign -p $signProg --signer $SIGNER --release ${VERSION}-win-signed --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-win-signer.yml
+	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}-win-signed --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-win-signer.yml
 	    mv build/out/bitcoin-*win64-setup.exe ../bitcoin-binaries/${VERSION}
 	    mv build/out/bitcoin-*win32-setup.exe ../bitcoin-binaries/${VERSION}
 	fi
@@ -365,7 +365,7 @@ then
 	    echo "Signing ${VERSION} Mac OSX"
 	    echo ""
 	    ./bin/gbuild -i --commit signature=${COMMIT} ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml
-	    ./bin/gsign -p $signProg --signer $SIGNER --release ${VERSION}-osx-signed --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml
+	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}-osx-signed --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml
 	    mv build/out/bitcoin-osx-signed.dmg ../bitcoin-binaries/${VERSION}/bitcoin-${VERSION}-osx.dmg
 	fi
 	popd
@@ -377,8 +377,8 @@ then
             echo ""
             echo "Committing ${VERSION} Signed Sigs"
             echo ""
-            git add ${VERSION}-win-signed/${SIGNER}
-            git add ${VERSION}-osx-signed/${SIGNER}
+            git add ${VERSION}-win-signed/"${SIGNER}"
+            git add ${VERSION}-osx-signed/"${SIGNER}"
             git commit -a -m "Add ${VERSION} signed binary sigs for ${SIGNER}"
             popd
         fi

--- a/contrib/gitian-build.sh
+++ b/contrib/gitian-build.sh
@@ -184,7 +184,7 @@ then
 fi
 
 # Get signer
-if [[ -n"$1" ]]
+if [[ -n "$1" ]]
 then
     SIGNER=$1
     shift

--- a/contrib/gitian-build.sh
+++ b/contrib/gitian-build.sh
@@ -43,7 +43,7 @@ Options:
 -j		Number of processes to use. Default 2
 -m		Memory to allocate in MiB. Default 2000
 --kvm           Use KVM instead of LXC
---setup         Setup the gitian building environment. Uses KVM. If you want to use lxc, use the --lxc option. Only works on Debian-based systems (Ubuntu, Debian)
+--setup         Set up the Gitian building environment. Uses LXC. If you want to use KVM, use the --kvm option. Only works on Debian-based systems (Ubuntu, Debian)
 --detach-sign   Create the assert file for detached signing. Will not commit anything.
 --no-commit     Do not commit anything to git
 -h|--help	Print this help message

--- a/contrib/gitian-build.sh
+++ b/contrib/gitian-build.sh
@@ -13,9 +13,9 @@ osx=true
 SIGNER=
 VERSION=
 commit=false
-url=https://github.com/bitcoin/bitcoin
-proc=4
-mem=4000
+url=https://github.com/bitcoinxt/bitcoinxt
+proc=2
+mem=2000
 lxc=true
 osslTarUrl=http://downloads.sourceforge.net/project/osslsigncode/osslsigncode/osslsigncode-1.7.1.tar.gz
 osslPatchUrl=https://bitcoincore.org/cfields/osslsigncode-Backports-to-1.7.1.patch
@@ -41,7 +41,7 @@ Options:
 -s|--sign	Make signed binaries for Windows and Mac OSX
 -B|--buildsign	Build both signed and unsigned binaries
 -o|--os		Specify which Operating Systems the build is for. Default is lwx. l for linux, w for windows, x for osx
--j		Number of processes to use. Default 4
+-j		Number of processes to use. Default 2
 -m		Memory to allocate in MiB. Default 2000
 --kvm           Use KVM instead of LXC
 --setup         Setup the gitian building environment. Uses KVM. If you want to use lxc, use the --lxc option. Only works on Debian-based systems (Ubuntu, Debian)

--- a/contrib/gitian-build.sh
+++ b/contrib/gitian-build.sh
@@ -8,7 +8,7 @@ build=false
 # Systems to build
 linux=true
 windows=true
-osx=true
+osx=false
 
 # Other Basic variables
 SIGNER=
@@ -19,7 +19,7 @@ proc=2
 mem=2000
 lxc=true
 osslTarUrl=http://downloads.sourceforge.net/project/osslsigncode/osslsigncode/osslsigncode-1.7.1.tar.gz
-osslPatchUrl=https://bitcoincore.org/cfields/osslsigncode-Backports-to-1.7.1.patch
+osslPatchUrl=https://bitcoinxt.software/buildassist/osslsigncode-Backports-to-1.7.1.patch
 scriptName=$(basename -- "$0")
 signProg="gpg --detach-sign"
 commitFiles=true
@@ -28,7 +28,7 @@ commitFiles=true
 read -d '' usage <<- EOF
 Usage: $scriptName [-c|u|v|b|s|B|o|h|j|m|] signer version
 
-Run this script from the directory containing the bitcoin, gitian-builder, gitian.sigs, and bitcoin-detached-sigs.
+Run this script from the directory containing the bitcoinxt, gitian-builder, gitian.sigs, and bitcoin-detached-sigs.
 
 Arguments:
 signer          GPG signer to sign each build assert file
@@ -36,7 +36,7 @@ version		Version number, commit, or branch to build. If building a commit or bra
 
 Options:
 -c|--commit	Indicate that the version argument is for a commit or branch
--u|--url	Specify the URL of the repository. Default is https://github.com/bitcoin/bitcoin
+-u|--url	Specify the URL of the repository. Default is https://github.com/bitcoinxt/bitcoinxt
 -v|--verify 	Verify the gitian build
 -b|--build	Do a gitiain build
 -s|--sign	Make signed binaries for Windows and Mac OSX
@@ -227,8 +227,8 @@ echo ${COMMIT}
 if [[ $setup = true ]]
 then
     sudo apt-get install ruby apache2 git apt-cacher-ng python-vm-builder qemu-kvm qemu-utils
-    git clone https://github.com/bitcoin-core/gitian.sigs.git
-    git clone https://github.com/bitcoin-core/bitcoin-detached-sigs.git
+    git clone https://github.com/bitcoinxt/gitian.sigs.git
+    git clone https://github.com/bitcoinxt/bitcoin-detached-sigs.git
     git clone https://github.com/devrandom/gitian-builder.git
     pushd ./gitian-builder
     if [[ -n "$USE_LXC" ]]
@@ -242,7 +242,7 @@ then
 fi
 
 # Set up build
-pushd ./bitcoin
+pushd ./bitcoinxt
 git fetch
 git checkout ${COMMIT}
 popd
@@ -261,7 +261,7 @@ then
 	mkdir -p inputs
 	wget -N -P inputs $osslPatchUrl
 	wget -N -P inputs $osslTarUrl
-	make -C ../bitcoin/depends download SOURCES_PATH=`pwd`/cache/common
+	make -C ../bitcoinxt/depends download SOURCES_PATH=`pwd`/cache/common
 
 	# Linux
 	if [[ $linux = true ]]
@@ -269,8 +269,8 @@ then
             echo ""
 	    echo "Compiling ${VERSION} Linux"
 	    echo ""
-	    ./bin/gbuild -j ${proc} -m ${mem} --commit bitcoin=${COMMIT} --url bitcoin=${url} ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
-	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}-linux --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
+	    ./bin/gbuild -j ${proc} -m ${mem} --commit bitcoin=${COMMIT} --url bitcoin=${url} ../bitcoinxt/contrib/gitian-descriptors/gitian-linux.yml
+	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}-linux --destination ../gitian.sigs/ ../bitcoinxt/contrib/gitian-descriptors/gitian-linux.yml
 	    mv build/out/bitcoin-*.tar.gz build/out/src/bitcoin-*.tar.gz ../bitcoin-binaries/${VERSION}
 	fi
 	# Windows
@@ -279,8 +279,8 @@ then
 	    echo ""
 	    echo "Compiling ${VERSION} Windows"
 	    echo ""
-	    ./bin/gbuild -j ${proc} -m ${mem} --commit bitcoin=${COMMIT} --url bitcoin=${url} ../bitcoin/contrib/gitian-descriptors/gitian-win.yml
-	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}-win-unsigned --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-win.yml
+	    ./bin/gbuild -j ${proc} -m ${mem} --commit bitcoin=${COMMIT} --url bitcoin=${url} ../bitcoinxt/contrib/gitian-descriptors/gitian-win.yml
+	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}-win-unsigned --destination ../gitian.sigs/ ../bitcoinxt/contrib/gitian-descriptors/gitian-win.yml
 	    mv build/out/bitcoin-*-win-unsigned.tar.gz inputs/bitcoin-win-unsigned.tar.gz
 	    mv build/out/bitcoin-*.zip build/out/bitcoin-*.exe ../bitcoin-binaries/${VERSION}
 	fi
@@ -290,8 +290,8 @@ then
 	    echo ""
 	    echo "Compiling ${VERSION} Mac OSX"
 	    echo ""
-	    ./bin/gbuild -j ${proc} -m ${mem} --commit bitcoin=${COMMIT} --url bitcoin=${url} ../bitcoin/contrib/gitian-descriptors/gitian-osx.yml
-	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}-osx-unsigned --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-osx.yml
+	    ./bin/gbuild -j ${proc} -m ${mem} --commit bitcoin=${COMMIT} --url bitcoin=${url} ../bitcoinxt/contrib/gitian-descriptors/gitian-osx.yml
+	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}-osx-unsigned --destination ../gitian.sigs/ ../bitcoinxt/contrib/gitian-descriptors/gitian-osx.yml
 	    mv build/out/bitcoin-*-osx-unsigned.tar.gz inputs/bitcoin-osx-unsigned.tar.gz
 	    mv build/out/bitcoin-*.tar.gz build/out/bitcoin-*.dmg ../bitcoin-binaries/${VERSION}
 	fi
@@ -320,27 +320,27 @@ then
 	echo ""
 	echo "Verifying v${VERSION} Linux"
 	echo ""
-	./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-linux ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
+	./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-linux ../bitcoinxt/contrib/gitian-descriptors/gitian-linux.yml
 	# Windows
 	echo ""
 	echo "Verifying v${VERSION} Windows"
 	echo ""
-	./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-win-unsigned ../bitcoin/contrib/gitian-descriptors/gitian-win.yml
+	./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-win-unsigned ../bitcoinxt/contrib/gitian-descriptors/gitian-win.yml
 	# Mac OSX
 	echo ""
 	echo "Verifying v${VERSION} Mac OSX"
 	echo ""
-	./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-osx-unsigned ../bitcoin/contrib/gitian-descriptors/gitian-osx.yml
+	./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-osx-unsigned ../bitcoinxt/contrib/gitian-descriptors/gitian-osx.yml
 	# Signed Windows
 	echo ""
 	echo "Verifying v${VERSION} Signed Windows"
 	echo ""
-	./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-osx-signed ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml
+	./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-osx-signed ../bitcoinxt/contrib/gitian-descriptors/gitian-osx-signer.yml
 	# Signed Mac OSX
 	echo ""
 	echo "Verifying v${VERSION} Signed Mac OSX"
 	echo ""
-	./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-osx-signed ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml
+	./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-osx-signed ../bitcoinxt/contrib/gitian-descriptors/gitian-osx-signer.yml
 	popd
 fi
 
@@ -355,8 +355,8 @@ then
 	    echo ""
 	    echo "Signing ${VERSION} Windows"
 	    echo ""
-	    ./bin/gbuild -i --commit signature=${COMMIT} ../bitcoin/contrib/gitian-descriptors/gitian-win-signer.yml
-	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}-win-signed --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-win-signer.yml
+	    ./bin/gbuild -i --commit signature=${COMMIT} ../bitcoinxt/contrib/gitian-descriptors/gitian-win-signer.yml
+	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}-win-signed --destination ../gitian.sigs/ ../bitcoinxt/contrib/gitian-descriptors/gitian-win-signer.yml
 	    mv build/out/bitcoin-*win64-setup.exe ../bitcoin-binaries/${VERSION}
 	    mv build/out/bitcoin-*win32-setup.exe ../bitcoin-binaries/${VERSION}
 	fi
@@ -366,8 +366,8 @@ then
 	    echo ""
 	    echo "Signing ${VERSION} Mac OSX"
 	    echo ""
-	    ./bin/gbuild -i --commit signature=${COMMIT} ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml
-	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}-osx-signed --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml
+	    ./bin/gbuild -i --commit signature=${COMMIT} ../bitcoinxt/contrib/gitian-descriptors/gitian-osx-signer.yml
+	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}-osx-signed --destination ../gitian.sigs/ ../bitcoinxt/contrib/gitian-descriptors/gitian-osx-signer.yml
 	    mv build/out/bitcoin-osx-signed.dmg ../bitcoin-binaries/${VERSION}/bitcoin-${VERSION}-osx.dmg
 	fi
 	popd

--- a/contrib/gitian-build.sh
+++ b/contrib/gitian-build.sh
@@ -1,0 +1,362 @@
+# What to do
+sign=false
+verify=false
+build=false
+setupenv=false
+
+# Systems to build
+linux=true
+windows=true
+osx=true
+
+# Other Basic variables
+SIGNER=
+VERSION=
+commit=false
+url=https://github.com/bitcoin/bitcoin
+proc=4
+mem=4000
+lxc=true
+osslTarUrl=http://downloads.sourceforge.net/project/osslsigncode/osslsigncode/osslsigncode-1.7.1.tar.gz
+osslPatchUrl=https://bitcoincore.org/cfields/osslsigncode-Backports-to-1.7.1.patch
+scriptName=$(basename -- "$0")
+
+# Help Message
+read -d '' usage <<- EOF
+Usage: $scriptName [-c|u|v|b|s|B|o|h|j|m|] signer version
+
+Run this script from the directory containing the bitcoin, gitian-builder, gitian.sigs, and bitcoin-detached-sigs.
+
+Arguments:
+signer          GPG signer to sign each build assert file
+version		Version number, commit, or branch to build. If building a commit or branch, the -c option must be specified
+
+Options:
+-c|--commit	Indicate that the version argument is for a commit or branch
+-u|--url	Specify the URL of the repository. Default is https://github.com/bitcoin/bitcoin
+-v|--verify 	Verify the gitian build
+-b|--build	Do a gitiain build
+-s|--sign	Make signed binaries for Windows and Mac OSX
+-B|--buildsign	Build both signed and unsigned binaries
+-o|--os		Specify which Operating Systems the build is for. Default is lwx. l for linux, w for windows, x for osx
+-j		Number of processes to use. Default 4
+-m		Memory to allocate in MiB. Default 2000
+--kvm           Use KVM instead of LXC
+--setup         Setup the gitian building environment. Uses KVM. If you want to use lxc, use the --lxc option. Only works on Debian-based systems (Ubuntu, Debian)
+-h|--help	Print this help message
+EOF
+
+# Get options and arguments
+while :; do
+    case $1 in
+        # Verify
+        -v|--verify)
+	    verify=true
+            ;;
+        # Build
+        -b|--build)
+	    build=true
+            ;;
+        # Sign binaries
+        -s|--sign)
+	    sign=true
+            ;;
+        # Build then Sign
+        -B|--buildsign)
+	    sign=true
+	    build=true
+            ;;
+        # PGP Signer
+        -S|--signer)
+	    if [ -n "$2" ]
+	    then
+		SIGNER=$2
+		shift
+	    else
+		echo 'Error: "--signer" requires a non-empty argument.'
+		exit 1
+	    fi
+           ;;
+        # Operating Systems
+        -o|--os)
+	    if [ -n "$2" ]
+	    then
+		linux=false
+		windows=false
+		osx=false
+		if [[ "$2" = *"l"* ]]
+		then
+		    linux=true
+		fi
+		if [[ "$2" = *"w"* ]]
+		then
+		    windows=true
+		fi
+		if [[ "$2" = *"x"* ]]
+		then
+		    osx=true
+		fi
+		shift
+	    else
+		echo 'Error: "--os" requires an argument containing an l (for linux), w (for windows), or x (for Mac OSX)\n'
+		exit 1
+	    fi
+	    ;;
+	# Help message
+	-h|--help)
+	    echo "$usage"
+	    exit 0
+	    ;;
+	# Commit or branch
+	-c|--commit)
+	    commit=true
+	    ;;
+	# Number of Processes
+	-j)
+	    if [ -n "$2" ]
+	    then
+		proc=$2
+		shift
+	    else
+		echo 'Error: "-j" requires an argument'
+		exit 1
+	    fi
+	    ;;
+	# Memory to allocate
+	-m)
+	    if [ -n "$2" ]
+	    then
+		mem=$2
+		shift
+	    else
+		echo 'Error: "-m" requires an argument'
+		exit 1
+	    fi
+	    ;;
+	# URL
+	-u)
+	    if [ -n "$2" ]
+	    then
+		url=$2
+		shift
+	    else
+		echo 'Error: "-u" requires an argument'
+		exit 1
+	    fi
+	    ;;
+        # kvm
+        --kvm)
+            lxc=false
+            ;;
+        # Setup
+        --setup)
+            setup=true
+            ;;
+	*)               # Default case: If no more options then break out of the loop.
+             break
+    esac
+    shift
+done
+
+# Set up LXC
+if [[ $lxc = true ]]
+then
+    export USE_LXC=1
+    export LXC_BRIDGE=lxcbr0
+    sudo ifconfig lxcbr0 up 10.0.2.2
+fi
+
+# Get signer
+if [[ -n"$1" ]]
+then
+    SIGNER=$1
+    shift
+fi
+
+# Get version
+if [[ -n "$1" ]]
+then
+    VERSION=$1
+    COMMIT=$VERSION
+    shift
+fi
+
+# Check that a signer is specified
+if [[ $SIGNER == "" ]]
+then
+    echo "$scriptName: Missing signer."
+    echo "Try $scriptName --help for more information"
+    exit 1
+fi
+
+# Check that a version is specified
+if [[ $VERSION == "" ]]
+then
+    echo "$scriptName: Missing version."
+    echo "Try $scriptName --help for more information"
+    exit 1
+fi
+
+# Add a "v" if no -c
+if [[ $commit = false ]]
+then
+	COMMIT="v${VERSION}"
+fi
+echo ${COMMIT}
+
+# Setup build environment
+if [[ $setup = true ]]
+then
+    pushd ./gitian-builder
+    sudo apt-get install ruby apache2 git apt-cacher-ng python-vm-builder qemu-kvm qemu-utils
+    git clone https://github.com/bitcoin-core/gitian.sigs.git
+    git clone https://github.com/bitcoin-core/bitcoin-detached-sigs.git
+    git clone https://github.com/devrandom/gitian-builder.git
+    if [[ -n "$USE_LXC" ]]
+    then
+        sudo apt-get install lxc
+        bin/make-base-vm --suite trusty --arch amd64 --lxc
+    else
+        bin/make-base-vm --suite trusty --arch amd64
+    fi
+    popd
+fi
+
+# Set up build
+pushd ./bitcoin
+git fetch
+git checkout ${COMMIT}
+popd
+
+# Build
+if [[ $build = true ]]
+then
+	# Make output folder
+	mkdir -p ./bitcoin-binaries/${VERSION}
+
+	# Build Dependencies
+	echo ""
+	echo "Building Dependencies"
+	echo ""
+	pushd ./gitian-builder
+	mkdir -p inputs
+	wget -N -P inputs $osslPatchUrl
+	wget -N -P inputs $osslTarUrl
+	make -C ../bitcoin/depends download SOURCES_PATH=`pwd`/cache/common
+
+	# Linux
+	if [[ $linux = true ]]
+	then
+            echo ""
+	    echo "Compiling ${VERSION} Linux"
+	    echo ""
+	    ./bin/gbuild -j ${proc} -m ${mem} --commit bitcoin=${COMMIT} --url bitcoin=${url} ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
+	    ./bin/gsign --signer $SIGNER --release ${VERSION}-linux --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
+	    mv build/out/bitcoin-*.tar.gz build/out/src/bitcoin-*.tar.gz ../bitcoin-binaries/${VERSION}
+	fi
+	# Windows
+	if [[ $windows = true ]]
+	then
+	    echo ""
+	    echo "Compiling ${VERSION} Windows"
+	    echo ""
+	    ./bin/gbuild -j ${proc} -m ${mem} --commit bitcoin=${COMMIT} --url bitcoin=${url} ../bitcoin/contrib/gitian-descriptors/gitian-win.yml
+	    ./bin/gsign --signer $SIGNER --release ${VERSION}-win-unsigned --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-win.yml
+	    mv build/out/bitcoin-*-win-unsigned.tar.gz inputs/bitcoin-win-unsigned.tar.gz
+	    mv build/out/bitcoin-*.zip build/out/bitcoin-*.exe ../bitcoin-binaries/${VERSION}
+	fi
+	# Mac OSX
+	if [[ $osx = true ]]
+	then
+	    echo ""
+	    echo "Compiling ${VERSION} Mac OSX"
+	    echo ""
+	    ./bin/gbuild -j ${proc} -m ${mem} --commit bitcoin=${COMMIT} --url bitcoin=${url} ../bitcoin/contrib/gitian-descriptors/gitian-osx.yml
+	    ./bin/gsign --signer $SIGNER --release ${VERSION}-osx-unsigned --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-osx.yml
+	    mv build/out/bitcoin-*-osx-unsigned.tar.gz inputs/bitcoin-osx-unsigned.tar.gz
+	    mv build/out/bitcoin-*.tar.gz build/out/bitcoin-*.dmg ../bitcoin-binaries/${VERSION}
+	fi
+	popd
+
+	# Commit to gitian.sigs repo
+	echo ""
+	echo "Committing ${VERSION} Unsigned Sigs"
+	echo ""
+	pushd gitian.sigs
+	git add ${VERSION}-linux/${SIGNER}
+	git add ${VERSION}-win-unsigned/${SIGNER}
+	git add ${VERSION}-osx-unsigned/${SIGNER}
+	git commit -a -m "Add ${VERSION} unsigned sigs for ${SIGNER}"
+	popd
+fi
+
+# Verify the build
+if [[ $verify = true ]]
+then
+	# Linux
+	pushd ./gitian-builder
+	echo ""
+	echo "Verifying v${VERSION} Linux"
+	echo ""
+	./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-linux ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
+	# Windows
+	echo ""
+	echo "Verifying v${VERSION} Windows"
+	echo ""
+	./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-win-unsigned ../bitcoin/contrib/gitian-descriptors/gitian-win.yml
+	# Mac OSX
+	echo ""
+	echo "Verifying v${VERSION} Mac OSX"
+	echo ""
+	./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-osx-unsigned ../bitcoin/contrib/gitian-descriptors/gitian-osx.yml
+	# Signed Windows
+	echo ""
+	echo "Verifying v${VERSION} Signed Windows"
+	echo ""
+	./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-osx-signed ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml
+	# Signed Mac OSX
+	echo ""
+	echo "Verifying v${VERSION} Signed Mac OSX"
+	echo ""
+	./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-osx-signed ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml
+	popd
+fi
+
+# Sign binaries
+if [[ $sign = true ]]
+then
+
+        pushd ./gitian-builder
+	# Sign Windows
+	if [[ $windows = true ]]
+	then
+	    echo ""
+	    echo "Signing ${VERSION} Windows"
+	    echo ""
+	    ./bin/gbuild -i --commit signature=${COMMIT} ../bitcoin/contrib/gitian-descriptors/gitian-win-signer.yml
+	    ./bin/gsign --signer $SIGNER --release ${VERSION}-win-signed --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-win-signer.yml
+	    mv build/out/bitcoin-*win64-setup.exe ../bitcoin-binaries/${VERSION}
+	    mv build/out/bitcoin-*win32-setup.exe ../bitcoin-binaries/${VERSION}
+	fi
+	# Sign Mac OSX
+	if [[ $osx = true ]]
+	then
+	    echo ""
+	    echo "Signing ${VERSION} Mac OSX"
+	    echo ""
+	    ./bin/gbuild -i --commit signature=${COMMIT} ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml
+	    ./bin/gsign --signer $SIGNER --release ${VERSION}-osx-signed --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml
+	    mv build/out/bitcoin-osx-signed.dmg ../bitcoin-binaries/${VERSION}/bitcoin-${VERSION}-osx.dmg
+	fi
+	popd
+
+	# Commit Sigs
+	pushd gitian.sigs
+	echo ""
+	echo "Committing ${VERSION} Signed Sigs"
+	echo ""
+	git add ${VERSION}-win-signed/${SIGNER}
+	git add ${VERSION}-osx-signed/${SIGNER}
+	git commit -a -m "Add ${VERSION} signed binary sigs for ${SIGNER}"
+	popd
+fi

--- a/contrib/gitian-build.sh
+++ b/contrib/gitian-build.sh
@@ -2,7 +2,6 @@
 sign=false
 verify=false
 build=false
-setupenv=false
 
 # Systems to build
 linux=true
@@ -102,7 +101,7 @@ while :; do
 		fi
 		shift
 	    else
-		echo 'Error: "--os" requires an argument containing an l (for linux), w (for windows), or x (for Mac OSX)\n'
+		echo 'Error: "--os" requires an argument containing an l (for linux), w (for windows), or x (for Mac OSX)'
 		exit 1
 	    fi
 	    ;;

--- a/contrib/gitian-build.sh
+++ b/contrib/gitian-build.sh
@@ -175,8 +175,6 @@ done
 if [[ $lxc = true ]]
 then
     export USE_LXC=1
-    export LXC_BRIDGE=lxcbr0
-    sudo ifconfig lxcbr0 up 10.0.2.2
 fi
 
 # Check for OSX SDK

--- a/contrib/gitian-build.sh
+++ b/contrib/gitian-build.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # What to do
 sign=false
 verify=false


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/pull/8566 - Easy to use gitian building script
https://github.com/bitcoin/bitcoin/pull/11391 - Remove lxcbr0 lines from gitian-build.sh
f6b3382 (squashed into next commit), b9e79ab and 564a172 from https://github.com/bitcoin/bitcoin/pull/10773/
https://github.com/bitcoin/bitcoin/pull/12394 - gitian-builder.sh: fix --setup doc, since lxc is default
https://github.com/bitcoin/bitcoin/pull/12527 - gitian-build.sh: fix signProg being recognized as two parameters
https://github.com/bitcoin/bitcoin/pull/13320 - Ensure gitian-build.sh uses bash

Tested by building Windows and Linux versions for 0.11I and the sha256sums match.

Documentation for using this is located here: https://github.com/bitcoin-core/docs/blob/master/gitian-building.md