### PR TITLE
Refactor tx fee/priority evaluation out of AcceptToMemoryPool

### DIFF
--- a/contrib/debian/manpages/bitcoin-qt.1
+++ b/contrib/debian/manpages/bitcoin-qt.1
@@ -178,8 +178,6 @@ Set minimum block size in bytes (default: 0)
 .TP
 \fB\-blockmaxsize=\fR<n>
 Set maximum block size in bytes (default: 250000)
-.HP
-\fB\-blockprioritysize=\fR<n> Set maximum size of high\-priority/low\-fee transactions in bytes (default: 27000)
 .PP
 Acceptable ciphers (default: TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!AH:!3DES:@STRENGTH)
 .SS "UI options:"

--- a/qa/rpc-tests/bip68-sequence.py
+++ b/qa/rpc-tests/bip68-sequence.py
@@ -38,20 +38,20 @@ class BIP68Test(BitcoinTestFramework):
         # Generate some coins
         self.nodes[0].generate(110)
 
-        print("Running test disable flag")
+        self.log.info("Running test disable flag")
         self.test_disable_flag()
 
-        print("Running test sequence-lock-confirmed-inputs")
+        self.log.print("Running test sequence-lock-confirmed-inputs")
         self.test_sequence_lock_confirmed_inputs()
 
-        print("Running test sequence-lock-unconfirmed-inputs")
+        self.log.print("Running test sequence-lock-unconfirmed-inputs")
         self.test_sequence_lock_unconfirmed_inputs()
 
         # This test needs to change when BIP68 becomes consensus
-        print("Running test BIP68 not consensus")
+        self.log.print("Running test BIP68 not consensus")
         self.test_bip68_not_consensus()
 
-        print("Passed\n")
+        self.log.print("Passed\n")
 
     # Test that BIP68 is not in effect if tx version is 1, or if
     # the first sequence bit is set.

--- a/qa/rpc-tests/mempool-accept-txn.py
+++ b/qa/rpc-tests/mempool-accept-txn.py
@@ -49,7 +49,7 @@ class FullBlockTest(ComparisonTestFramework):
         self.blocks = {}
 
     def setup_network(self):
-        self.extra_args = [['-norelaypriority']]
+        self.extra_args = [['-allowfreetx=0']]
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
                                  self.extra_args,
                                  binary=[self.options.testbinary])
@@ -220,8 +220,9 @@ class FullBlockTest(ComparisonTestFramework):
 
         # P2SH tests
         # Create a p2sh transaction
+        value = out[0].tx.vout[out[0].n].nValue # absurdly high fee
         p2sh_tx = self.create_and_sign_transaction(
-            out[0].tx, out[0].n, 1, p2sh_script)
+            out[0].tx, out[0].n, value, p2sh_script)
 
         # Add the transaction to the block
         block(1)
@@ -254,7 +255,7 @@ class FullBlockTest(ComparisonTestFramework):
         # A transaction with this output script can get into the mempool
         max_p2sh_sigops_txn = spend_p2sh_tx(p2sh_tx, max_p2sh_sigops_mempool)
         max_p2sh_sigops_txn_id = node.sendrawtransaction(
-            ToHex(max_p2sh_sigops_txn))
+            ToHex(max_p2sh_sigops_txn), True)
         assert_equal(set(node.getrawmempool()), {max_p2sh_sigops_txn_id})
 
         # Mine the transaction

--- a/qa/rpc-tests/mempool_packages.py
+++ b/qa/rpc-tests/mempool_packages.py
@@ -23,8 +23,8 @@ class MempoolPackagesTest(BitcoinTestFramework):
 
     def setup_network(self):
         self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-maxorphantx=1000", "-relaypriority=0", "-debug"]))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-maxorphantx=1000", "-relaypriority=0", "-limitancestorcount=5", "-debug"]))
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-maxorphantx=1000", "-allowfreetx=0", "-debug"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-maxorphantx=1000", "-allowfreetx=0", "-limitancestorcount=5", "-debug"]))
         connect_nodes(self.nodes[0], 1)
         self.is_network_split = False
         self.sync_all()

