### PR TITLE
[test] Add helper function BuildDummyBlockIndex

### DIFF
--- a/src/test/maxblocksize_tests.cpp
+++ b/src/test/maxblocksize_tests.cpp
@@ -7,6 +7,7 @@
 #include "chainparams.h"
 #include "options.h"
 #include "test/test_bitcoin.h"
+#include "test/testutil.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -18,23 +19,14 @@ void fillBlockIndex(
         Consensus::Params& params, std::vector<CBlockIndex>& blockIndexes,
         bool addVotes, int64_t currMax) {
 
-    int height = 0;
-    int64_t blocktime = Opt().UAHFTime();
-
-    CBlockIndex* prev = nullptr;
-    for (CBlockIndex& index : blockIndexes)
-    {
-        index.nHeight = height++;
-        index.nTime = blocktime++;
+    auto customizeFunc = [addVotes, currMax](CBlockIndex& index) {
         index.nMaxBlockSize = currMax;
 
-        if (addVotes)
-            index.nMaxBlockSizeVote = std::max(
-                index.nHeight * 1000000, 1000000);
+        if (!addVotes) return;
 
-        index.pprev = prev;
-        prev = &index;
-    }
+        index.nMaxBlockSizeVote = std::max(index.nHeight * 1000000, 1000000);
+    };
+    BuildDummyBlockIndex(blockIndexes, customizeFunc, Opt().UAHFTime());
 };
 
 BOOST_AUTO_TEST_CASE(get_next_max_blocksize) {

--- a/src/test/testutil.cpp
+++ b/src/test/testutil.cpp
@@ -39,3 +39,24 @@ std::function<bool(const std::invalid_argument&)> errorContains(
         return std::string(err.what()).find(str) != std::string::npos;
     };
 }
+
+void BuildDummyBlockIndex(std::vector<CBlockIndex>& blocks,
+                          const std::function<void(CBlockIndex&)>& customizeFunc,
+                          int64_t genesisBlockTime)
+{
+    int height = 0;
+    int64_t blocktime = genesisBlockTime;
+
+    CBlockIndex* prev = nullptr;
+
+    for (CBlockIndex& b : blocks)
+    {
+        b.nHeight = height++;
+        b.nTime = blocktime++;
+
+        b.pprev = prev;
+        prev = &b;
+
+        customizeFunc(b);
+    }
+}

--- a/src/test/testutil.h
+++ b/src/test/testutil.h
@@ -25,4 +25,9 @@ boost::filesystem::path GetTempPath();
 std::function<bool(const std::invalid_argument&)> errorContains(
         const std::string& str);
 
+// Initialize dummy block index and chain them.
+void BuildDummyBlockIndex(std::vector<CBlockIndex>& blocks,
+                          const std::function<void(CBlockIndex&)>& customizeFunc,
+                          int64_t genesisBlockTime = 100);
+
 #endif // BITCOIN_TEST_TESTUTIL_H


### PR DESCRIPTION
Make code for chaining a dummy index reusable with new function `BuildDummyBlockIndex`.

I plan to use this with #477 