### PR TITLE
Throw detailed error from DecodeHexTx

### DIFF
--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -636,8 +636,7 @@ static int CommandLineRawTx(int argc, char* argv[])
             if (strHexTx == "-")                 // "-" implies standard input
                 strHexTx = readStdin();
 
-            if (!DecodeHexTx(txDecodeTmp, strHexTx))
-                throw runtime_error("invalid transaction encoding");
+            txDecodeTmp = DecodeHexTx(strHexTx);
 
             startArg = 2;
         } else

--- a/src/core_io.h
+++ b/src/core_io.h
@@ -17,7 +17,7 @@ class UniValue;
 // core_read.cpp
 extern CScript ParseScript(std::string s);
 extern std::string ScriptToAsmStr(const CScript& script, const bool fAttemptSighashDecode = false);
-extern bool DecodeHexTx(CTransaction& tx, const std::string& strHexTx);
+extern CTransaction DecodeHexTx(const std::string& strHexTx);
 extern bool DecodeHexBlk(CBlock&, const std::string& strHexBlk);
 extern uint256 ParseHashUV(const UniValue& v, const std::string& strName);
 extern uint256 ParseHashStr(const std::string&, const std::string& strName);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -485,8 +485,13 @@ UniValue decoderawtransaction(const JSONRPCRequest& request)
 
     CTransaction tx;
 
-    if (!DecodeHexTx(tx, request.params[0].get_str()))
-        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
+    try {
+        tx = DecodeHexTx(request.params[0].get_str());
+    }
+    catch (const std::exception& e) {
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR,
+                           "TX decode failed: " + std::string(e.what()));
+    }
 
     UniValue result(UniValue::VOBJ);
     TxToJSON(tx, uint256(), result);
@@ -861,8 +866,13 @@ UniValue sendrawtransaction(const JSONRPCRequest& request)
 
     // parse hex string from parameter
     CTransaction tx;
-    if (!DecodeHexTx(tx, request.params[0].get_str()))
-        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
+    try {
+        tx = DecodeHexTx(request.params[0].get_str());
+    }
+    catch (const std::exception& e) {
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR,
+                           "TX decode failed:" + std::string(e.what()));
+    }
     uint256 hashTx = tx.GetHash();
 
     bool fOverrideFees = false;

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -10,6 +10,7 @@
 #include "maxblocksize.h"
 
 #include "test/test_bitcoin.h"
+#include "test/testutil.h"
 #include "test/thinblockutil.h"
 
 #include <boost/test/unit_test.hpp>
@@ -40,14 +41,6 @@ BOOST_AUTO_TEST_CASE(TransactionsRequestSerializationTest) {
     BOOST_CHECK_EQUAL(req1.indexes[1], req2.indexes[1]);
     BOOST_CHECK_EQUAL(req1.indexes[2], req2.indexes[2]);
     BOOST_CHECK_EQUAL(req1.indexes[3], req2.indexes[3]);
-}
-
-// Predicate for checking exception message contains string
-std::function<bool(const std::invalid_argument&)>
-errorContains(const std::string& str) {
-    return [str](const std::invalid_argument& err) {
-        return std::string(err.what()).find(str) != std::string::npos;
-    };
 }
 
 BOOST_AUTO_TEST_CASE(validate_compact_block) {

--- a/src/test/testutil.cpp
+++ b/src/test/testutil.cpp
@@ -31,3 +31,11 @@ boost::filesystem::path GetTempPath() {
     return path;
 #endif
 }
+
+std::function<bool(const std::invalid_argument&)> errorContains(
+        const std::string& str)
+{
+    return [str](const std::invalid_argument& err) {
+        return std::string(err.what()).find(str) != std::string::npos;
+    };
+}

--- a/src/test/testutil.h
+++ b/src/test/testutil.h
@@ -3,7 +3,9 @@
 
 #include "main.h"
 #include <boost/filesystem/path.hpp>
-
+#include <functional>
+#include <stdexcept>
+#include <string>
 struct DummyBlockIndexEntry {
 DummyBlockIndexEntry(const uint256& hash) : hash(hash) {
     index.nStatus = BLOCK_HAVE_DATA;
@@ -18,5 +20,9 @@ DummyBlockIndexEntry(const uint256& hash) : hash(hash) {
 };
 
 boost::filesystem::path GetTempPath();
+
+// Used with BOOST_CHECK_EXCEPTION for checking contents of exception string
+std::function<bool(const std::invalid_argument&)> errorContains(
+        const std::string& str);
 
 #endif // BITCOIN_TEST_TESTUTIL_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2504,9 +2504,13 @@ UniValue fundrawtransaction(const JSONRPCRequest& request)
 
     // parse hex string from parameter
     CTransaction origTx;
-    if (!DecodeHexTx(origTx, request.params[0].get_str()))
-        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
-
+    try {
+        origTx = DecodeHexTx(request.params[0].get_str());
+    }
+    catch (const std::exception& e) {
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR,
+                           "TX decode failed: " + std::string(e.what()));
+    }
     if (origTx.vout.size() == 0)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "TX must have at least one output");
 


### PR DESCRIPTION
This improves the output from the RPC interface.

```
decoderawtransaction 0100000001db4f85b6e2b9f6378fd9f52d80e17c63153D61e1cbc4d46632bf2aba3190d5b000000000000000000001000000000000000001510000000000

TX decode failed: Excess data in hex string. After parsing transaction, 1 bytes remained. (code -22)
```