--- a/qa/rpc-tests/mempool_resurrect_test.py
+++ b/qa/rpc-tests/mempool_resurrect_test.py
@@ -23,7 +23,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
 
     def setup_network(self):
         # Just need one node for this test
-        args = ["-checkmempool", "-debug=mempool", "-relaypriority=0"]
+        args = ["-checkmempool", "-debug=mempool", "-allowfreetx=0"]
         self.nodes = []
         self.nodes.append(start_node(0, self.options.tmpdir, args))
         self.is_network_split = False
@@ -40,9 +40,10 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         # Mine a new block
         # ... make sure all the transactions are confirmed again.
 
+        fee = get_relay_fee(self.nodes[0])
         b = [ self.nodes[0].getblockhash(n) for n in range(1, 4) ]
         coinbase_txids = [ self.nodes[0].getblock(h)['tx'][0] for h in b ]
-        spends1_raw = [ create_tx(self.nodes[0], txid, node0_address, 50) for txid in coinbase_txids ]
+        spends1_raw = [ create_tx(self.nodes[0], txid, node0_address, 50 - fee) for txid in coinbase_txids ]
         spends1_id = [ self.nodes[0].sendrawtransaction(tx) for tx in spends1_raw ]
 
         blocks = []

--- a/qa/rpc-tests/mempool_spendcoinbase.py
+++ b/qa/rpc-tests/mempool_spendcoinbase.py
@@ -28,7 +28,7 @@ class MempoolSpendCoinbaseTest(BitcoinTestFramework):
 
     def setup_network(self):
         # Just need one node for this test
-        args = ["-checkmempool", "-debug=mempool", "-relaypriority=0"]
+        args = ["-checkmempool", "-debug=mempool", "-allowfreetx=0"]
         self.nodes = []
         self.nodes.append(start_node(0, self.options.tmpdir, args))
         self.is_network_split = False
@@ -41,9 +41,10 @@ class MempoolSpendCoinbaseTest(BitcoinTestFramework):
         # Coinbase at height chain_height-100+1 ok in mempool, should
         # get mined. Coinbase at height chain_height-100+2 is
         # is too immature to spend.
+        fee = get_relay_fee(self.nodes[0])
         b = [ self.nodes[0].getblockhash(n) for n in range(101, 103) ]
         coinbase_txids = [ self.nodes[0].getblock(h)['tx'][0] for h in b ]
-        spends_raw = [ create_tx(self.nodes[0], txid, node0_address, 50) for txid in coinbase_txids ]
+        spends_raw = [ create_tx(self.nodes[0], txid, node0_address, 50 - fee) for txid in coinbase_txids ]
 
         spend_101_id = self.nodes[0].sendrawtransaction(spends_raw[0])
 

--- a/qa/rpc-tests/smartfees.py
+++ b/qa/rpc-tests/smartfees.py
@@ -151,7 +151,7 @@ class EstimateFeeTest(BitcoinTestFramework):
         self.nodes = []
         # Use node0 to mine blocks for input splitting
         self.nodes.append(start_node(0, self.options.tmpdir, ["-maxorphantx=1000",
-                                                              "-relaypriority=0", "-whitelist=127.0.0.1"]))
+                                                              "-allowfreetx=0", "-whitelist=127.0.0.1"]))
 
         print("This test is time consuming, please be patient")
         print("Splitting inputs to small size so we can generate low priority tx's")
@@ -189,12 +189,12 @@ class EstimateFeeTest(BitcoinTestFramework):
         # (17k is room enough for 110 or so transactions)
         self.nodes.append(start_node(1, self.options.tmpdir,
                                      ["-blockmaxsize=18000",
-                                      "-maxorphantx=1000", "-relaypriority=0", "-debug=estimatefee"]))
+                                      "-maxorphantx=1000", "-allowfreetx=0", "-debug=estimatefee"]))
         connect_nodes(self.nodes[1], 0)
 
         # Node2 is a stingy miner, that
         # produces too small blocks (room for only 70 or so transactions)
