### PR TITLE
Do not relay double spends to SPV clients

### DIFF
--- a/src/bloom.h
+++ b/src/bloom.h
@@ -63,6 +63,8 @@ private:
     friend class CRollingBloomFilter;
 
 public:
+    bool IsEmpty() const { return isEmpty; }
+    bool IsFull() const { return isFull; }
     /**
      * Creates a new bloom filter which will provide the given fp rate when filled with the given number of elements
      * Note that if the given parameters will result in a filter outside the bounds of the protocol limits,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5495,8 +5495,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv,
         else
         {
             LOCK(pfrom->cs_filter);
-            delete pfrom->pfilter;
-            pfrom->pfilter = new CBloomFilter(filter);
+            pfrom->pfilter.reset(new CBloomFilter(filter));
             pfrom->pfilter->UpdateEmptyFull();
         }
         pfrom->fRelayTxes = true;
@@ -5526,8 +5525,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv,
     else if (strCommand == "filterclear")
     {
         LOCK(pfrom->cs_filter);
-        delete pfrom->pfilter;
-        pfrom->pfilter = new CBloomFilter();
+        pfrom->pfilter.reset(new CBloomFilter());
         pfrom->fRelayTxes = true;
     }
 

--- a/src/net.h
+++ b/src/net.h
@@ -182,8 +182,8 @@ public:
         post();
     };
 
-    void RelayTransaction(const CTransaction& tx, std::vector<uint256>& vAncestors);
-    void RelayTransaction(const CTransaction& tx, const CDataStream& ss, std::vector<uint256>& vAncestors);
+    void RelayTransaction(const CTransaction& tx, std::vector<uint256>& vAncestors, const bool fRespend = false);
+    void RelayTransaction(const CTransaction& tx, const CDataStream& ss, std::vector<uint256>& vAncestors, const bool fRespend = false);
 
     // Addrman functions
     size_t GetAddressCount() const;
@@ -544,7 +544,7 @@ public:
     bool fSentAddr;
     CSemaphoreGrant grantOutbound;
     CCriticalSection cs_filter, cs_xfilter;
-    CBloomFilter* pfilter;
+    std::unique_ptr<CBloomFilter> pfilter;
     std::unique_ptr<CBloomFilter> xthinFilter;
     int nRefCount;
     const NodeId id;
@@ -706,6 +706,9 @@ public:
 
     bool SupportsXThinBlocks() const;
     bool SupportsCompactBlocks() const;
+
+    // Best effort determination if node is an SPV client.
+    bool IsSPVClient();
 };
 
 

--- a/src/respend/respendrelayer.cpp
+++ b/src/respend/respendrelayer.cpp
@@ -87,7 +87,7 @@ void RespendRelayer::Trigger() {
 
     std::vector<uint256> vAncestors;
     vAncestors.push_back(respend.GetHash()); // Alert only for the tx itself
-    connman->RelayTransaction(respend, vAncestors);
+    connman->RelayTransaction(respend, vAncestors, true);
 }
 
 } // ns respend

--- a/src/respend/test/respendrelayer_tests.cpp
+++ b/src/respend/test/respendrelayer_tests.cpp
@@ -76,6 +76,19 @@ BOOST_AUTO_TEST_CASE(triggers_correctly) {
     r.Trigger();
     BOOST_CHECK_EQUAL(size_t(1), node.vInventoryToSend.size());
     BOOST_CHECK(respend.GetHash() == node.vInventoryToSend.at(0).hash);
+
+    // Create an interesting and valid respend to an SPV peer.
+    //
+    // As a precation, we *don't* relay respends to SPV nodes. They may not be
+    // tracking the original transaction.
+    node.pfilter.reset(new CBloomFilter(1, .00001, 5, BLOOM_UPDATE_ALL));
+    node.pfilter->insert(respend.GetHash());
+    node.vInventoryToSend.clear();
+    r.SetValid(true);
+    r.Trigger();
+    BOOST_CHECK_EQUAL(size_t(0), node.vInventoryToSend.size());
+    node.pfilter->clear();
+
     connman.RemoveTestNode(&node);
 }
 

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -192,4 +192,16 @@ BOOST_AUTO_TEST_CASE(ipgroup_assigned) {
     BOOST_CHECK_EQUAL(0, ipgroup.connCount);
 }
 
+BOOST_AUTO_TEST_CASE(is_spv_client) {
+    CNetAddr ip("10.0.0.1");
+    CNode node(42, NODE_NETWORK, 0, INVALID_SOCKET, CAddress(CService(ip, 1234)), 0);
+
+    // node has not sent a bloom filter, so we assume it's not SPV.
+    BOOST_CHECK(!node.IsSPVClient());
+
+    // node sends a bloom filter
+    node.pfilter.reset(new CBloomFilter(1, .00001, 5, BLOOM_UPDATE_ALL));
+    BOOST_CHECK(node.IsSPVClient());
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Skip sending respends to peers without an effective bloom filter.  SPV clients will need to opt in to respend relay since they will not see conflicting transactions that don't pay them.

Picked from https://github.com/BitcoinUnlimited/BitcoinUnlimited/pull/1240 which implemented first.