### PR TITLE
[fork] Introduce Any-Order-Rule

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -127,6 +127,7 @@ testScripts = [
     'abc-monolith-activation.py',
     'bip64.py',
     'p2p-leaktests.py',
+    'abc-transaction-ordering.py',
 ]
 
 testScriptsExt = [

--- a/qa/rpc-tests/abc-transaction-ordering.py
+++ b/qa/rpc-tests/abc-transaction-ordering.py
@@ -257,6 +257,10 @@ class TransactionOrderingTest(ComparisonTestFramework):
         out_of_order_block(4445, out[16])
         yield accepted()
 
+        oooblockhash = node.getbestblockhash()
+        node.invalidateblock(oooblockhash)
+        assert(node.getbestblockhash() != oooblockhash)
+
 
 if __name__ == '__main__':
     TransactionOrderingTest().main()

--- a/qa/rpc-tests/abc-transaction-ordering.py
+++ b/qa/rpc-tests/abc-transaction-ordering.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2016 The Bitcoin Core developers
+# Copyright (c) 2017 The Bitcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+This test checks that the nod esoftware accepts transactions in
+non topological order once the feature is activated.
+"""
+
+from test_framework.test_framework import ComparisonTestFramework
+from test_framework.util import assert_equal, assert_raises_jsonrpc, start_nodes
+from test_framework.comptool import TestManager, TestInstance, RejectResult
+from test_framework.blocktools import *
+import time
+from test_framework.key import CECKey
+from test_framework.script import *
+from collections import deque
+
+# far into the future
+AOR_ACTIVATION_TIME = 2000000000
+
+
+class PreviousSpendableOutput():
+
+    def __init__(self, tx=CTransaction(), n=-1):
+        self.tx = tx
+        self.n = n  # the output we're spending
+
+
+class TransactionOrderingTest(ComparisonTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.set_test_params()
+
+    # Can either run this test as 1 node with expected answers, or two and compare them.
+    # Change the "outcome" variable from each TestInstance object to only do
+    # the comparison.
+
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.block_heights = {}
+        self.tip = None
+        self.blocks = {}
+        self.extra_args = [['-whitelist=127.0.0.1',
+                            "-fourthhftime=%d" % AOR_ACTIVATION_TIME ]]
+        self.dbg = self.log.debug
+
+    def setup_network(self):
+        self.nodes = start_nodes(
+            self.num_nodes, self.options.tmpdir,
+            extra_args=self.extra_args * self.num_nodes,
+            binary=[self.options.testbinary] +
+            [self.options.refbinary]*(self.num_nodes-1))
+
+    def run_test(self):
+        self.test = TestManager(self, self.options.tmpdir)
+        self.test.add_all_connections(self.nodes)
+        NetworkThread().start()
+
+        # knock the node out of IBD
+        self.nodes[0].generate(1)
+
+        self.nodes[0].setmocktime(AOR_ACTIVATION_TIME)
+        self.test.run()
+
+    def add_transactions_to_block(self, block, tx_list):
+        [tx.rehash() for tx in tx_list]
+        block.vtx.extend(tx_list)
+
+    # this is a little handier to use than the version in blocktools.py
+    def create_tx(self, spend, value, script=CScript([OP_TRUE])):
+        tx = create_transaction(spend.tx, spend.n, b"", value, script)
+        return tx
+
+    def next_block(self, number, spend=None, tx_count=0):
+        if self.tip == None:
+            base_block_hash = self.genesis_hash
+            block_time = int(time.time()) + 1
+        else:
+            base_block_hash = self.tip.sha256
+            block_time = self.tip.nTime + 1
+        # First create the coinbase
+        height = self.block_heights[base_block_hash] + 1
+        coinbase = create_coinbase(height)
+        coinbase.rehash()
+        if spend == None:
+            # We need to have something to spend to fill the block.
+            block = create_block(base_block_hash, coinbase, block_time)
+        else:
+            # all but one satoshi to fees
+            coinbase.vout[0].nValue += spend.tx.vout[spend.n].nValue - 1
+            coinbase.rehash()
+            block = create_block(base_block_hash, coinbase, block_time)
+
+            # Make sure we have plenty enough to spend going forward.
+            spendable_outputs = deque([spend])
+
+            def get_base_transaction():
+                # Create the new transaction
+                tx = CTransaction()
+                # Spend from one of the spendable outputs
+                spend = spendable_outputs.popleft()
+                tx.vin.append(CTxIn(COutPoint(spend.tx.sha256, spend.n)))
+                # Add spendable outputs
+                for i in range(4):
+                    tx.vout.append(CTxOut(0, CScript([OP_TRUE])))
+                    spendable_outputs.append(PreviousSpendableOutput(tx, i))
+                return tx
+
+            tx = get_base_transaction()
+
+            # Make it the same format as transaction added for padding and save the size.
+            # It's missing the padding output, so we add a constant to account for it.
+            tx.rehash()
+            base_tx_size = len(tx.serialize()) + 18
+
+            # Put some random data into the first transaction of the chain to randomize ids.
+            tx.vout.append(
+                CTxOut(0, CScript([random.randint(0, 256), OP_RETURN])))
+
+            # Add the transaction to the block
+            self.add_transactions_to_block(block, [tx])
+
+            # If we have a transaction count requirement, just fill the block until we get there
+            while len(block.vtx) < tx_count:
+                # Create the new transaction and add it.
+                tx = get_base_transaction()
+                self.add_transactions_to_block(block, [tx])
+
+            # Now that we added a bunch of transaction, we need to recompute
+            # the merkle root.
+            block.hashMerkleRoot = block.calc_merkle_root()
+
+        if tx_count > 0:
+            assert_equal(len(block.vtx), tx_count)
+
+        # Do PoW, which is cheap on regnet
+        block.solve()
+        self.tip = block
+        self.block_heights[block.sha256] = height
+        assert number not in self.blocks
+        self.blocks[number] = block
+        return block
+
+    def get_tests(self):
+        node = self.nodes[0]
+        self.genesis_hash = int(node.getbestblockhash(), 16)
+        self.block_heights[self.genesis_hash] = 0
+        spendable_outputs = []
+
+        # save the current tip so it can be spent by a later block
+        def save_spendable_output():
+            spendable_outputs.append(self.tip)
+
+        # get an output that we previously marked as spendable
+        def get_spendable_output():
+            return PreviousSpendableOutput(spendable_outputs.pop(0).vtx[0], 0)
+
+        # returns a test case that asserts that the current tip was accepted
+        def accepted():
+            return TestInstance([[self.tip, True]])
+
+        # returns a test case that asserts that the current tip was rejected
+        def rejected(reject=None):
+            if reject is None:
+                return TestInstance([[self.tip, False]])
+            else:
+                return TestInstance([[self.tip, reject]])
+
+        # move the tip back to a previous block
+        def tip(number):
+            self.tip = self.blocks[number]
+
+        # adds transactions to the block and updates state
+        def update_block(block_number, new_transactions=[]):
+            block = self.blocks[block_number]
+            self.add_transactions_to_block(block, new_transactions)
+            old_sha256 = block.sha256
+            block.hashMerkleRoot = block.calc_merkle_root()
+            block.solve()
+            # Update the internal state just like in next_block
+            self.tip = block
+            if block.sha256 != old_sha256:
+                self.block_heights[block.sha256] = self.block_heights[old_sha256]
+                del self.block_heights[old_sha256]
+            self.blocks[block_number] = block
+            return block
+
+        # shorthand for functions
+        block = self.next_block
+
+        self.dbg("Create a new block")
+        block(0)
+        save_spendable_output()
+        yield accepted()
+
+        self.dbg("Now we need that block to mature so we can spend the coinbase.")
+        test = TestInstance(sync_every_block=False)
+        for i in range(99):
+            block(5000 + i)
+            test.blocks_and_transactions.append([self.tip, True])
+            save_spendable_output()
+        yield test
+
+        # collect spendable outputs now to avoid cluttering the code later on
+        out = []
+        for i in range(100):
+            out.append(get_spendable_output())
+
+        self.dbg("Let's build some blocks and test them.")
+        for i in range(15):
+            n = i + 1
+            block(n)
+            yield accepted()
+
+        self.dbg("Start moving MTP forward")
+        bfork = block(5555)
+        bfork.nTime = AOR_ACTIVATION_TIME - 1
+        update_block(5555)
+        yield accepted()
+
+        self.dbg("Get to one block of the Nov 15, 2018 HF activation")
+        for i in range(5):
+            block(5100 + i)
+            test.blocks_and_transactions.append([self.tip, True])
+        yield test
+
+        self.dbg("Check that the MTP is just before the configured fork point.")
+        assert_equal(node.getblockheader(node.getbestblockhash())['mediantime'],
+                     AOR_ACTIVATION_TIME - 1)
+
+        self.dbg("Before we activate the Nov 15, 2018 HF, transaction order is respected.")
+        def out_of_order_block(block_number, spend):
+            b = block(block_number, spend=spend, tx_count=3)
+            b.vtx[1], b.vtx[2] = b.vtx[2], b.vtx[1]
+            update_block(block_number)
+            return b
+
+        out_of_order_block(4444, out[16])
+        yield rejected(RejectResult(16, b'bad-txns-inputs-missingorspent'))
+
+        # Rewind bad block.
+        tip(5104)
+
+        self.dbg("Activate the Nov 15, 2018 HF")
+        block(5556)
+        yield accepted()
+
+        self.dbg("Now MTP is exactly the fork time.")
+        assert_equal(node.getblockheader(node.getbestblockhash())['mediantime'],
+                     AOR_ACTIVATION_TIME)
+
+        self.dbg("Now that the fork activated, we can put transactions out of order in the block.")
+        out_of_order_block(4445, out[16])
+        yield accepted()
+
+
+if __name__ == '__main__':
+    TransactionOrderingTest().main()

--- a/src/checkqueue.h
+++ b/src/checkqueue.h
@@ -16,7 +16,7 @@
 template <typename T>
 class CCheckQueueControl;
 
-/** 
+/**
  * Queue for verifications that have to be performed.
   * The verifications are represented by a type T, which must provide an
   * operator(), returning a bool.
@@ -146,15 +146,15 @@ public:
     void Add(std::vector<T>& vChecks)
     {
         boost::unique_lock<boost::mutex> lock(mutex);
-        BOOST_FOREACH (T& check, vChecks) {
-            queue.push_back(T());
-            check.swap(queue.back());
+        for (T &check : vChecks) {
+            queue.push_back(std::move(check));
         }
         nTodo += vChecks.size();
-        if (vChecks.size() == 1)
+        if (vChecks.size() == 1) {
             condWorker.notify_one();
-        else if (vChecks.size() > 1)
+        } else if (vChecks.size() > 1) {
             condWorker.notify_all();
+        }
     }
 
     ~CCheckQueue()
@@ -169,7 +169,7 @@ public:
 
 };
 
-/** 
+/**
  * RAII-style controller object for a CCheckQueue that guarantees the passed
  * queue is finished before continuing.
  */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1402,7 +1402,7 @@ void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, int nHeight)
 
 bool CScriptCheck::operator()() {
     const CScript &scriptSig = ptxTo->vin[nIn].scriptSig;
-    if (!VerifyScript(scriptSig, scriptPubKey, nFlags, CachingTransactionSignatureChecker(ptxTo, nIn, amount, cacheStore, *txdata), &error)) {
+    if (!VerifyScript(scriptSig, scriptPubKey, nFlags, CachingTransactionSignatureChecker(ptxTo, nIn, amount, cacheStore, txdata), &error)) {
         return ::error("CScriptCheck(): %s:%d VerifySignature failed: %s", ptxTo->GetHash().ToString(), nIn, ScriptErrorString(error));
     }
     return true;
@@ -1415,7 +1415,7 @@ int GetSpendHeight(const CCoinsViewCache& inputs)
     return pindexPrev->nHeight + 1;
 }
 
-bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &inputs, bool fScriptChecks, unsigned int flags, bool cacheStore, PrecomputedTransactionData& txdata, std::vector<CScriptCheck> *pvChecks)
+bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &inputs, bool fScriptChecks, unsigned int flags, bool cacheStore, const PrecomputedTransactionData& txdata, std::vector<CScriptCheck> *pvChecks)
 {
     if (!tx.IsCoinBase())
     {
@@ -1447,10 +1447,9 @@ bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsVi
                 const CAmount amount = coin.out.nValue;
 
                 // Verify signature
-                CScriptCheck check(scriptPubKey, amount, tx, i, flags, cacheStore, &txdata);
+                CScriptCheck check(scriptPubKey, amount, tx, i, flags, cacheStore, txdata);
                 if (pvChecks) {
-                    pvChecks->push_back(CScriptCheck());
-                    check.swap(pvChecks->back());
+                    pvChecks->push_back(std::move(check));
                 } else if (!check()) {
                     const bool hasNonMandatoryFlags
                         = (flags & STANDARD_NOT_MANDATORY_VERIFY_FLAGS) != 0;
@@ -1474,7 +1473,7 @@ bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsVi
                             | SCRIPT_ENABLE_MONOLITH_OPCODES;
 
                         CScriptCheck check2(scriptPubKey, amount, tx, i,
-                                flagsFiltered, cacheStore, &txdata);
+                                flagsFiltered, cacheStore, txdata);
 
                         if (check2())
                             return state.Invalid(false, REJECT_NONSTANDARD, strprintf("non-mandatory-script-verify-flag (%s)", ScriptErrorString(check.GetScriptError())));
@@ -1938,8 +1937,6 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     std::vector<std::pair<uint256, CDiskTxPos> > vPos;
     vPos.reserve(block.vtx.size());
     blockundo.vtxundo.reserve(block.vtx.size() - 1);
-    std::vector<PrecomputedTransactionData> txdata;
-    txdata.reserve(block.vtx.size()); // Required so that pointers to individual PrecomputedTransactionData don't get invalidated
     for (unsigned int i = 0; i < block.vtx.size(); i++)
     {
         const CTransaction &tx = block.vtx[i];
@@ -1986,7 +1983,6 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 return state.DoS(100, error("ConnectBlock(): too many sigops in tx"), REJECT_INVALID, "bad-txn-sigops");
             }
         }
-        txdata.emplace_back(tx);
         if (!tx.IsCoinBase())
         {
             nFees += view.GetValueIn(tx)-tx.GetValueOut();
@@ -1995,7 +1991,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             bool fCacheResults = fJustCheck; /* Don't cache results if we're actually connecting blocks (still consult the cache, though) */
             static auto nScriptCheckThreads = Opt().ScriptCheckThreads();
             if (!CheckInputs(tx, state, view, fScriptChecks, flags, fCacheResults,
-                             txdata[i], nScriptCheckThreads ? &vChecks : NULL))
+                             PrecomputedTransactionData(tx), nScriptCheckThreads ? &vChecks : NULL))
                 return false;
             control.Add(vChecks);
         }

--- a/src/main.h
+++ b/src/main.h
@@ -46,7 +46,6 @@ class CScriptCheck;
 class CValidationInterface;
 class CValidationState;
 
-struct PrecomputedTransactionData;
 struct CNodeStateStats;
 struct LockPoints;
 
@@ -310,7 +309,7 @@ CAmount GetMinRelayFee(const CTransaction& tx, unsigned int nBytes, bool fAllowF
  * instead of being performed inline.
  */
 bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &view, bool fScriptChecks,
-                 unsigned int flags, bool cacheStore, PrecomputedTransactionData& txdata, std::vector<CScriptCheck> *pvChecks = NULL);
+                 unsigned int flags, bool cacheStore, const PrecomputedTransactionData& txdata, std::vector<CScriptCheck> *pvChecks = nullptr);
 
 /** Apply the effects of this transaction on the UTXO set represented by view */
 void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, int nHeight);
@@ -358,11 +357,11 @@ private:
     unsigned int nFlags;
     bool cacheStore;
     ScriptError error;
-    PrecomputedTransactionData *txdata;
+    PrecomputedTransactionData txdata;
 
 public:
     CScriptCheck(): amount(0), ptxTo(0), nIn(0), nFlags(0), cacheStore(false), error(SCRIPT_ERR_UNKNOWN_ERROR) {}
-    CScriptCheck(const CScript& scriptPubKeyIn, const CAmount amountIn, const CTransaction& txToIn, unsigned int nInIn, unsigned int nFlagsIn, bool cacheIn, PrecomputedTransactionData* txdataIn) :
+    CScriptCheck(const CScript& scriptPubKeyIn, const CAmount amountIn, const CTransaction& txToIn, unsigned int nInIn, unsigned int nFlagsIn, bool cacheIn, const PrecomputedTransactionData& txdataIn) :
         scriptPubKey(scriptPubKeyIn), amount(amountIn),
         ptxTo(&txToIn), nIn(nInIn), nFlags(nFlagsIn), cacheStore(cacheIn), error(SCRIPT_ERR_UNKNOWN_ERROR), txdata(txdataIn)
     {

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -26,6 +26,11 @@ struct PrecomputedTransactionData
 {
     uint256 hashPrevouts, hashSequence, hashOutputs;
 
+    PrecomputedTransactionData()
+        : hashPrevouts(), hashSequence(), hashOutputs()
+    {
+    }
+
     PrecomputedTransactionData(const CTransaction& tx);
 };
 uint256 SignatureHash(const CScript &scriptCode, const CTransaction &txTo,

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -17,7 +17,8 @@
 
 #include <boost/test/unit_test.hpp>
 
-int ApplyTxInUndo(Coin&& undo, CCoinsViewCache& view, const COutPoint& out);
+enum class DisconnectResult;
+DisconnectResult ApplyTxInUndo(Coin undo, CCoinsViewCache& view, const COutPoint& out);
 void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo &txundo, int nHeight);
 
 namespace

--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(sign)
             const CTxOut& output = txFrom.vout[txTo[i].vin[0].prevout.n];
             bool sigOK = CScriptCheck(output.scriptPubKey, output.nValue, txTo[i], 0,
                     SCRIPT_VERIFY_P2SH | SCRIPT_ENABLE_SIGHASH_FORKID | SCRIPT_VERIFY_STRICTENC,
-                    false, &txdata)();
+                    false, PrecomputedTransactionData(txTo[i]))();
             if (i == j)
                 BOOST_CHECK_MESSAGE(sigOK, strprintf("VerifySignature %d %d", i, j));
             else

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -418,7 +418,7 @@ BOOST_AUTO_TEST_CASE(test_big_transaction) {
         std::vector<CScriptCheck> vChecks;
         const CTxOut& output = coins[tx.vin[i].prevout.n].out;
         CScriptCheck check(output.scriptPubKey, output.nValue,
-                tx, i, SCRIPT_VERIFY_P2SH, false, &txdata);
+                tx, i, SCRIPT_VERIFY_P2SH, false, txdata);
         vChecks.push_back(CScriptCheck());
         check.swap(vChecks.back());
         control.Add(vChecks);


### PR DESCRIPTION
* Make a copy of PrecomputedTransactionData in the CScriptCheck - https://reviews.bitcoinabc.org/D297
    * Did not move the header declaration of PrecomputedTransactionData
    * Did not add a copy constructor (we'll rely on implicitly-declared)

* Process transactions in two loops in ConnectBlock instead of one - https://reviews.bitcoinabc.org/D1484
    * Needed some patching. ABC has refactored the sigop counting.


* Remove topological ordering constraint from block starting Nov, 15 2018 - https://reviews.bitcoinabc.org/D1487
    * Test needed some patching due to test framework differences

* Update ApplyBlockUndo to be able to undo out of order blocks - https://reviews.bitcoinabc.org/D1528
    * Compiler started to complain about returning `int`, so I converted DisconnectResult into an `enum class`. The `class` attribute allows it to be forward declared in the tests.
    * Some minor patching due to ABC refactors