-        node2args = ["-blockmaxsize=12000", "-maxorphantx=1000", "-relaypriority=0"]
+        node2args = ["-allowfreetx=0", "-blockmaxsize=12000", "-maxorphantx=1000"]
 
         self.nodes.append(start_node(2, self.options.tmpdir, node2args))
         connect_nodes(self.nodes[0], 2)

--- a/qa/rpc-tests/smartfees.py
+++ b/qa/rpc-tests/smartfees.py
@@ -188,13 +188,13 @@ class EstimateFeeTest(BitcoinTestFramework):
         # NOTE: the CreateNewBlock code starts counting block size at 1,000 bytes,
         # (17k is room enough for 110 or so transactions)
         self.nodes.append(start_node(1, self.options.tmpdir,
-                                     ["-blockprioritysize=1500", "-blockmaxsize=18000",
+                                     ["-blockmaxsize=18000",
                                       "-maxorphantx=1000", "-relaypriority=0", "-debug=estimatefee"]))
         connect_nodes(self.nodes[1], 0)
 
         # Node2 is a stingy miner, that
         # produces too small blocks (room for only 70 or so transactions)
-        node2args = ["-blockprioritysize=0", "-blockmaxsize=12000", "-maxorphantx=1000", "-relaypriority=0"]
+        node2args = ["-blockmaxsize=12000", "-maxorphantx=1000", "-relaypriority=0"]
 
         self.nodes.append(start_node(2, self.options.tmpdir, node2args))
         connect_nodes(self.nodes[0], 2)

--- a/qa/rpc-tests/spv.py
+++ b/qa/rpc-tests/spv.py
@@ -90,8 +90,8 @@ class SPVTest(BitcoinTestFramework):
 
     def setup_network(self):
         self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-relaypriority=0 -debug=mempool"]))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-relaypriority=0 -debug=mempool"]))
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-allowfreetx=0 -debug=mempool"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-allowfreetx=0 -debug=mempool"]))
         connect_nodes(self.nodes[0], 1)
 
     def run_test(self):

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -25,6 +25,7 @@ import errno
 
 from . import coverage
 from .authproxy import AuthServiceProxy, JSONRPCException
+from test_framework.mininode import COIN
 
 COVERAGE_DIR = None
 
@@ -695,3 +696,11 @@ def wait_for(criteria, what = None, timeout = 60):
         time.sleep(0.1 * i**2) # geometric back-off
         i += 1
 
+def get_relay_fee(node, txsize = 500, unit = "bch"):
+    bchrate = node.getnetworkinfo()["relayfee"] * Decimal(txsize / 1000)
+    if (unit == "bch"):
+        return bchrate
+    if (unit == "sat"):
+        return int(bchrate * COIN)
+    else:
+        raise Exception("unsupported unit")

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -21,7 +21,7 @@ class WalletTest (BitcoinTestFramework):
         self.num_nodes = 4
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(3, self.options.tmpdir, [["-relaypriority=0"],]*3)
+        self.nodes = start_nodes(3, self.options.tmpdir, [["-allowfreetx=1"],]*3)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)
@@ -74,6 +74,7 @@ class WalletTest (BitcoinTestFramework):
 
         # create both transactions
         txns_to_send = []
+        fee = get_relay_fee(self.nodes[0])
         for utxo in node0utxos:
             inputs = []
             outputs = {}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -128,6 +128,7 @@ BITCOIN_CORE_H = \
   limitedmap.h \
   main.h \
   maxblocksize.h \
+  mempoolaccepter.h \
   mempoolfeemodifier.h \
   memusage.h \
   merkleblock.h \
@@ -233,6 +234,7 @@ libbitcoin_server_a_SOURCES = \
   leakybucket.cpp \
   main.cpp \
   maxblocksize.cpp \
+  mempoolaccepter.cpp \
   mempoolfeemodifier.cpp \
   merkleblock.cpp \
   miner.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -78,6 +78,7 @@ BITCOIN_TESTS =\
   test/main_tests.cpp \
   test/maxblocksize_tests.cpp \
   test/mempool_tests.cpp \
