### PR TITLE
Add operator> to base_blob and use proper endianess

### DIFF
--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -36,7 +36,8 @@ public:
 
     friend bool operator<(const COutPoint& a, const COutPoint& b)
     {
-        return (a.hash < b.hash || (a.hash == b.hash && a.n < b.n));
+        int cmp = a.hash.Compare(b.hash);
+        return cmp < 0 || (cmp == 0 && a.n < b.n);
     }
 
     friend bool operator==(const COutPoint& a, const COutPoint& b)

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -124,24 +124,24 @@ static void CheckComparison(const uint160 &a, const uint160 &b) {
 // <= >= < >
 BOOST_AUTO_TEST_CASE(comparison) {
     uint256 LastL;
-    for (int i = 255; i >= 0; --i) {
+    for (int i = 0; i < 256; i++) {
         uint256 TmpL;
-        *(TmpL.begin() + (i >> 3)) |= 1 << (7 - (i & 7));
+        *(TmpL.begin() + (i >> 3)) |= 1 << (i & 7);
         CheckComparison(LastL, TmpL);
         LastL = TmpL;
     }
 
     CheckComparison(ZeroL, R1L);
-    CheckComparison(R2L, R1L);
+    CheckComparison(R1L, R2L);
     CheckComparison(ZeroL, OneL);
     CheckComparison(OneL, MaxL);
     CheckComparison(R1L, MaxL);
     CheckComparison(R2L, MaxL);
 
     uint160 LastS;
-    for (int i = 159; i >= 0; --i) {
+    for (int i = 0; i < 160; i++) {
         uint160 TmpS;
-        *(TmpS.begin() + (i >> 3)) |= 1 << (7 - (i & 7));
+        *(TmpS.begin() + (i >> 3)) |= 1 << (i & 7);
         CheckComparison(LastS, TmpS);
         LastS = TmpS;
     }

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -111,36 +111,47 @@ BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
     BOOST_CHECK(uint160(OneS) == OneS);
 }
 
-BOOST_AUTO_TEST_CASE( comparison ) // <= >= < >
-{
+static void CheckComparison(const uint256 &a, const uint256 &b) {
+    BOOST_CHECK(a < b);
+    BOOST_CHECK(b > a);
+}
+
+static void CheckComparison(const uint160 &a, const uint160 &b) {
+    BOOST_CHECK(a < b);
+    BOOST_CHECK(b > a);
+}
+
+// <= >= < >
+BOOST_AUTO_TEST_CASE(comparison) {
     uint256 LastL;
     for (int i = 255; i >= 0; --i) {
         uint256 TmpL;
-        *(TmpL.begin() + (i>>3)) |= 1<<(7-(i&7));
-        BOOST_CHECK( LastL < TmpL );
+        *(TmpL.begin() + (i >> 3)) |= 1 << (7 - (i & 7));
+        CheckComparison(LastL, TmpL);
         LastL = TmpL;
     }
 
-    BOOST_CHECK( ZeroL < R1L );
-    BOOST_CHECK( R2L < R1L );
-    BOOST_CHECK( ZeroL < OneL );
-    BOOST_CHECK( OneL < MaxL );
-    BOOST_CHECK( R1L < MaxL );
-    BOOST_CHECK( R2L < MaxL );
+    CheckComparison(ZeroL, R1L);
+    CheckComparison(R2L, R1L);
+    CheckComparison(ZeroL, OneL);
+    CheckComparison(OneL, MaxL);
+    CheckComparison(R1L, MaxL);
+    CheckComparison(R2L, MaxL);
 
     uint160 LastS;
     for (int i = 159; i >= 0; --i) {
         uint160 TmpS;
-        *(TmpS.begin() + (i>>3)) |= 1<<(7-(i&7));
-        BOOST_CHECK( LastS < TmpS );
+        *(TmpS.begin() + (i >> 3)) |= 1 << (7 - (i & 7));
+        CheckComparison(LastS, TmpS);
         LastS = TmpS;
     }
-    BOOST_CHECK( ZeroS < R1S );
-    BOOST_CHECK( R2S < R1S );
-    BOOST_CHECK( ZeroS < OneS );
-    BOOST_CHECK( OneS < MaxS );
-    BOOST_CHECK( R1S < MaxS );
-    BOOST_CHECK( R2S < MaxS );
+
+    CheckComparison(ZeroS, R1S);
+    CheckComparison(R2S, R1S);
+    CheckComparison(ZeroS, OneS);
+    CheckComparison(OneS, MaxS);
+    CheckComparison(R1S, MaxS);
+    CheckComparison(R2S, MaxS);
 }
 
 BOOST_AUTO_TEST_CASE( methods ) // GetHex SetHex begin() end() size() GetLow64 GetSerializeSize, Serialize, Unserialize

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -41,7 +41,20 @@ public:
         memset(data, 0, sizeof(data));
     }
 
-    inline int Compare(const base_blob& other) const { return memcmp(data, other.data, sizeof(data)); }
+    inline int Compare(const base_blob &other) const {
+        for (size_t i = 0; i < sizeof(data); i++) {
+            const uint8_t& a = data[sizeof(data) - 1 - i];
+            const uint8_t& b = other.data[sizeof(data) - 1 - i];
+            if (a > b) {
+                return 1;
+            }
+            if (a < b) {
+                return -1;
+            }
+        }
+
+        return 0;
+    }
 
     friend inline bool operator==(const base_blob& a, const base_blob& b) { return a.Compare(b) == 0; }
     friend inline bool operator!=(const base_blob& a, const base_blob& b) { return a.Compare(b) != 0; }

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -41,9 +41,11 @@ public:
         memset(data, 0, sizeof(data));
     }
 
-    friend inline bool operator==(const base_blob& a, const base_blob& b) { return memcmp(a.data, b.data, sizeof(a.data)) == 0; }
-    friend inline bool operator!=(const base_blob& a, const base_blob& b) { return memcmp(a.data, b.data, sizeof(a.data)) != 0; }
-    friend inline bool operator<(const base_blob& a, const base_blob& b) { return memcmp(a.data, b.data, sizeof(a.data)) < 0; }
+    inline int Compare(const base_blob& other) const { return memcmp(data, other.data, sizeof(data)); }
+
+    friend inline bool operator==(const base_blob& a, const base_blob& b) { return a.Compare(b) == 0; }
+    friend inline bool operator!=(const base_blob& a, const base_blob& b) { return a.Compare(b) != 0; }
+    friend inline bool operator<(const base_blob& a, const base_blob& b) { return a.Compare(b) < 0; }
 
     std::string GetHex() const;
     void SetHex(const char* psz);

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -46,6 +46,9 @@ public:
     friend inline bool operator==(const base_blob& a, const base_blob& b) { return a.Compare(b) == 0; }
     friend inline bool operator!=(const base_blob& a, const base_blob& b) { return a.Compare(b) != 0; }
     friend inline bool operator<(const base_blob& a, const base_blob& b) { return a.Compare(b) < 0; }
+    friend inline bool operator>(const base_blob &a, const base_blob &b) {
+        return a.Compare(b) > 0;
+    }
 
     std::string GetHex() const;
     void SetHex(const char* psz);


### PR DESCRIPTION
* https://github.com/bitcoin/bitcoin/pull/7712 - Improve COutPoint less operator
* https://reviews.bitcoinabc.org/D1526 - Add support for both way comparison for uint256/uint160
    * Random code formatting changes removed
* https://reviews.bitcoinabc.org/D1527 - Modify uint256's comparison to use proper endianess
    * Changed to const reference for `a` and `b` in `base_blob::Compare`

As far as I can tell, nothing depended on the existing behavior of `base_blob::Compare`, only that there was an order. This is a prerequisite for CTOR.