### PR TITLE
Disallow messages before receiving VERACK

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -151,7 +151,8 @@ testScriptsExt = [
     'p2p-compactblocks.py',
     'mempool_packages.py',
     'p2p-compactblocks-limits.py',
-    'dbcrash.py'
+    'dbcrash.py',
+    'p2p-timeouts.py',
 ]
 
 

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -122,7 +122,8 @@ testScripts = [
     'disablewallet.py',
     'rpcnamedargs.py',
     'abc-monolith-activation.py',
-    'bip64.py'
+    'bip64.py',
+    'p2p-leaktests.py',
 ]
 
 testScriptsExt = [

--- a/qa/rpc-tests/p2p-leaktests.py
+++ b/qa/rpc-tests/p2p-leaktests.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.mininode import *
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+'''
+Test for message sending before handshake completion
+
+A node should never send anything other than VERSION/VERACK/REJECT until it's
+received a VERACK.
+
+This test connects to a node and sends it a few messages, trying to intice it
+into sending us something it shouldn't.
+'''
+
+banscore = 10
+
+class CLazyNode(NodeConnCB):
+    def __init__(self):
+        self.connection = None
+        self.unexpected_msg = False
+        self.connected = False
+        super().__init__()
+
+    def add_connection(self, conn):
+        self.connection = conn
+
+    def send_message(self, message):
+        self.connection.send_message(message)
+
+    def bad_message(self, message):
+        self.unexpected_msg = True
+        print("should not have received message: %s" % message.command)
+
+    def on_open(self, conn):
+        self.connected = True
+
+    def on_version(self, conn, message): self.bad_message(message)
+    def on_verack(self, conn, message): self.bad_message(message)
+    def on_reject(self, conn, message): self.bad_message(message)
+    def on_inv(self, conn, message): self.bad_message(message)
+    def on_addr(self, conn, message): self.bad_message(message)
+    def on_alert(self, conn, message): self.bad_message(message)
+    def on_getdata(self, conn, message): self.bad_message(message)
+    def on_getblocks(self, conn, message): self.bad_message(message)
+    def on_tx(self, conn, message): self.bad_message(message)
+    def on_block(self, conn, message): self.bad_message(message)
+    def on_getaddr(self, conn, message): self.bad_message(message)
+    def on_headers(self, conn, message): self.bad_message(message)
+    def on_getheaders(self, conn, message): self.bad_message(message)
+    def on_ping(self, conn, message): self.bad_message(message)
+    def on_mempool(self, conn): self.bad_message(message)
+    def on_pong(self, conn, message): self.bad_message(message)
+    def on_feefilter(self, conn, message): self.bad_message(message)
+    def on_sendheaders(self, conn, message): self.bad_message(message)
+    def on_sendcmpct(self, conn, message): self.bad_message(message)
+    def on_cmpctblock(self, conn, message): self.bad_message(message)
+    def on_getblocktxn(self, conn, message): self.bad_message(message)
+    def on_blocktxn(self, conn, message): self.bad_message(message)
+
+# Node that never sends a version. We'll use this to send a bunch of messages
+# anyway, and eventually get disconnected.
+class CNodeNoVersionBan(CLazyNode):
+    def __init__(self):
+        super().__init__()
+
+    # send a bunch of veracks without sending a message. This should get us disconnected.
+    # NOTE: implementation-specific check here. Remove if bitcoind ban behavior changes
+    def on_open(self, conn):
+        super().on_open(conn)
+        for i in range(banscore):
+            self.send_message(msg_verack())
+
+    def on_reject(self, conn, message): pass
+
+# Node that never sends a version. This one just sits idle and hopes to receive
+# any message (it shouldn't!)
+class CNodeNoVersionIdle(CLazyNode):
+    def __init__(self):
+        super().__init__()
+
+# Node that sends a version but not a verack.
+class CNodeNoVerackIdle(CLazyNode):
+    def __init__(self):
+        self.version_received = False
+        super().__init__()
+
+    def on_reject(self, conn, message): pass
+    def on_verack(self, conn, message): pass
+    # When version is received, don't reply with a verack. Instead, see if the
+    # node will give us a message that it shouldn't. This is not an exhaustive
+    # list!
+    def on_version(self, conn, message):
+        self.version_received = True
+        conn.send_message(msg_ping())
+        conn.send_message(msg_getaddr())
+
+class P2PLeakTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 1
+    def setup_network(self):
+        extra_args = [['-debug', '-banscore='+str(banscore)]
+                      for i in range(self.num_nodes)]
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, extra_args)
+
+    def run_test(self):
+        no_version_bannode = CNodeNoVersionBan()
+        no_version_idlenode = CNodeNoVersionIdle()
+        no_verack_idlenode = CNodeNoVerackIdle()
+
+        connections = []
+        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], no_version_bannode, send_version=False))
+        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], no_version_idlenode, send_version=False))
+        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], no_verack_idlenode))
+        no_version_bannode.add_connection(connections[0])
+        no_version_idlenode.add_connection(connections[1])
+        no_verack_idlenode.add_connection(connections[2])
+
+        NetworkThread().start()  # Start up network handling in another thread
+
+        assert(wait_until(lambda: no_version_bannode.connected and no_version_idlenode.connected and no_verack_idlenode.version_received, timeout=10))
+
+        # Mine a block and make sure that it's not sent to the connected nodes
+        self.nodes[0].generate(1)
+
+        #Give the node enough time to possibly leak out a message
+        time.sleep(5)
+
+        #This node should have been banned
+        assert(no_version_bannode.connection.state == "closed")
+
+        [conn.disconnect_node() for conn in connections]
+
+        # Make sure no unexpected messages came in
+        assert(no_version_bannode.unexpected_msg == False)
+        assert(no_version_idlenode.unexpected_msg == False)
+        assert(no_verack_idlenode.unexpected_msg == False)
+
+if __name__ == '__main__':
+    P2PLeakTest().main()