+  test/mempoolaccepter_tests.cpp \
   test/mempoolfeemodifier_tests.cpp \
   test/merkle_tests.cpp \
   test/merkleblock_tests.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -438,7 +438,7 @@ std::string HelpMessage(HelpMessageMode mode)
     {
         strUsage += HelpMessageOpt("-limitfreerelay=<n>", strprintf("Continuously rate-limit free transactions to <n>*1000 bytes per minute (default: %u)", 15));
         strUsage += HelpMessageOpt("-limitrespendrelay=<n>", strprintf("Continuously rate-limit respend relays to <n>*1000 bytes per minute (default: %u)", 100));
-        strUsage += HelpMessageOpt("-relaypriority", strprintf("Require high priority for relaying free or low-fee transactions (default: %u)", 1));
+        strUsage += HelpMessageOpt("-allowfreetx", strprintf("Mine and relay free or low-fee transactions if they have high priority (default: %u)", 1));
         strUsage += HelpMessageOpt("-maxsigcachesize=<n>", strprintf("Limit size of signature cache to <n> MiB (default: %u)", DEFAULT_MAX_SIG_CACHE_SIZE));
     }
     strUsage += HelpMessageOpt("-minrelaytxfee=<amt>", strprintf(_("Fees (in BTC/Kb) smaller than this are considered zero fee for relaying (default: %s)"), FormatMoney(::minRelayTxFee.GetFeePerK())));

--- a/src/mempoolaccepter.cpp
+++ b/src/mempoolaccepter.cpp
@@ -1,0 +1,109 @@
+#include "mempoolaccepter.h"
+#include "amount.h"
+#include "policy/txpriority.h"
+#include "primitives/transaction.h"
+#include "txmempool.h"
+#include "util.h"
+#include "utilprocessmsg.h"
+
+static std::string TxIDStr(const CTxMemPoolEntry& entry) {
+    return entry.GetTx().ToString();
+}
+
+
+static bool CheckFreeRateLimit(const CTxMemPoolEntry& entry,
+                               RateLimitState* limit)
+{
+    assert(limit);
+    std::unique_lock<std::mutex> lock(limit->cs);
+    if (!RateLimitExceeded(limit->count, limit->lastTime,
+                           limit->limit, entry.GetTxSize()))
+    {
+        LogPrint(Log::MEMPOOL, "Rate limit count: %g => %g\n",
+                 limit->count, limit->count + entry.GetTxSize());
+        return true;
+    }
+
+    return false;
+}
+
+FeeEvaluator::FeeEvaluator(bool allowFreeTxs,
+                           const MempoolFeeModifier& feemodifier,
+                           const CFeeRate& minRelayRate,
+                           RateLimitState* limiter)
+    : allowFreeTxs(allowFreeTxs), feemodifier(feemodifier), minRelayRate(minRelayRate)
+{
+    static RateLimitState defaultLimiter(GetArg("-limitfreerelay", 15));
+    ratelimiter = limiter == nullptr ? &defaultLimiter : limiter;
+}
+
+FeeEvaluator::FeeState FeeEvaluator::HasSufficientFee(const CCoinsViewCache& view,
+                                                      const CTxMemPoolEntry& entry,
+                                                      int chainHeight) const
+{
+    if (chainHeight == -1)
+        throw std::invalid_argument("invalid chainheight");
+
+    const CTransaction& tx = entry.GetTx();
+    if (feemodifier.GetDelta(tx.GetHash()) > 0) {
+        // Any transaction that has had its fee artifically bumped doesn't
+        // gets to pass. No need to consider fee/priority.
+        return FEE_OK;
+    }
+
+    const size_t txSize = entry.GetTxSize();
+    const CAmount& minFee = minRelayRate.GetFee(txSize);
+
+    if (entry.GetFee() >= minFee) {
+        return FEE_OK;
+    }
+
+    if (!IsPriorityCandidate(txSize)) {
+        LogPrint(Log::MEMPOOL, "%s: not enough fees %s, %d < %d\n",
+                 __func__, TxIDStr(entry), entry.GetFee(), minFee);
+
+        return INSUFFICIENT_FEE;
+    }
+
+    double priority = GetPriority(view, entry, chainHeight);
+    if (priority < AllowFreeThreshold()) {
+        LogPrint(Log::MEMPOOL, "%s: insufficient priority %s, %d < %d\n",
+                 __func__, TxIDStr(entry), priority, AllowFreeThreshold());
+
+        return INSUFFICIENT_PRIORITY;
+    }
+
+    // Continuously rate-limit free (really, very-low-fee) transactions
+    // This mitigates 'penny-flooding' -- sending thousands of free transactions just to
+    // be annoying or make others' transactions take longer to confirm.
+    if (!CheckFreeRateLimit(entry, ratelimiter)) {
+
+        LogPrint(Log::MEMPOOL, "%s: %s rejected by rate limiter\n",
+                 __func__, TxIDStr(entry));
+        return RATE_LIMITED;
+    }
+
+    return FEE_OK;
+}
+
+bool FeeEvaluator::IsPriorityCandidate(size_t txSize) const {
+    return allowFreeTxs && txSize <= MAX_FREE_TX_SIZE;
+}
+
+double FeeEvaluator::GetPriority(const CCoinsViewCache& view,
+                                 const CTxMemPoolEntry& entry,
+                                 int tipHeight) const
+{
+    // Free transactions must have sufficient priority to be mined in the next block.
+    return ::GetPriority(view, entry.GetTx(), tipHeight + 1, entry.GetTxSize());
+}
+
+std::string FeeEvaluator::ToString(FeeState s) {
+    switch (s) {
+    case FeeState::INSUFFICIENT_FEE: return "insufficient fee";
+    case FeeState::INSUFFICIENT_PRIORITY: return "insufficient priority";
+    case FeeState::RATE_LIMITED: return "free tx rejected by rate limiter";
+    case FeeState::FEE_OK: return "";
+    default: return "unknown";
+    }
+}

