### PR TITLE
Move transaction priority functions into policy

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -139,6 +139,7 @@ BITCOIN_CORE_H = \
   options.h \
   policy/fees.h \
   policy/policy.h \
+  policy/txpriority.h \
   pow.h \
   process_xthinblock.h \
   protocol.h \
@@ -237,6 +238,7 @@ libbitcoin_server_a_SOURCES = \
   options.cpp \
   policy/fees.cpp \
   policy/policy.cpp \
+  policy/txpriority.cpp \
   pow.cpp \
   process_xthinblock.cpp \
   rest.cpp \

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -245,22 +245,6 @@ bool CCoinsViewCache::HaveInputs(const CTransaction& tx) const
     return true;
 }
 
-double CCoinsViewCache::GetPriority(const CTransaction &tx, uint32_t nHeight) const
-{
-    if (tx.IsCoinBase())
-        return 0.0;
-    double dResult = 0.0;
-    BOOST_FOREACH(const CTxIn& txin, tx.vin)
-    {
-        const Coin& coin = AccessCoin(txin.prevout);
-        if (coin.IsSpent()) continue;
-        if (coin.nHeight < nHeight) {
-            dResult += coin.out.nValue * (nHeight - coin.nHeight);
-        }
-    }
-    return tx.ComputePriority(dResult);
-}
-
 // TODO: merge with similar definition in undo.h.
 static const size_t MAX_OUTPUTS_PER_TX =
     MAX_TRANSACTION_SIZE / ::GetSerializeSize(CTxOut(), SER_NETWORK, PROTOCOL_VERSION);

--- a/src/coins.h
+++ b/src/coins.h
@@ -290,9 +290,6 @@ public:
     //! Check whether all prevouts of the transaction are present in the UTXO set represented by this view
     bool HaveInputs(const CTransaction& tx) const;
 
-    //! Return priority of tx at height nHeight
-    double GetPriority(const CTransaction &tx, uint32_t nHeight) const;
-
 private:
     CCoinsMap::iterator FetchCoin(const COutPoint &outpoint) const;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,6 +31,7 @@
 #include "nodestate.h"
 #include "options.h"
 #include "policy/policy.h"
+#include "policy/txpriority.h"
 #include "pow.h"
 #include "process_xthinblock.h"
 #include "respend/respenddetector.h"
@@ -1016,7 +1017,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
                              REJECT_INSUFFICIENTFEE, "insufficient fee");
 
         // Require that free transactions have sufficient priority to be mined in the next block.
-        if (GetBoolArg("-relaypriority", true) && nFees < ::minRelayTxFee.GetFee(nSize) && !AllowFree(view.GetPriority(tx, chainActive.Height() + 1))) {
+        if (GetBoolArg("-relaypriority", true) && nFees < ::minRelayTxFee.GetFee(nSize) && !AllowFree(GetPriority(view, tx, chainActive.Height() + 1))) {
             return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "insufficient priority");
         }
 

--- a/src/policy/txpriority.cpp
+++ b/src/policy/txpriority.cpp
@@ -1,0 +1,50 @@
+#include "policy/txpriority.h"
+#include "primitives/transaction.h"
+#include "coins.h"
+
+// Compute modified tx size for priority calculation
+static size_t CalculateModifiedSize(const CTransaction& tx, size_t nTxSize)
+{
+    // In order to avoid disincentivizing cleaning up the UTXO set we don't count
+    // the constant overhead for each txin and up to 110 bytes of scriptSig (which
+    // is enough to cover a compressed pubkey p2sh redemption) for priority.
+    // Providing any more cleanup incentive than making additional inputs free would
+    // risk encouraging people to create junk outputs to redeem later.
+    for (auto& in : tx.vin)
+    {
+        size_t offset = size_t(41) + std::min(size_t(110), in.scriptSig.size());
+        if (nTxSize > offset)
+            nTxSize -= offset;
+    }
+    return nTxSize;
+}
+
+double ComputePriority(const CTransaction& tx, double dPriorityInputs, size_t nTxSize)
+{
+    nTxSize = CalculateModifiedSize(tx, nTxSize);
+    if (nTxSize == 0) return 0.0;
+
+    return dPriorityInputs / nTxSize;
+}
+
+double GetPriority(const CCoinsViewCache& view, const CTransaction &tx,
+                   uint32_t nHeight, size_t nTxSize)
+{
+    if (tx.IsCoinBase())
+        return 0.0;
+
+    double dResult = 0.0;
+    for (const CTxIn& txin : tx.vin)
+    {
+        const Coin& coin = view.AccessCoin(txin.prevout);
+        if (coin.IsSpent()) continue;
+        if (coin.nHeight < nHeight) {
+            dResult += coin.out.nValue * (nHeight - coin.nHeight);
+        }
+    }
+
+    if (nTxSize == 0)
+        nTxSize = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
+
+    return ComputePriority(tx, dResult, nTxSize);
+}