--- a/qa/rpc-tests/p2p-timeouts.py
+++ b/qa/rpc-tests/p2p-timeouts.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# Copyright (c) 2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+""" TimeoutsTest -- test various net timeouts (only in extended tests)
+
+- Create three bitcoind nodes:
+
+    no_verack_node - we never send a verack in response to their version
+    no_version_node - we never send a version (only a ping)
+    no_send_node - we never send any P2P message.
+
+- Start all three nodes
+- Wait 1 second
+- Assert that we're connected
+- Send a ping to no_verack_node and no_version_node
+- Wait 30 seconds
+- Assert that we're still connected
+- Send a ping to no_verack_node and no_version_node
+- Wait 31 seconds
+- Assert that we're no longer connected (timeout to receive version/verack is 60 seconds)
+"""
+
+from time import sleep
+
+from test_framework.mininode import *
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class TestNode(SingleNodeConnCB):
+    def __init__(self):
+        SingleNodeConnCB.__init__(self)
+        self.connected = False
+        self.received_version = False
+
+    def on_open(self, conn):
+        self.connected = True
+
+    def on_close(self, conn):
+        self.connected = False
+
+    def on_version(self, conn, message):
+        # Don't send a verack in response
+        self.received_version = True
+
+class TimeoutsTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def setup_network(self):
+        self.nodes = []
+
+        # Start up node0 to be a version 1, pre-segwit node.
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, 
+                [["-debug", "-logtimemicros=1"]])
+
+    def run_test(self):
+        # Setup the p2p connections and start up the network thread.
+        self.no_verack_node = TestNode() # never send verack
+        self.no_version_node = TestNode() # never send version (just ping)
+        self.no_send_node = TestNode() # never send anything
+
+        connections = []
+        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], self.no_verack_node))
+        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], self.no_version_node, send_version=False))
+        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], self.no_send_node, send_version=False))
+        self.no_verack_node.add_connection(connections[0])
+        self.no_version_node.add_connection(connections[1])
+        self.no_send_node.add_connection(connections[2])
+
+        NetworkThread().start()  # Start up network handling in another thread
+
+        sleep(1)
+
+        assert(self.no_verack_node.connected)
+        assert(self.no_version_node.connected)
+        assert(self.no_send_node.connected)
+
+        ping_msg = msg_ping()
+        connections[0].send_message(ping_msg)
+        connections[1].send_message(ping_msg)
+
+        sleep(30)
+
+        assert(self.no_verack_node.received_version)
+
+        assert(self.no_verack_node.connected)
+        assert(self.no_version_node.connected)
+        assert(self.no_send_node.connected)
+
+        connections[0].send_message(ping_msg)
+        connections[1].send_message(ping_msg)
+
+        sleep(31)
+
+        assert(not self.no_verack_node.connected)
+        assert(not self.no_version_node.connected)
+        assert(not self.no_send_node.connected)
+
+if __name__ == '__main__':
+    TimeoutsTest().main()

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -1443,6 +1443,7 @@ class NodeConnCB(object):
         if conn.ver_send > BIP0031_VERSION:
             conn.send_message(msg_pong(message.nonce))
     def on_reject(self, conn, message): pass
+    def on_open(self, conn): pass
     def on_close(self, conn): pass
     def on_mempool(self, conn): pass
     def on_pong(self, conn, message): pass
@@ -1562,6 +1563,7 @@ class NodeConn(asyncore.dispatcher):
         if self.state != "connected":
             self.show_debug_msg("MiniNode: Connected & Listening: \n")
             self.state = "connected"
+            self.cb.on_open(self)
 
     def handle_close(self):
         self.show_debug_msg("MiniNode: Closing Connection to %s:%d... "

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4756,9 +4756,12 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv,
         }
         pfrom->fSuccessfullyConnected = true;
     }
-
-
-    else if (strCommand == "addr")
+    else if (!pfrom->fSuccessfullyConnected)
+    {
+        Misbehaving(pfrom->GetId(), 1, "must have a verack message before anything else");
+        return false;
+    }
+    else if (strCommand == NetMsgType::ADDR)
     {
         vector<CAddress> vAddr;
         vRecv >> vAddr;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1080,6 +1080,11 @@ void CConnman::ThreadSocketHandler()
                     LogPrintf("ping timeout: %fs\n", 0.000001 * (GetTimeMicros() - pnode->nPingUsecStart));
                     pnode->fDisconnect = true;
                 }
+                else if (!pnode->fSuccessfullyConnected)
+                {
+                    LogPrintf("version handshake timeout from %d\n", pnode->id);
+                    pnode->fDisconnect = true;
+                }
             }
         }
         {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -824,12 +824,13 @@ void CConnman::ThreadSocketHandler()
                 {
                     bool fDelete = false;
                     {
-                        TRY_LOCK(pnode->cs_vSend, lockSend);
-                        if (lockSend)
+                        TRY_LOCK(pnode->cs_inventory, lockInv);
+                        if (lockInv)
                         {
-                                TRY_LOCK(pnode->cs_inventory, lockInv);
-                                if (lockInv)
-                                    fDelete = true;
+                            TRY_LOCK(pnode->cs_vSend, lockSend);
+                            if (lockSend) {
+                                fDelete = true;
+                            }
                         }
                     }
                     if (fDelete)

--- a/src/test/p2p_protocol_tests.cpp
+++ b/src/test/p2p_protocol_tests.cpp
@@ -71,6 +71,7 @@ BOOST_AUTO_TEST_CASE(MaxSizeWeirdRejectMessage)
 {
     DummyNode n;
     n.nVersion = PROTOCOL_VERSION;
+    n.fSuccessfullyConnected = true;
     CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
     s << std::string(12, 'a'); // not a real command, but it uses the max of 12 here.
     s << (uint8_t)0x10;
@@ -88,6 +89,7 @@ BOOST_AUTO_TEST_CASE(MaxSizeValidRejectMessage)
 {
     DummyNode n;
     n.nVersion = PROTOCOL_VERSION;
+    n.fSuccessfullyConnected = true;
     CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
     s << std::string("block"); // does not use the max of 12, but "block" is the longest command that has a defined extension of 32 bytes
     s << (uint8_t)0x10;

--- a/src/utilprocessmsg.h
+++ b/src/utilprocessmsg.h
@@ -4,10 +4,12 @@
 #include <vector>
 #include <cstdint>
 
-class uint256;
-class CNode;
 class CBlockHeader;
 class CBlockIndex;
+class CConnman;
+class CNode;
+class CNode;
+class uint256;
 namespace Consensus { struct Params; }
 
 typedef int NodeId;
@@ -31,5 +33,12 @@ void UpdateBestHeaderSent(CNode& node, CBlockIndex* blockIndex);
 
 // Exponentially limit the rate of nSize flow to nLimit.  nLimit unit is thousands-per-minute.
 bool RateLimitExceeded(double& dCount, int64_t& nLastTime, int64_t nLimit, unsigned int nSize);
+
+/**
+ * Handle async rejects and ban flags.
+ *
+ * Helper function for ProcessMessages and SendMessages. Returns true if parent function should return.
+ */
+bool ProcessRejectsAndBans(CConnman* connman, CNode* pnode);
 
 #endif


### PR DESCRIPTION
* fd13eca from https://github.com/bitcoin/bitcoin/pull/9674
* https://github.com/bitcoin/bitcoin/pull/9715 - Disconnect peers which we do not receive VERACKs from within 60 sec
* https://github.com/bitcoin/bitcoin/pull/9720 - net: fix banning and disallow sending messages before receiving verack
    * c45b9f - I already wrote the same function as SendRejectsAndCheckIfBanned. Moved it to utilprocessmsg instead of moving it up in main.
    * skipped 5b5e4f8 and 8650bbb, we already got them in 9715