--- a/src/mempoolaccepter.h
+++ b/src/mempoolaccepter.h
@@ -9,6 +9,8 @@ class CFeeRate;
 class CTxMemPoolEntry;
 class MempoolFeeModifier;
 
+typedef int64_t CAmount;
+
 /**
  * This was DEFAULT_BLOCK_PRIORITY_SIZE - 1000. The concept of block priority
  * size is gone.
@@ -17,6 +19,11 @@ class MempoolFeeModifier;
  * muiltiple transactions instead of one big transaction for avoiding fees.
  */
 static const uint64_t MAX_FREE_TX_SIZE = 49000;
+/**
+ * Fee is considered absurdly high if it's higher or equal to minimal relay fee
+ * multiplied with this factor.
+ */
+static const int64_t ABSURD_FEE_FACTOR = 10000;
 
 struct RateLimitState {
     RateLimitState(int64_t limit) : count(0), lastTime(0), limit(limit) {
@@ -33,6 +40,7 @@ class FeeEvaluator {
 public:
     enum FeeState {
         FEE_OK,
+        ABSURD_HIGH_FEE,
         INSUFFICIENT_FEE,
         INSUFFICIENT_PRIORITY,
         RATE_LIMITED
@@ -57,6 +65,7 @@ private:
     RateLimitState* ratelimiter;
 
     bool IsPriorityCandidate(size_t txSize) const;
+    bool HasAbsurdFee(CAmount minRelayFee, CAmount txFee) const;
 };
 
 #endif

--- a/src/mempoolaccepter.h
+++ b/src/mempoolaccepter.h
@@ -1,0 +1,62 @@
+#ifndef BITCOIN_MEMPOOLACCEPTER_H
+#define BITCOIN_MEMPOOLACCEPTER_H
+
+#include <cstdint>
+#include <mutex>
+
+class CCoinsViewCache;
+class CFeeRate;
+class CTxMemPoolEntry;
+class MempoolFeeModifier;
+
+/**
+ * This was DEFAULT_BLOCK_PRIORITY_SIZE - 1000. The concept of block priority
+ * size is gone.
+ *
+ * We want to keep this limit large, as we don't want to encourage sending
+ * muiltiple transactions instead of one big transaction for avoiding fees.
+ */
+static const uint64_t MAX_FREE_TX_SIZE = 49000;
+
+struct RateLimitState {
+    RateLimitState(int64_t limit) : count(0), lastTime(0), limit(limit) {
+    }
+    double count;
+    int64_t lastTime;
+    int64_t limit;
+    std::mutex cs;
+};
+
+// Evaluate if transaction has enough fee to enter the mempool.
+// This class is thread safe.
+class FeeEvaluator {
+public:
+    enum FeeState {
+        FEE_OK,
+        INSUFFICIENT_FEE,
+        INSUFFICIENT_PRIORITY,
+        RATE_LIMITED
+    };
+
+    FeeEvaluator(bool allowFreeTxs, const MempoolFeeModifier& feemodifier,
+                 const CFeeRate& minRelayRate, RateLimitState* limiter = nullptr);
+
+    FeeState HasSufficientFee(const CCoinsViewCache& view,
+                              const CTxMemPoolEntry& entry, int chainHeight) const;
+
+    static std::string ToString(FeeState s);
+
+protected:
+    virtual double GetPriority(const CCoinsViewCache&,
+                               const CTxMemPoolEntry&, int chainHeight) const;
+
+private:
+    const bool allowFreeTxs;
+    const MempoolFeeModifier& feemodifier;
+    const CFeeRate& minRelayRate;
+    RateLimitState* ratelimiter;
+
+    bool IsPriorityCandidate(size_t txSize) const;
+};
+
+#endif

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -99,9 +99,6 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
     // Limit to between 1K and (hard limit - 1K) for sanity:
     nBlockMaxSize = std::max((uint64_t)1000, std::min((hardLimit - 1000),  nBlockMaxSize));
 
-    // Skip free transactions if -relaypriority argument is true
-    bool fSkipFree = GetBoolArg("-relaypriority", true);
-
     // Collect memory pool transactions into the block
     CTxMemPool::setEntries inBlock;
     CTxMemPool::setEntries gotParents;
@@ -150,12 +147,6 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
             }
 
             const CTransaction& tx = iter->GetTx();
-
-            // To allow a free tx to be mined with fSkipFree set, use fee delta to push fees up to minimum
-            CAmount nFeeDelta = mempool.GetFeeModifier().GetDelta(tx.GetHash());
-            if (fSkipFree && iter->GetFee() + nFeeDelta < ::minRelayTxFee.GetFee(iter->GetTxSize())) {
-                continue;
-            }
 
             // Our index guarantees that all ancestors are paid for.
             // If it has parents, push this tx, then its parents, onto the stack.

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -119,6 +119,10 @@ bool Opt::PreferXThinBlocks() const {
     return Args->GetBool("-prefer-xthin-blocks", false);
 }
 
+bool Opt::AllowFreeTx() const {
+    return Args->GetBool("-allowfreetx", true);
+}
+
 static std::string createErrorStr(const std::vector<std::string>& param) {
     std::stringstream err;
     err << "Invalid option '" << param.at(0) << "'. "
@@ -132,7 +136,8 @@ static std::string createErrorStr(const std::vector<std::string>& param) {
 void Opt::CheckRemovedOptions() const {
     std::vector<std::vector<std::string>> removed = {
         {"-blockprioritysize", "0.11G", "-allowfreetx"},
-        {"-stealth-mode", "0.11J", "-useragent"}};
+        {"-stealth-mode", "0.11J", "-useragent"},
+        {"-relaypriority", "0.11J", "-allowfreetx"}};
 
     for (auto& r : removed) {
         if (!Args->GetBool(r.at(0), false))

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -119,11 +119,26 @@ bool Opt::PreferXThinBlocks() const {
     return Args->GetBool("-prefer-xthin-blocks", false);
 }
 
-void Opt::CheckRemovedOptions() const {
-    const std::string removedIn = "Option was removed in verison 0.11J";
+static std::string createErrorStr(const std::vector<std::string>& param) {
+    std::stringstream err;
+    err << "Invalid option '" << param.at(0) << "'. "
+        << "Option was removed in " << param.at(1) << ".";
+    if (!param.at(3).empty())
+        err << " See alternative '" << param.at(3) << "'.";
 
-    if (Args->GetBool("-stealth-mode", false))
-        throw std::invalid_argument("invalid option -stealth-mode: " + removedIn);
+    return err.str();
+}
+
+void Opt::CheckRemovedOptions() const {
+    std::vector<std::vector<std::string>> removed = {
+        {"-blockprioritysize", "0.11G", "-allowfreetx"},
+        {"-stealth-mode", "0.11J", "-useragent"}};
+
+    for (auto& r : removed) {
+        if (!Args->GetBool(r.at(0), false))
+            continue;
+        throw std::invalid_argument(createErrorStr(r));
+    }
 }
 
 std::unique_ptr<ArgReset> SetDummyArgGetter(std::unique_ptr<ArgGetter> getter) {

--- a/src/options.h
+++ b/src/options.h
@@ -31,6 +31,9 @@ public:
         int ThinBlocksMaxParallel();
         bool PreferXThinBlocks() const;
 
+    // Policy
+    bool AllowFreeTx() const;
+
     //! Throws invalid argument on use of options that are no longer supported.
     void CheckRemovedOptions() const;
 };

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -14,8 +14,6 @@
 
 class CCoinsViewCache;
 
-/** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
-static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000;
 /** The maximum size for transactions we're willing to relay/mine */
 static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */

--- a/src/test/mempoolaccepter_tests.cpp
+++ b/src/test/mempoolaccepter_tests.cpp
@@ -1,0 +1,130 @@
+#include "test/test_bitcoin.h"
+#include "test/test_random.h"
+#include "coins.h"
+#include "mempoolaccepter.h"
+#include "policy/txpriority.h"
+
+#include <boost/test/unit_test.hpp>
+
+namespace {
+CMutableTransaction CreateDummyTx() {
+    CScript garbage;
+    for (unsigned int i = 0; i < 128; i++) {
+        // use rand to get unique hash
+        garbage.push_back(static_cast<char>(insecure_rand()));
+    }
+
+    CMutableTransaction tx;
+    tx.vin.resize(1);
+    tx.vin[0].scriptSig = garbage;
+    tx.vout.resize(1);
+    tx.vout[0].nValue=0LL;
+    return tx;
+}
+
+size_t TxSize(const CMutableTransaction& tx) {
+    return ::GetSerializeSize(CTransaction(tx), SER_NETWORK, PROTOCOL_VERSION);
+}
+
+class DummyFeeEvaluator : public FeeEvaluator {
+public:
+    using FeeEvaluator::FeeEvaluator;
+
+    double GetPriority(const CCoinsViewCache& view,
+                        const CTxMemPoolEntry& entry,
+                        int tipHeight) const override
+    {
+        return priority;
+    }
+    double priority;
+};
+
+class MempoolAccepterTestFixture : public BasicTestingSetup {
+public:
+    MempoolAccepterTestFixture() : minRelayFeeRate(1000), allowFreeTxs(true), view(&dummybase)
+    {
+    }
+
+    MempoolFeeModifier feemodifier;
+    CFeeRate minRelayFeeRate;
+    bool allowFreeTxs;
+    CCoinsView dummybase;
+    CCoinsViewCache view;
+
+    CTxMemPoolEntry CreateTxWithFee()
+    {
+        CMutableTransaction tx = CreateDummyTx();
+        CAmount fee = minRelayFeeRate.GetFee(TxSize(tx));
+        TestMemPoolEntryHelper entry;
+        return entry.Fee(fee).Time(GetTime()).Height(0).FromTx(tx, nullptr);
+    }
+
+    CTxMemPoolEntry CreateFreeTx()
+    {
+        CMutableTransaction tx = CreateDummyTx();
+        TestMemPoolEntryHelper entry;
+        return entry.Fee(CAmount(0)).Time(GetTime()).Height(0).FromTx(tx, nullptr);
+    }
+
+    FeeEvaluator FeeEval() {
+        static RateLimitState nolimit(std::numeric_limits<int64_t>::max());
+        return FeeEvaluator(allowFreeTxs, feemodifier, minRelayFeeRate, &nolimit);
+    }
+};
+} // ns anon
+
+BOOST_FIXTURE_TEST_SUITE(mempoolaccepter_tests, MempoolAccepterTestFixture)
+
+BOOST_AUTO_TEST_CASE(hassufficientfee_has_delta) {
+    allowFreeTxs = false;
+
+    // No delta = not sufficient.
+    CTxMemPoolEntry freetx = CreateFreeTx();
+    BOOST_CHECK_EQUAL(FeeEvaluator::INSUFFICIENT_FEE,
+                      FeeEval().HasSufficientFee(view, freetx, 0));
+
+    // Transactions that are prioritized never need any relay fee.
+    // Positive delta = prioritized
+    feemodifier.AddDelta(freetx.GetTx().GetHash(), 1);
+    BOOST_CHECK_EQUAL(FeeEvaluator::FEE_OK,
+                      FeeEval().HasSufficientFee(view, freetx, 0));
+
+    // TXs with negative delta require normal relay fee.
+    feemodifier.AddDelta(freetx.GetTx().GetHash(), -2);
+    BOOST_CHECK_EQUAL(FeeEvaluator::INSUFFICIENT_FEE,
+                      FeeEval().HasSufficientFee(view, freetx, 0));
+
+    CTxMemPoolEntry txwithfee = CreateTxWithFee();
+    feemodifier.AddDelta(txwithfee.GetTx().GetHash(), -2);
+    BOOST_CHECK_EQUAL(FeeEvaluator::FEE_OK,
+                      FeeEval().HasSufficientFee(view, txwithfee, 0));
+}
+
+BOOST_AUTO_TEST_CASE(hassufficientfee_not_free) {
+    allowFreeTxs = false;
+    BOOST_CHECK_EQUAL(FeeEvaluator::FEE_OK,
+                      FeeEval().HasSufficientFee(view, CreateTxWithFee(), 0));
+    BOOST_CHECK_EQUAL(FeeEvaluator::INSUFFICIENT_FEE,
+                      FeeEval().HasSufficientFee(view, CreateFreeTx(), 0));
+}
+
+BOOST_AUTO_TEST_CASE(getminrelayfee_free) {
+    allowFreeTxs = true;
+    CTxMemPoolEntry freetx = CreateFreeTx();
+    DummyFeeEvaluator eval(allowFreeTxs, feemodifier, minRelayFeeRate);
+    eval.priority = AllowFreeThreshold();
+    BOOST_CHECK_EQUAL(FeeEvaluator::FEE_OK, eval.HasSufficientFee(view, freetx, 0));
+    eval.priority = AllowFreeThreshold() - 1;
+    BOOST_CHECK_EQUAL(FeeEvaluator::INSUFFICIENT_PRIORITY, eval.HasSufficientFee(view, freetx, 0));
+}
+
+BOOST_AUTO_TEST_CASE(getminrelayfree_rate_limited) {
+    allowFreeTxs = true;
+    CTxMemPoolEntry freetx = CreateFreeTx();
+    RateLimitState limit(0 /* limit will always exceed */);
+    DummyFeeEvaluator eval(allowFreeTxs, feemodifier, minRelayFeeRate, &limit);
+    eval.priority = AllowFreeThreshold();
+    BOOST_CHECK_EQUAL(FeeEvaluator::RATE_LIMITED, eval.HasSufficientFee(view, freetx, 0));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This split out transaction fee/priority evaluation out of `AcceptToMemoryPool` and into a class `FeeEvaluator`. This class is given unit test coverage, and the tests clearly define transaction acceptance policy.

The somewhat broken `-relaypriority` parameter is replaced with a more descriptive `-allowfreetx` parameter.

QA tests that broke due to fee policy change are fixed.

On top of #459 