--- a/src/policy/txpriority.h
+++ b/src/policy/txpriority.h
@@ -1,0 +1,30 @@
+#ifndef BITCOIN_TXPRIORITY_H
+#define BITCOIN_TXPRIORITY_H
+
+#include "amount.h" // COIN
+
+class CCoinsViewCache;
+class CTransaction;
+
+inline double AllowFreeThreshold()
+{
+    return COIN * 144 / 250;
+}
+
+inline bool AllowFree(double dPriority)
+{
+    // Large (in bytes) low-priority (new, small-coin) transactions
+    // need a fee.
+    return dPriority > AllowFreeThreshold();
+}
+
+//! Return priority of tx at height nHeight
+double GetPriority(const CCoinsViewCache& view,
+                   const CTransaction &tx, uint32_t nHeight,
+                   size_t nTxSize = 0);
+
+// Compute priority, given priority of inputs and tx size
+double ComputePriority(const CTransaction& tx, double dPriorityInputs,
+                       size_t nTxSize);
+
+#endif // BITCOIN_PRIORITYTX_H

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -108,32 +108,6 @@ CAmount CTransaction::GetValueOut() const
     return nValueOut;
 }
 
-double CTransaction::ComputePriority(double dPriorityInputs, unsigned int nTxSize) const
-{
-    nTxSize = CalculateModifiedSize(nTxSize);
-    if (nTxSize == 0) return 0.0;
-
-    return dPriorityInputs / nTxSize;
-}
-
-unsigned int CTransaction::CalculateModifiedSize(unsigned int nTxSize) const
-{
-    // In order to avoid disincentivizing cleaning up the UTXO set we don't count
-    // the constant overhead for each txin and up to 110 bytes of scriptSig (which
-    // is enough to cover a compressed pubkey p2sh redemption) for priority.
-    // Providing any more cleanup incentive than making additional inputs free would
-    // risk encouraging people to create junk outputs to redeem later.
-    if (nTxSize == 0)
-        nTxSize = ::GetSerializeSize(*this, SER_NETWORK, PROTOCOL_VERSION);
-    for (std::vector<CTxIn>::const_iterator it(vin.begin()); it != vin.end(); ++it)
-    {
-        unsigned int offset = 41U + std::min(110U, (unsigned int)it->scriptSig.size());
-        if (nTxSize > offset)
-            nTxSize -= offset;
-    }
-    return nTxSize;
-}
-
 std::string CTransaction::ToString() const
 {
     std::string str;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -263,12 +263,6 @@ public:
     // GetValueIn() is a method on CCoinsViewCache, because
     // inputs must be known to compute value in.
 
-    // Compute priority, given priority of inputs and (optionally) tx size
-    double ComputePriority(double dPriorityInputs, unsigned int nTxSize=0) const;
-
-    // Compute modified tx size for priority calculation (optionally given tx size)
-    unsigned int CalculateModifiedSize(unsigned int nTxSize=0) const;
-
     bool IsCoinBase() const
     {
         return (vin.size() == 1 && vin[0].prevout.IsNull());

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -16,6 +16,7 @@
 #include "dstencode.h"
 #include "init.h"
 #include "main.h"
+#include "policy/txpriority.h"
 #include "wallet/wallet.h"
 
 #include <boost/assign/list_of.hpp> // for 'map_list_of()'

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -31,7 +31,6 @@ CTxMemPoolEntry::CTxMemPoolEntry(const CTransaction& _tx, const CAmount& _nFee,
         lockPoints(lp), sigOpCount(_sigOps)
 {
     nTxSize = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
-    nModSize = tx.CalculateModifiedSize(nTxSize);
     nUsageSize = RecursiveDynamicUsage(tx);
 
     nCountWithDescendants = 1;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -22,18 +22,6 @@
 class CAutoFile;
 class CBlockIndex;
 
-inline double AllowFreeThreshold()
-{
-    return COIN * 144 / 250;
-}
-
-inline bool AllowFree(double dPriority)
-{
-    // Large (in bytes) low-priority (new, small-coin) transactions
-    // need a fee.
-    return dPriority > AllowFreeThreshold();
-}
-
 /** Fake height value used in Coin to signify they are only in the memory pool (since 0.8) */
 static const uint32_t MEMPOOL_HEIGHT = 0x7FFFFFFF;
 
@@ -77,7 +65,6 @@ private:
     CTransaction tx;
     CAmount nFee; //! Cached to avoid expensive parent-transaction lookups
     size_t nTxSize; //! ... and avoid recomputing tx size
-    size_t nModSize; //! ... and modified size for priority
     size_t nUsageSize; //! ... and total memory usage
     int64_t nTime; //! Local time when entering the mempool
     unsigned int nHeight; //! Chain height when entering the mempool

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -14,6 +14,7 @@
 #include "net.h"
 #include "options.h"
 #include "policy/policy.h"
+#include "policy/txpriority.h"
 #include "script/script.h"
 #include "script/sign.h"
 #include "timedata.h"
@@ -2104,7 +2105,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                     return false;
                 }
 
-                dPriority = wtxNew.ComputePriority(dPriority, nBytes);
+                dPriority = ComputePriority(wtxNew, dPriority, nBytes);
 
                 // Can we complete this as a free transaction?
                 if (fSendFreeTransactions && nBytes <= MAX_FREE_TRANSACTION_CREATE_SIZE)


### PR DESCRIPTION
Transaction priority is rules for which low fee transactions we're willing to include in the blocks we mine. It's policy.

On top of #457 