### PR TITLE
Convert signature hash type to enum class

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -161,6 +161,7 @@ BITCOIN_CORE_H = \
   script/sigcache.h \
   script/sign.h \
   script/standard.h \
+  script/sighashtype.h \
   streams.h \
   support/allocators/secure.h \
   support/allocators/zeroafterfree.h \
@@ -362,6 +363,7 @@ libbitcoin_common_a_SOURCES = \
   scheduler.cpp \
   script/sign.cpp \
   script/standard.cpp \
+  script/sighashtype.cpp \
   utxocommit.cpp \
   $(BITCOIN_CORE_H)
 

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -106,6 +106,7 @@ BITCOIN_TESTS =\
   test/scriptnum_tests.cpp \
   test/serialize_tests.cpp \
   test/sighash_tests.cpp \
+  test/sighashtype_tests.cpp \
   test/sigopcount_tests.cpp \
   test/skiplist_tests.cpp \
   test/streams_tests.cpp \

--- a/src/bench/verify_script.cpp
+++ b/src/bench/verify_script.cpp
@@ -8,6 +8,7 @@
 #include "script/bitcoinconsensus.h"
 #endif
 #include "script/script.h"
+#include "script/sighashtype.h"
 #include "script/sign.h"
 #include "streams.h"
 
@@ -66,12 +67,12 @@ static void VerifyScriptBench(benchmark::State& state)
     CTransaction txCredit = BuildCreditingTransaction(scriptPubKey);
     CMutableTransaction txSpend = BuildSpendingTransaction(scriptSig, txCredit);
 
-    uint256 hash = SignatureHash(scriptPubKey, txSpend, 0, SIGHASH_ALL | SIGHASH_FORKID, txCredit.vout[0].nValue);
+    uint256 hash = SignatureHash(scriptPubKey, txSpend, 0, SigHashType::ALL | SigHashType::FORKID, txCredit.vout[0].nValue);
     std::vector<uint8_t> sig;
     if (!key.Sign(hash, sig)) {
         assert(!"sign failed");
     }
-    sig.push_back(static_cast<uint8_t>(SIGHASH_ALL | SIGHASH_FORKID));
+    sig.push_back(static_cast<uint8_t>(SigHashType::ALL | SigHashType::FORKID));
     txSpend.vin[0].scriptSig = CScript() << sig << ToByteVector(pubkey);
 
     // Benchmark.

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -17,16 +17,7 @@ class CPubKey;
 class CScript;
 class CTransaction;
 class uint256;
-
-/** Signature hash types/flags */
-enum
-{
-    SIGHASH_ALL = 1,
-    SIGHASH_NONE = 2,
-    SIGHASH_SINGLE = 3,
-    SIGHASH_FORKID = 0x40,
-    SIGHASH_ANYONECANPAY = 0x80,
-};
+enum class SigHashType : uint32_t;
 
 /** Script verification flags */
 enum
@@ -110,7 +101,7 @@ struct PrecomputedTransactionData
     PrecomputedTransactionData(const CTransaction& tx);
 };
 uint256 SignatureHash(const CScript &scriptCode, const CTransaction &txTo,
-                        unsigned int nIn, uint32_t nHashType, const CAmount &amount,
+                        unsigned int nIn, SigHashType nHashType, const CAmount &amount,
                         unsigned int flags = SCRIPT_ENABLE_SIGHASH_FORKID,
                         const PrecomputedTransactionData* cache = nullptr);
 

--- a/src/script/sighashtype.cpp
+++ b/src/script/sighashtype.cpp
@@ -1,0 +1,65 @@
+#include "script/sighashtype.h"
+#include <map>
+#include <sstream>
+#include <stdexcept>
+
+SigHashType GetBaseType(SigHashType h) {
+    return h & static_cast<SigHashType>(0x1f);
+}
+SigHashType RemoveBaseType(SigHashType h) {
+    return h & ~GetBaseType(h);
+}
+
+static const std::map<std::string, SigHashType>& GetSigHashTypeMap() {
+    using T = SigHashType;
+    static std::map<std::string, SigHashType> mapSigHashValues = {
+        { "ALL", T::ALL },
+        { "ALL|ANYONECANPAY", T::ALL | T::ANYONECANPAY },
+        { "ALL|FORKID", T::ALL | T::FORKID },
+        { "ALL|FORKID|ANYONECANPAY", T::ALL | T::FORKID | T::ANYONECANPAY },
+        { "NONE", T::NONE },
+        { "NONE|ANYONECANPAY", T::NONE | T::ANYONECANPAY },
+        { "NONE|FORKID", T::NONE | T::FORKID },
+        { "NONE|FORKID|ANYONECANPAY", T::NONE | T::FORKID | T::ANYONECANPAY },
+        { "SINGLE", T::SINGLE },
+        { "SINGLE|ANYONECANPAY", T::SINGLE | T::ANYONECANPAY },
+        { "SINGLE|FORKID", T::SINGLE | T::FORKID },
+        { "SINGLE|FORKID|ANYONECANPAY", T::SINGLE | T::FORKID | T::ANYONECANPAY } };
+    return mapSigHashValues;
+}
+
+SigHashType FromStr(const std::string& sighashtype) {
+    auto map = GetSigHashTypeMap();
+    auto t = map.find(sighashtype);
+    if (t == end(map)) {
+        throw std::invalid_argument("Invalid sighash type '" + sighashtype + "'");
+    }
+    return t->second;
+}
+
+std::string ToStr(SigHashType h) {
+    auto map = GetSigHashTypeMap();
+    for (auto& t : map) {
+        if (t.second == h) {
+            return t.first;
+        }
+    }
+    std::stringstream ss;
+    ss << "Invalid sighashtype '" << static_cast<std::uint32_t>(h) << "'";
+    throw std::invalid_argument(ss.str());
+}
+
+std::uint32_t ToInt(SigHashType h) {
+    return static_cast<std::uint32_t>(h);
+}
+
+std::ostream& operator<<(std::ostream& stream,
+                     const SigHashType& h) {
+    try {
+        stream << ToStr(h);
+    }
+    catch (const std::invalid_argument&) {
+        stream << ToInt(h);
+    }
+    return stream;
+ }

--- a/src/script/sighashtype.h
+++ b/src/script/sighashtype.h
@@ -1,0 +1,57 @@
+#ifndef BITCOIN_SIGHASHTYPE_H
+#define BITCOIN_SIGHASHTYPE_H
+
+#include <string>
+#include <cstdint>
+
+/** Signature hash types/flags */
+enum class SigHashType : uint32_t
+{
+    UNDEFINED = 0,
+    ALL = 1,
+    NONE = 2,
+    SINGLE = 3,
+    FORKID = 0x40,
+    ANYONECANPAY = 0x80,
+};
+
+inline SigHashType operator|(SigHashType lhs, SigHashType rhs) {
+    return static_cast<SigHashType>(
+            static_cast<uint32_t>(lhs) | static_cast<uint32_t>(rhs));
+}
+
+inline SigHashType operator&(SigHashType lhs, SigHashType rhs) {
+    return static_cast<SigHashType>(
+            static_cast<uint32_t>(lhs) & static_cast<uint32_t>(rhs));
+}
+
+inline SigHashType operator~(SigHashType rhs) {
+    return static_cast<SigHashType>(~static_cast<uint32_t>(rhs));
+}
+
+inline bool operator!(SigHashType rhs) {
+    return !static_cast<uint32_t>(rhs);
+}
+
+inline SigHashType& operator|=(SigHashType& lhs, SigHashType rhs) {
+    lhs = static_cast<SigHashType>(
+            static_cast<uint32_t>(lhs) | static_cast<uint32_t>(rhs));
+    return lhs;
+}
+
+inline SigHashType& operator&=(SigHashType& lhs, SigHashType rhs) {
+    lhs = static_cast<SigHashType>(
+        static_cast<uint32_t>(lhs) & static_cast<uint32_t>(rhs));
+    return lhs;
+}
+
+SigHashType GetBaseType(SigHashType);
+SigHashType RemoveBaseType(SigHashType);
+
+SigHashType FromStr(const std::string& sighashtype);
+std::string ToStr(SigHashType);
+uint32_t ToInt(SigHashType);
+
+std::ostream& operator<<(std::ostream& stream, const SigHashType& h);
+
+#endif // BITCOIN_SIGHASHTYPE_H

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -35,11 +35,11 @@ class TransactionSignatureCreator : public BaseSignatureCreator {
     const CTransaction* txTo;
     unsigned int nIn;
     CAmount amount;
-    uint32_t nHashType;
+    SigHashType nHashType;
     const TransactionSignatureChecker checker;
 
 public:
-    TransactionSignatureCreator(const CKeyStore* keystoreIn, const CTransaction* txToIn, unsigned int nInIn, const CAmount &amountIn, uint32_t nHashTypeIn);
+    TransactionSignatureCreator(const CKeyStore* keystoreIn, const CTransaction* txToIn, unsigned int nInIn, const CAmount &amountIn, SigHashType nHashTypeIn);
     const BaseSignatureChecker& Checker() const override { return checker; }
     bool CreateSig(std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode) const override;
 };
@@ -56,8 +56,8 @@ public:
 bool ProduceSignature(const BaseSignatureCreator& creator, const CScript& scriptPubKey, CScript& scriptSig);
 
 /** Produce a script signature for a transaction. */
-bool SignSignature(const CKeyStore& keystore, const CScript& fromPubKey, CMutableTransaction& txTo, unsigned int nIn, const CAmount &amount, uint32_t nHashType);
-bool SignSignature(const CKeyStore& keystore, const CTransaction& txFrom, CMutableTransaction& txTo, unsigned int nIn, uint32_t nHashType);
+bool SignSignature(const CKeyStore& keystore, const CScript& fromPubKey, CMutableTransaction& txTo, unsigned int nIn, const CAmount &amount, SigHashType nHashType);
+bool SignSignature(const CKeyStore& keystore, const CTransaction& txFrom, CMutableTransaction& txTo, unsigned int nIn, SigHashType nHashType);
 
 /** Combine two script signatures using a generic signature checker, intelligently, possibly with OP_0 placeholders. */
 CScript CombineSignatures(const CScript& scriptPubKey, const BaseSignatureChecker& checker, const CScript& scriptSig1, const CScript& scriptSig2);

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -12,6 +12,7 @@
 #include "main.h"
 #include "net.h"
 #include "pow.h"
+#include "script/sighashtype.h"
 #include "script/sign.h"
 #include "serialize.h"
 #include "util.h"
@@ -171,7 +172,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         tx.vout.resize(1);
         tx.vout[0].nValue = 1*CENT;
         tx.vout[0].scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());
-        SignSignature(keystore, txPrev, tx, 0, SIGHASH_ALL | SIGHASH_FORKID);
+        SignSignature(keystore, txPrev, tx, 0, SigHashType::ALL | SigHashType::FORKID);
 
         AddOrphanTx(tx, i);
     }
@@ -191,7 +192,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
             tx.vin[j].prevout.n = j;
             tx.vin[j].prevout.hash = txPrev.GetHash();
         }
-        SignSignature(keystore, txPrev, tx, 0, SIGHASH_ALL | SIGHASH_FORKID);
+        SignSignature(keystore, txPrev, tx, 0, SigHashType::ALL | SigHashType::FORKID);
         // Re-use same signature for other inputs
         // (they don't have to be valid for this test)
         for (unsigned int j = 1; j < tx.vin.size(); j++)

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -5,11 +5,12 @@
 #include "key.h"
 #include "keystore.h"
 #include "policy/policy.h"
+#include "script/interpreter.h"
+#include "script/ismine.h"
 #include "script/script.h"
 #include "script/script_error.h"
-#include "script/interpreter.h"
+#include "script/sighashtype.h"
 #include "script/sign.h"
-#include "script/ismine.h"
 #include "uint256.h"
 #include "test/test_bitcoin.h"
 
@@ -26,7 +27,7 @@ BOOST_FIXTURE_TEST_SUITE(multisig_tests, BasicTestingSetup)
 CScript
 sign_multisig(CScript scriptPubKey, vector<CKey> keys, CTransaction transaction, int whichIn)
 {
-    uint256 hash = SignatureHash(scriptPubKey, transaction, whichIn, SIGHASH_ALL | SIGHASH_FORKID, 0);
+    uint256 hash = SignatureHash(scriptPubKey, transaction, whichIn, SigHashType::ALL | SigHashType::FORKID, 0);
 
     CScript result;
     result << OP_0; // CHECKMULTISIG bug workaround
@@ -34,7 +35,7 @@ sign_multisig(CScript scriptPubKey, vector<CKey> keys, CTransaction transaction,
     {
         vector<unsigned char> vchSig;
         BOOST_CHECK(key.Sign(hash, vchSig));
-        vchSig.push_back((unsigned char)(SIGHASH_ALL | SIGHASH_FORKID));
+        vchSig.push_back(static_cast<unsigned char>(SigHashType::ALL | SigHashType::FORKID));
         result << vchSig;
     }
     return result;
@@ -303,7 +304,7 @@ BOOST_AUTO_TEST_CASE(multisig_Sign)
 
     for (int i = 0; i < 3; i++)
     {
-        BOOST_CHECK_MESSAGE(SignSignature(keystore, txFrom, txTo[i], 0, SIGHASH_ALL | SIGHASH_FORKID), strprintf("SignSignature %d", i));
+        BOOST_CHECK_MESSAGE(SignSignature(keystore, txFrom, txTo[i], 0, SigHashType::ALL | SigHashType::FORKID), strprintf("SignSignature %d", i));
     }
 }
 

--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -8,10 +8,11 @@
 #include "keystore.h"
 #include "main.h"
 #include "policy/policy.h"
+#include "script/ismine.h"
 #include "script/script.h"
 #include "script/script_error.h"
+#include "script/sighashtype.h"
 #include "script/sign.h"
-#include "script/ismine.h"
 #include "test/test_bitcoin.h"
 
 #include <vector>
@@ -44,7 +45,7 @@ Verify(const CScript& scriptSig, const CScript& scriptPubKey, bool fStrict, Scri
     txTo.vin[0].scriptSig = scriptSig;
     txTo.vout[0].nValue = 1;
 
-    return VerifyScript(scriptSig, scriptPubKey, fStrict ? SCRIPT_VERIFY_P2SH | SIGHASH_FORKID: SCRIPT_VERIFY_NONE, MutableTransactionSignatureChecker(&txTo, 0, txFrom.vout[0].nValue), &err);
+    return VerifyScript(scriptSig, scriptPubKey, fStrict ? SCRIPT_VERIFY_P2SH | SCRIPT_ENABLE_SIGHASH_FORKID: SCRIPT_VERIFY_NONE, MutableTransactionSignatureChecker(&txTo, 0, txFrom.vout[0].nValue), &err);
 }
 
 
@@ -104,7 +105,7 @@ BOOST_AUTO_TEST_CASE(sign)
     }
     for (int i = 0; i < 8; i++)
     {
-        BOOST_CHECK_MESSAGE(SignSignature(keystore, txFrom, txTo[i], 0, SIGHASH_ALL | SIGHASH_FORKID), strprintf("SignSignature %d", i));
+        BOOST_CHECK_MESSAGE(SignSignature(keystore, txFrom, txTo[i], 0, SigHashType::ALL | SigHashType::FORKID), strprintf("SignSignature %d", i));
     }
     // All of the above should be OK, and the txTos have valid signatures
     // Check to make sure signature verification fails if we use the wrong ScriptSig:
@@ -204,7 +205,7 @@ BOOST_AUTO_TEST_CASE(set)
     }
     for (int i = 0; i < 4; i++)
     {
-        BOOST_CHECK_MESSAGE(SignSignature(keystore, txFrom, txTo[i], 0, SIGHASH_ALL | SIGHASH_FORKID), strprintf("SignSignature %d", i));
+        BOOST_CHECK_MESSAGE(SignSignature(keystore, txFrom, txTo[i], 0, SigHashType::ALL | SigHashType::FORKID), strprintf("SignSignature %d", i));
         BOOST_CHECK_MESSAGE(IsStandardTx(txTo[i], reason), strprintf("txTo[%d].IsStandard", i));
     }
 }
@@ -333,9 +334,9 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
         txTo.vin[i].prevout.n = i;
         txTo.vin[i].prevout.hash = txFrom.GetHash();
     }
-    BOOST_CHECK(SignSignature(keystore, txFrom, txTo, 0, SIGHASH_ALL | SIGHASH_FORKID));
-    BOOST_CHECK(SignSignature(keystore, txFrom, txTo, 1, SIGHASH_ALL | SIGHASH_FORKID));
-    BOOST_CHECK(SignSignature(keystore, txFrom, txTo, 2, SIGHASH_ALL | SIGHASH_FORKID));
+    BOOST_CHECK(SignSignature(keystore, txFrom, txTo, 0, SigHashType::ALL | SigHashType::FORKID));
+    BOOST_CHECK(SignSignature(keystore, txFrom, txTo, 1, SigHashType::ALL | SigHashType::FORKID));
+    BOOST_CHECK(SignSignature(keystore, txFrom, txTo, 2, SigHashType::ALL | SigHashType::FORKID));
     // SignSignature doesn't know how to sign these. We're
     // not testing validating signatures, so just create
     // dummy signatures that DO include the correct P2SH scripts:

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -11,6 +11,7 @@
 #include "rpc/server.h"
 #include "script/script.h"
 #include "script/script_error.h"
+#include "script/sighashtype.h"
 #include "script/sign.h"
 #include "util.h"
 #include "test/test_bitcoin.h"
@@ -35,9 +36,6 @@ using namespace std;
 // #define UPDATE_JSON_TESTS
 
 static const unsigned int flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC;
-
-// Invalid sighashtype
-static const unsigned int SIGHASH_BUG = 0x20;
 
 unsigned int ParseScriptFlags(string strFlags);
 string FormatScriptFlags(unsigned int flags);
@@ -321,7 +319,7 @@ public:
         return *this;
     }
 
-    TestBuilder& PushSig(const CKey& key, int nHashType = SIGHASH_ALL, unsigned int lenR = 32, unsigned int lenS = 32, CAmount amount = 0, uint32_t flags = SCRIPT_ENABLE_SIGHASH_FORKID)
+    TestBuilder& PushSig(const CKey& key, SigHashType nHashType = SigHashType::ALL, unsigned int lenR = 32, unsigned int lenS = 32, CAmount amount = 0, uint32_t flags = SCRIPT_ENABLE_SIGHASH_FORKID)
     {
         uint256 hash = SignatureHash(script, spendTx, 0, nHashType, amount, flags);
         std::vector<unsigned char> vchSig, r, s;
@@ -443,10 +441,10 @@ BOOST_AUTO_TEST_CASE(script_build)
 
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1) << OP_CHECKSIG,
                                 "P2PK anyonecanpay", 0
-                               ).PushSig(keys.key1, SIGHASH_ALL | SIGHASH_ANYONECANPAY));
+                                ).PushSig(keys.key1, SigHashType::ALL | SigHashType::ANYONECANPAY));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1) << OP_CHECKSIG,
                                 "P2PK anyonecanpay marked with normal hashtype", 0
-                               ).PushSig(keys.key1, SIGHASH_ALL | SIGHASH_ANYONECANPAY).EditPush(70, "81", "01").ScriptError(SCRIPT_ERR_EVAL_FALSE));
+                                ).PushSig(keys.key1, SigHashType::ALL | SigHashType::ANYONECANPAY).EditPush(70, "81", "01").ScriptError(SCRIPT_ERR_EVAL_FALSE));
 
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0C) << OP_CHECKSIG,
                                 "P2SH(P2PK)", SCRIPT_VERIFY_P2SH, true
@@ -478,47 +476,47 @@ BOOST_AUTO_TEST_CASE(script_build)
 
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1C) << OP_CHECKSIG,
                                 "P2PK with too much R padding but no DERSIG", 0
-                               ).PushSig(keys.key1, SIGHASH_ALL, 31, 32).EditPush(1, "43021F", "44022000"));
+                               ).PushSig(keys.key1, SigHashType::ALL, 31, 32).EditPush(1, "43021F", "44022000"));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1C) << OP_CHECKSIG,
                                 "P2PK with too much R padding", SCRIPT_VERIFY_DERSIG
-                               ).PushSig(keys.key1, SIGHASH_ALL, 31, 32).EditPush(1, "43021F", "44022000").ScriptError(SCRIPT_ERR_SIG_DER));
+                               ).PushSig(keys.key1, SigHashType::ALL, 31, 32).EditPush(1, "43021F", "44022000").ScriptError(SCRIPT_ERR_SIG_DER));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1C) << OP_CHECKSIG,
                                 "P2PK with too much S padding but no DERSIG", 0
-                               ).PushSig(keys.key1, SIGHASH_ALL).EditPush(1, "44", "45").EditPush(37, "20", "2100"));
+                               ).PushSig(keys.key1, SigHashType::ALL).EditPush(1, "44", "45").EditPush(37, "20", "2100"));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1C) << OP_CHECKSIG,
                                 "P2PK with too much S padding", SCRIPT_VERIFY_DERSIG
-                               ).PushSig(keys.key1, SIGHASH_ALL).EditPush(1, "44", "45").EditPush(37, "20", "2100").ScriptError(SCRIPT_ERR_SIG_DER));
+                               ).PushSig(keys.key1, SigHashType::ALL).EditPush(1, "44", "45").EditPush(37, "20", "2100").ScriptError(SCRIPT_ERR_SIG_DER));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1C) << OP_CHECKSIG,
                                 "P2PK with too little R padding but no DERSIG", 0
-                               ).PushSig(keys.key1, SIGHASH_ALL, 33, 32).EditPush(1, "45022100", "440220"));
+                               ).PushSig(keys.key1, SigHashType::ALL, 33, 32).EditPush(1, "45022100", "440220"));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1C) << OP_CHECKSIG,
                                 "P2PK with too little R padding", SCRIPT_VERIFY_DERSIG
-                               ).PushSig(keys.key1, SIGHASH_ALL, 33, 32).EditPush(1, "45022100", "440220").ScriptError(SCRIPT_ERR_SIG_DER));
+                               ).PushSig(keys.key1, SigHashType::ALL, 33, 32).EditPush(1, "45022100", "440220").ScriptError(SCRIPT_ERR_SIG_DER));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey2C) << OP_CHECKSIG << OP_NOT,
                                 "P2PK NOT with bad sig with too much R padding but no DERSIG", 0
-                               ).PushSig(keys.key2, SIGHASH_ALL, 31, 32).EditPush(1, "43021F", "44022000").DamagePush(10));
+                               ).PushSig(keys.key2, SigHashType::ALL, 31, 32).EditPush(1, "43021F", "44022000").DamagePush(10));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey2C) << OP_CHECKSIG << OP_NOT,
                                 "P2PK NOT with bad sig with too much R padding", SCRIPT_VERIFY_DERSIG
-                               ).PushSig(keys.key2, SIGHASH_ALL, 31, 32).EditPush(1, "43021F", "44022000").DamagePush(10).ScriptError(SCRIPT_ERR_SIG_DER));
+                               ).PushSig(keys.key2, SigHashType::ALL, 31, 32).EditPush(1, "43021F", "44022000").DamagePush(10).ScriptError(SCRIPT_ERR_SIG_DER));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey2C) << OP_CHECKSIG << OP_NOT,
                                 "P2PK NOT with too much R padding but no DERSIG", 0
-                               ).PushSig(keys.key2, SIGHASH_ALL, 31, 32).EditPush(1, "43021F", "44022000").ScriptError(SCRIPT_ERR_EVAL_FALSE));
+                               ).PushSig(keys.key2, SigHashType::ALL, 31, 32).EditPush(1, "43021F", "44022000").ScriptError(SCRIPT_ERR_EVAL_FALSE));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey2C) << OP_CHECKSIG << OP_NOT,
                                 "P2PK NOT with too much R padding", SCRIPT_VERIFY_DERSIG
-                               ).PushSig(keys.key2, SIGHASH_ALL, 31, 32).EditPush(1, "43021F", "44022000").ScriptError(SCRIPT_ERR_SIG_DER));
+                               ).PushSig(keys.key2, SigHashType::ALL, 31, 32).EditPush(1, "43021F", "44022000").ScriptError(SCRIPT_ERR_SIG_DER));
 
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1C) << OP_CHECKSIG,
                                 "BIP66 example 1, without DERSIG", 0
-                               ).PushSig(keys.key1, SIGHASH_ALL, 33, 32).EditPush(1, "45022100", "440220"));
+                               ).PushSig(keys.key1, SigHashType::ALL, 33, 32).EditPush(1, "45022100", "440220"));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1C) << OP_CHECKSIG,
                                 "BIP66 example 1, with DERSIG", SCRIPT_VERIFY_DERSIG
-                               ).PushSig(keys.key1, SIGHASH_ALL, 33, 32).EditPush(1, "45022100", "440220").ScriptError(SCRIPT_ERR_SIG_DER));
+                               ).PushSig(keys.key1, SigHashType::ALL, 33, 32).EditPush(1, "45022100", "440220").ScriptError(SCRIPT_ERR_SIG_DER));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1C) << OP_CHECKSIG << OP_NOT,
                                 "BIP66 example 2, without DERSIG", 0
-                               ).PushSig(keys.key1, SIGHASH_ALL, 33, 32).EditPush(1, "45022100", "440220").ScriptError(SCRIPT_ERR_EVAL_FALSE));
+                               ).PushSig(keys.key1, SigHashType::ALL, 33, 32).EditPush(1, "45022100", "440220").ScriptError(SCRIPT_ERR_EVAL_FALSE));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1C) << OP_CHECKSIG << OP_NOT,
                                 "BIP66 example 2, with DERSIG", SCRIPT_VERIFY_DERSIG
-                               ).PushSig(keys.key1, SIGHASH_ALL, 33, 32).EditPush(1, "45022100", "440220").ScriptError(SCRIPT_ERR_SIG_DER));
+                               ).PushSig(keys.key1, SigHashType::ALL, 33, 32).EditPush(1, "45022100", "440220").ScriptError(SCRIPT_ERR_SIG_DER));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1C) << OP_CHECKSIG,
                                 "BIP66 example 3, without DERSIG", 0
                                ).Num(0).ScriptError(SCRIPT_ERR_EVAL_FALSE));
@@ -563,103 +561,107 @@ BOOST_AUTO_TEST_CASE(script_build)
                                ).Num(1).ScriptError(SCRIPT_ERR_SIG_DER));
     tests.push_back(TestBuilder(CScript() << OP_2 << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey2C) << OP_2 << OP_CHECKMULTISIG,
                                 "BIP66 example 7, without DERSIG", 0
-                               ).Num(0).PushSig(keys.key1, SIGHASH_ALL, 33, 32).EditPush(1, "45022100", "440220").PushSig(keys.key2));
+                               ).Num(0).PushSig(keys.key1, SigHashType::ALL, 33, 32).EditPush(1, "45022100", "440220").PushSig(keys.key2));
     tests.push_back(TestBuilder(CScript() << OP_2 << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey2C) << OP_2 << OP_CHECKMULTISIG,
                                 "BIP66 example 7, with DERSIG", SCRIPT_VERIFY_DERSIG
-                               ).Num(0).PushSig(keys.key1, SIGHASH_ALL, 33, 32).EditPush(1, "45022100", "440220").PushSig(keys.key2).ScriptError(SCRIPT_ERR_SIG_DER));
+                               ).Num(0).PushSig(keys.key1, SigHashType::ALL, 33, 32).EditPush(1, "45022100", "440220").PushSig(keys.key2).ScriptError(SCRIPT_ERR_SIG_DER));
     tests.push_back(TestBuilder(CScript() << OP_2 << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey2C) << OP_2 << OP_CHECKMULTISIG << OP_NOT,
                                 "BIP66 example 8, without DERSIG", 0
-                               ).Num(0).PushSig(keys.key1, SIGHASH_ALL, 33, 32).EditPush(1, "45022100", "440220").PushSig(keys.key2).ScriptError(SCRIPT_ERR_EVAL_FALSE));
+                               ).Num(0).PushSig(keys.key1, SigHashType::ALL, 33, 32).EditPush(1, "45022100", "440220").PushSig(keys.key2).ScriptError(SCRIPT_ERR_EVAL_FALSE));
     tests.push_back(TestBuilder(CScript() << OP_2 << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey2C) << OP_2 << OP_CHECKMULTISIG << OP_NOT,
                                 "BIP66 example 8, with DERSIG", SCRIPT_VERIFY_DERSIG
-                               ).Num(0).PushSig(keys.key1, SIGHASH_ALL, 33, 32).EditPush(1, "45022100", "440220").PushSig(keys.key2).ScriptError(SCRIPT_ERR_SIG_DER));
+                               ).Num(0).PushSig(keys.key1, SigHashType::ALL, 33, 32).EditPush(1, "45022100", "440220").PushSig(keys.key2).ScriptError(SCRIPT_ERR_SIG_DER));
     tests.push_back(TestBuilder(CScript() << OP_2 << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey2C) << OP_2 << OP_CHECKMULTISIG,
                                 "BIP66 example 9, without DERSIG", 0
-                               ).Num(0).Num(0).PushSig(keys.key2, SIGHASH_ALL, 33, 32).EditPush(1, "45022100", "440220").ScriptError(SCRIPT_ERR_EVAL_FALSE));
+                               ).Num(0).Num(0).PushSig(keys.key2, SigHashType::ALL, 33, 32).EditPush(1, "45022100", "440220").ScriptError(SCRIPT_ERR_EVAL_FALSE));
     tests.push_back(TestBuilder(CScript() << OP_2 << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey2C) << OP_2 << OP_CHECKMULTISIG,
                                 "BIP66 example 9, with DERSIG", SCRIPT_VERIFY_DERSIG
-                               ).Num(0).Num(0).PushSig(keys.key2, SIGHASH_ALL, 33, 32).EditPush(1, "45022100", "440220").ScriptError(SCRIPT_ERR_SIG_DER));
+                               ).Num(0).Num(0).PushSig(keys.key2, SigHashType::ALL, 33, 32).EditPush(1, "45022100", "440220").ScriptError(SCRIPT_ERR_SIG_DER));
     tests.push_back(TestBuilder(CScript() << OP_2 << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey2C) << OP_2 << OP_CHECKMULTISIG << OP_NOT,
                                 "BIP66 example 10, without DERSIG", 0
-                               ).Num(0).Num(0).PushSig(keys.key2, SIGHASH_ALL, 33, 32).EditPush(1, "45022100", "440220"));
+                               ).Num(0).Num(0).PushSig(keys.key2, SigHashType::ALL, 33, 32).EditPush(1, "45022100", "440220"));
     tests.push_back(TestBuilder(CScript() << OP_2 << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey2C) << OP_2 << OP_CHECKMULTISIG << OP_NOT,
                                 "BIP66 example 10, with DERSIG", SCRIPT_VERIFY_DERSIG
-                               ).Num(0).Num(0).PushSig(keys.key2, SIGHASH_ALL, 33, 32).EditPush(1, "45022100", "440220").ScriptError(SCRIPT_ERR_SIG_DER));
+                               ).Num(0).Num(0).PushSig(keys.key2, SigHashType::ALL, 33, 32).EditPush(1, "45022100", "440220").ScriptError(SCRIPT_ERR_SIG_DER));
     tests.push_back(TestBuilder(CScript() << OP_2 << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey2C) << OP_2 << OP_CHECKMULTISIG,
                                 "BIP66 example 11, without DERSIG", 0
-                               ).Num(0).PushSig(keys.key1, SIGHASH_ALL, 33, 32).EditPush(1, "45022100", "440220").Num(0).ScriptError(SCRIPT_ERR_EVAL_FALSE));
+                               ).Num(0).PushSig(keys.key1, SigHashType::ALL, 33, 32).EditPush(1, "45022100", "440220").Num(0).ScriptError(SCRIPT_ERR_EVAL_FALSE));
     tests.push_back(TestBuilder(CScript() << OP_2 << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey2C) << OP_2 << OP_CHECKMULTISIG,
                                 "BIP66 example 11, with DERSIG", SCRIPT_VERIFY_DERSIG
-                               ).Num(0).PushSig(keys.key1, SIGHASH_ALL, 33, 32).EditPush(1, "45022100", "440220").Num(0).ScriptError(SCRIPT_ERR_EVAL_FALSE));
+                               ).Num(0).PushSig(keys.key1, SigHashType::ALL, 33, 32).EditPush(1, "45022100", "440220").Num(0).ScriptError(SCRIPT_ERR_EVAL_FALSE));
     tests.push_back(TestBuilder(CScript() << OP_2 << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey2C) << OP_2 << OP_CHECKMULTISIG << OP_NOT,
                                 "BIP66 example 12, without DERSIG", 0
-                               ).Num(0).PushSig(keys.key1, SIGHASH_ALL, 33, 32).EditPush(1, "45022100", "440220").Num(0));
+                               ).Num(0).PushSig(keys.key1, SigHashType::ALL, 33, 32).EditPush(1, "45022100", "440220").Num(0));
     tests.push_back(TestBuilder(CScript() << OP_2 << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey2C) << OP_2 << OP_CHECKMULTISIG << OP_NOT,
                                 "BIP66 example 12, with DERSIG", SCRIPT_VERIFY_DERSIG
-                               ).Num(0).PushSig(keys.key1, SIGHASH_ALL, 33, 32).EditPush(1, "45022100", "440220").Num(0));
+                               ).Num(0).PushSig(keys.key1, SigHashType::ALL, 33, 32).EditPush(1, "45022100", "440220").Num(0));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey2C) << OP_CHECKSIG,
                                 "P2PK with multi-byte hashtype, without DERSIG", 0
-                               ).PushSig(keys.key2, SIGHASH_ALL).EditPush(70, "01", "0101"));
+                               ).PushSig(keys.key2, SigHashType::ALL).EditPush(70, "01", "0101"));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey2C) << OP_CHECKSIG,
                                 "P2PK with multi-byte hashtype, with DERSIG", SCRIPT_VERIFY_DERSIG
-                               ).PushSig(keys.key2, SIGHASH_ALL).EditPush(70, "01", "0101").ScriptError(SCRIPT_ERR_SIG_DER));
+                               ).PushSig(keys.key2, SigHashType::ALL).EditPush(70, "01", "0101").ScriptError(SCRIPT_ERR_SIG_DER));
 
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey2C) << OP_CHECKSIG,
                                 "P2PK with high S but no LOW_S", 0
-                               ).PushSig(keys.key2, SIGHASH_ALL, 32, 33));
+                               ).PushSig(keys.key2, SigHashType::ALL, 32, 33));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey2C) << OP_CHECKSIG,
                                 "P2PK with high S", SCRIPT_VERIFY_LOW_S
-                               ).PushSig(keys.key2, SIGHASH_ALL, 32, 33).ScriptError(SCRIPT_ERR_SIG_HIGH_S));
+                               ).PushSig(keys.key2, SigHashType::ALL, 32, 33).ScriptError(SCRIPT_ERR_SIG_HIGH_S));
 
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0H) << OP_CHECKSIG,
                                 "P2PK with hybrid pubkey but no STRICTENC", 0
-                               ).PushSig(keys.key0, SIGHASH_ALL));
+                               ).PushSig(keys.key0, SigHashType::ALL));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0H) << OP_CHECKSIG,
                                 "P2PK with hybrid pubkey", SCRIPT_VERIFY_STRICTENC
-                               ).PushSig(keys.key0, SIGHASH_ALL).ScriptError(SCRIPT_ERR_PUBKEYTYPE));
+                               ).PushSig(keys.key0, SigHashType::ALL).ScriptError(SCRIPT_ERR_PUBKEYTYPE));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0H) << OP_CHECKSIG << OP_NOT,
                                 "P2PK NOT with hybrid pubkey but no STRICTENC", 0
-                               ).PushSig(keys.key0, SIGHASH_ALL).ScriptError(SCRIPT_ERR_EVAL_FALSE));
+                               ).PushSig(keys.key0, SigHashType::ALL).ScriptError(SCRIPT_ERR_EVAL_FALSE));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0H) << OP_CHECKSIG << OP_NOT,
                                 "P2PK NOT with hybrid pubkey", SCRIPT_VERIFY_STRICTENC
-                               ).PushSig(keys.key0, SIGHASH_ALL).ScriptError(SCRIPT_ERR_PUBKEYTYPE));
+                               ).PushSig(keys.key0, SigHashType::ALL).ScriptError(SCRIPT_ERR_PUBKEYTYPE));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0H) << OP_CHECKSIG << OP_NOT,
                                 "P2PK NOT with invalid hybrid pubkey but no STRICTENC", 0
-                               ).PushSig(keys.key0, SIGHASH_ALL).DamagePush(10));
+                               ).PushSig(keys.key0, SigHashType::ALL).DamagePush(10));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0H) << OP_CHECKSIG << OP_NOT,
                                 "P2PK NOT with invalid hybrid pubkey", SCRIPT_VERIFY_STRICTENC
-                               ).PushSig(keys.key0, SIGHASH_ALL).DamagePush(10).ScriptError(SCRIPT_ERR_PUBKEYTYPE));
+                               ).PushSig(keys.key0, SigHashType::ALL).DamagePush(10).ScriptError(SCRIPT_ERR_PUBKEYTYPE));
     tests.push_back(TestBuilder(CScript() << OP_1 << ToByteVector(keys.pubkey0H) << ToByteVector(keys.pubkey1C) << OP_2 << OP_CHECKMULTISIG,
                                 "1-of-2 with the second 1 hybrid pubkey and no STRICTENC", 0
-                               ).Num(0).PushSig(keys.key1, SIGHASH_ALL));
+                               ).Num(0).PushSig(keys.key1, SigHashType::ALL));
     tests.push_back(TestBuilder(CScript() << OP_1 << ToByteVector(keys.pubkey0H) << ToByteVector(keys.pubkey1C) << OP_2 << OP_CHECKMULTISIG,
                                 "1-of-2 with the second 1 hybrid pubkey", SCRIPT_VERIFY_STRICTENC
-                               ).Num(0).PushSig(keys.key1, SIGHASH_ALL));
+                               ).Num(0).PushSig(keys.key1, SigHashType::ALL));
     tests.push_back(TestBuilder(CScript() << OP_1 << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey0H) << OP_2 << OP_CHECKMULTISIG,
                                 "1-of-2 with the first 1 hybrid pubkey", SCRIPT_VERIFY_STRICTENC
-                               ).Num(0).PushSig(keys.key1, SIGHASH_ALL).ScriptError(SCRIPT_ERR_PUBKEYTYPE));
+                               ).Num(0).PushSig(keys.key1, SigHashType::ALL).ScriptError(SCRIPT_ERR_PUBKEYTYPE));
 
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1) << OP_CHECKSIG,
                                 "P2PK with undefined hashtype but no STRICTENC", 0
-                               ).PushSig(keys.key1, 5));
+                                ).PushSig(keys.key1, SigHashType(5)));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1) << OP_CHECKSIG,
                                 "P2PK with undefined hashtype", SCRIPT_VERIFY_STRICTENC
-                               ).PushSig(keys.key1, 5).ScriptError(SCRIPT_ERR_SIG_HASHTYPE));
+                                ).PushSig(keys.key1, SigHashType(5)).ScriptError(SCRIPT_ERR_SIG_HASHTYPE));
 
     // Generate P2PKH tests for invalid SigHashType
+
+    // Invalid sighashtype
+    const SigHashType SIGHASH_BUG = SigHashType(0x20);
+
     tests.push_back(
         TestBuilder(CScript() << OP_DUP << OP_HASH160
                               << ToByteVector(keys.pubkey0.GetID())
                               << OP_EQUALVERIFY << OP_CHECKSIG,
                     "P2PKH with invalid sighashtype", 0)
-            .PushSig(keys.key0, SIGHASH_BUG | SIGHASH_ALL, 32, 32, CAmount(0), 0)
+            .PushSig(keys.key0, SIGHASH_BUG | SigHashType::ALL, 32, 32, CAmount(0), 0)
             .Push(keys.pubkey0));
     tests.push_back(TestBuilder(CScript() << OP_DUP << OP_HASH160
                                           << ToByteVector(keys.pubkey0.GetID())
                                           << OP_EQUALVERIFY << OP_CHECKSIG,
                                 "P2PKH with invalid sighashtype and STRICTENC",
                                 SCRIPT_VERIFY_STRICTENC)
-                        .PushSig(keys.key0, SIGHASH_BUG | SIGHASH_ALL, 32, 32,
+                        .PushSig(keys.key0, SIGHASH_BUG | SigHashType::ALL, 32, 32,
                                  CAmount(0), SCRIPT_VERIFY_STRICTENC)
                         .Push(keys.pubkey0)
                         // Should fail for STRICTENC
@@ -670,23 +672,23 @@ BOOST_AUTO_TEST_CASE(script_build)
         TestBuilder(CScript() << ToByteVector(keys.pubkey1) << OP_CHECKSIG,
                     "P2SH(P2PK) with invalid sighashtype", SCRIPT_VERIFY_P2SH,
                     true)
-            .PushSig(keys.key1, SIGHASH_BUG | SIGHASH_ALL)
+            .PushSig(keys.key1, SIGHASH_BUG | SigHashType::ALL)
             .PushRedeem());
     tests.push_back(
         TestBuilder(CScript() << ToByteVector(keys.pubkey1) << OP_CHECKSIG,
                     "P2SH(P2PK) with invalid sighashtype and STRICTENC",
                     SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC, true)
-            .PushSig(keys.key1, SIGHASH_BUG | SIGHASH_ALL)
+            .PushSig(keys.key1, SIGHASH_BUG | SigHashType::ALL)
             .PushRedeem()
             // Should fail for STRICTENC
             .ScriptError(SCRIPT_ERR_SIG_HASHTYPE));
 
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1) << OP_CHECKSIG << OP_NOT,
                                 "P2PK NOT with invalid sig and undefined hashtype but no STRICTENC", 0
-                               ).PushSig(keys.key1, 5).DamagePush(10));
+                                ).PushSig(keys.key1, SigHashType(5)).DamagePush(10));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey1) << OP_CHECKSIG << OP_NOT,
                                 "P2PK NOT with invalid sig and undefined hashtype", SCRIPT_VERIFY_STRICTENC
-                               ).PushSig(keys.key1, 5).DamagePush(10).ScriptError(SCRIPT_ERR_SIG_HASHTYPE));
+                                ).PushSig(keys.key1, SigHashType(5)).DamagePush(10).ScriptError(SCRIPT_ERR_SIG_HASHTYPE));
 
     tests.push_back(TestBuilder(CScript() << OP_3 << ToByteVector(keys.pubkey0C) << ToByteVector(keys.pubkey1C) << ToByteVector(keys.pubkey2C) << OP_3 << OP_CHECKMULTISIG,
                                 "3-of-3 with nonzero dummy but no NULLDUMMY", 0
@@ -741,14 +743,14 @@ BOOST_AUTO_TEST_CASE(script_build)
     static const CAmount TEST_AMOUNT = 12345000000000;
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0) << OP_CHECKSIG,
                                 "P2PK FORKID", SCRIPT_ENABLE_SIGHASH_FORKID, false, TEST_AMOUNT
-                               ).PushSig(keys.key0, SIGHASH_ALL | SIGHASH_FORKID, 32, 32, TEST_AMOUNT));
+                               ).PushSig(keys.key0, SigHashType::ALL | SigHashType::FORKID, 32, 32, TEST_AMOUNT));
 
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0) << OP_CHECKSIG,
                                 "P2PK INVALID AMOUNT", SCRIPT_ENABLE_SIGHASH_FORKID, false, TEST_AMOUNT
-                               ).PushSig(keys.key0, SIGHASH_ALL | SIGHASH_FORKID, 32, 32, TEST_AMOUNT + 1).ScriptError(SCRIPT_ERR_EVAL_FALSE));
+                               ).PushSig(keys.key0, SigHashType::ALL | SigHashType::FORKID, 32, 32, TEST_AMOUNT + 1).ScriptError(SCRIPT_ERR_EVAL_FALSE));
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0) << OP_CHECKSIG,
                                 "P2PK INVALID FORKID", SCRIPT_VERIFY_STRICTENC, false, TEST_AMOUNT
-                               ).PushSig(keys.key0, SIGHASH_ALL | SIGHASH_FORKID, 32, 32, TEST_AMOUNT).ScriptError(SCRIPT_ERR_ILLEGAL_FORKID));
+                               ).PushSig(keys.key0, SigHashType::ALL | SigHashType::FORKID, 32, 32, TEST_AMOUNT).ScriptError(SCRIPT_ERR_ILLEGAL_FORKID));
 
     std::set<std::string> tests_set;
 
@@ -852,7 +854,7 @@ BOOST_AUTO_TEST_CASE(script_PushData)
 CScript
 sign_multisig(CScript scriptPubKey, std::vector<CKey> keys, CTransaction transaction)
 {
-    uint256 hash = SignatureHash(scriptPubKey, transaction, 0, SIGHASH_ALL, 0);
+    uint256 hash = SignatureHash(scriptPubKey, transaction, 0, SigHashType::ALL, 0);
 
     CScript result;
     //
@@ -868,7 +870,7 @@ sign_multisig(CScript scriptPubKey, std::vector<CKey> keys, CTransaction transac
     {
         vector<unsigned char> vchSig;
         BOOST_CHECK(key.Sign(hash, vchSig));
-        vchSig.push_back((unsigned char)SIGHASH_ALL);
+        vchSig.push_back((unsigned char)SigHashType::ALL);
         result << vchSig;
     }
     return result;
@@ -1006,14 +1008,14 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
     BOOST_CHECK(combined.empty());
 
     // Single signature case:
-    SignSignature(keystore, txFrom, txTo, 0, SIGHASH_ALL | SIGHASH_FORKID); // changes scriptSig
+    SignSignature(keystore, txFrom, txTo, 0, SigHashType::ALL | SigHashType::FORKID); // changes scriptSig
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), scriptSig, empty);
     BOOST_CHECK(combined == scriptSig);
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), empty, scriptSig);
     BOOST_CHECK(combined == scriptSig);
     CScript scriptSigCopy = scriptSig;
     // Signing again will give a different, valid signature:
-    SignSignature(keystore, txFrom, txTo, 0, SIGHASH_ALL | SIGHASH_FORKID);
+    SignSignature(keystore, txFrom, txTo, 0, SigHashType::ALL | SigHashType::FORKID);
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), scriptSigCopy, scriptSig);
     BOOST_CHECK(combined == scriptSigCopy || combined == scriptSig);
 
@@ -1021,13 +1023,13 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
     CScript pkSingle; pkSingle << ToByteVector(keys[0].GetPubKey()) << OP_CHECKSIG;
     keystore.AddCScript(pkSingle);
     scriptPubKey = GetScriptForDestination(CScriptID(pkSingle));
-    SignSignature(keystore, txFrom, txTo, 0, SIGHASH_ALL | SIGHASH_FORKID);
+    SignSignature(keystore, txFrom, txTo, 0, SigHashType::ALL | SigHashType::FORKID);
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), scriptSig, empty);
     BOOST_CHECK(combined == scriptSig);
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), empty, scriptSig);
     BOOST_CHECK(combined == scriptSig);
     scriptSigCopy = scriptSig;
-    SignSignature(keystore, txFrom, txTo, 0, SIGHASH_ALL | SIGHASH_FORKID);
+    SignSignature(keystore, txFrom, txTo, 0, SigHashType::ALL | SigHashType::FORKID);
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), scriptSigCopy, scriptSig);
     BOOST_CHECK(combined == scriptSigCopy || combined == scriptSig);
     // dummy scriptSigCopy with placeholder, should always choose non-placeholder:
@@ -1040,25 +1042,25 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
     // Hardest case:  Multisig 2-of-3
     scriptPubKey = GetScriptForMultisig(2, pubkeys);
     keystore.AddCScript(scriptPubKey);
-    SignSignature(keystore, txFrom, txTo, 0, SIGHASH_ALL | SIGHASH_FORKID);
+    SignSignature(keystore, txFrom, txTo, 0, SigHashType::ALL | SigHashType::FORKID);
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), scriptSig, empty);
     BOOST_CHECK(combined == scriptSig);
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), empty, scriptSig);
     BOOST_CHECK(combined == scriptSig);
 
     // A couple of partially-signed versions:
-    vector<unsigned char> sig1;
-    uint256 hash1 = SignatureHash(scriptPubKey, txTo, 0, SIGHASH_ALL, 0);
+    std::vector<unsigned char> sig1;
+    uint256 hash1 = SignatureHash(scriptPubKey, txTo, 0, SigHashType::ALL, 0);
     BOOST_CHECK(keys[0].Sign(hash1, sig1));
-    sig1.push_back(SIGHASH_ALL);
+    sig1.push_back(ToInt(SigHashType::ALL));
     vector<unsigned char> sig2;
-    uint256 hash2 = SignatureHash(scriptPubKey, txTo, 0, SIGHASH_NONE, 0);
+    uint256 hash2 = SignatureHash(scriptPubKey, txTo, 0, SigHashType::NONE, 0);
     BOOST_CHECK(keys[1].Sign(hash2, sig2));
-    sig2.push_back(SIGHASH_NONE);
+    sig2.push_back(ToInt(SigHashType::NONE));
     vector<unsigned char> sig3;
-    uint256 hash3 = SignatureHash(scriptPubKey, txTo, 0, SIGHASH_SINGLE, 0);
+    uint256 hash3 = SignatureHash(scriptPubKey, txTo, 0, SigHashType::SINGLE, 0);
     BOOST_CHECK(keys[2].Sign(hash3, sig3));
-    sig3.push_back(SIGHASH_SINGLE);
+    sig3.push_back(ToInt(SigHashType::SINGLE));
 
     // Not fussy about order (or even existence) of placeholders or signatures:
     CScript partial1a = CScript() << OP_0 << sig1 << OP_0;

--- a/src/test/sighashtype_tests.cpp
+++ b/src/test/sighashtype_tests.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2018 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "test/test_bitcoin.h"
+#include "script/sighashtype.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(sighashtype_tests, BasicTestingSetup);
+
+BOOST_AUTO_TEST_CASE(bitwise_tests) {
+    BOOST_CHECK_EQUAL(0x1 | 0x2, ToInt(SigHashType(0x1) | SigHashType(0x2)));
+    BOOST_CHECK_EQUAL(0x1 & 0x3, ToInt(SigHashType(0x1) & SigHashType(0x3)));
+    BOOST_CHECK_EQUAL(0x3 & ~0x1, ToInt(SigHashType(0x3) & ~SigHashType(0x1)));
+    BOOST_CHECK_EQUAL(0xC0, ToInt(SigHashType(0xC3) & ~SigHashType(0x3)));
+
+    SigHashType t = SigHashType(0x1);
+    t |= SigHashType(0x2);
+    BOOST_CHECK_EQUAL(SigHashType(0x3), t);
+    t &= SigHashType(0x1);
+    BOOST_CHECK_EQUAL(SigHashType(0x1), t);
+}
+
+BOOST_AUTO_TEST_CASE(boolean_tests) {
+    BOOST_CHECK(!bool(SigHashType(0x0)));
+    BOOST_CHECK(bool(SigHashType(0x3)));
+    BOOST_CHECK(!SigHashType(0x0) == true);
+    BOOST_CHECK(!SigHashType(0x3) == false);
+}
+
+BOOST_AUTO_TEST_CASE(basetype_tests) {
+    SigHashType manyflags = SigHashType::SINGLE | SigHashType::FORKID | SigHashType::ANYONECANPAY;
+
+    BOOST_CHECK_EQUAL(SigHashType::SINGLE, GetBaseType(manyflags));
+    BOOST_CHECK_EQUAL(SigHashType::FORKID | SigHashType::ANYONECANPAY,
+                      RemoveBaseType(manyflags));
+}
+
+BOOST_AUTO_TEST_CASE(strconversion) {
+    BOOST_CHECK_EQUAL(SigHashType::ALL | SigHashType::ANYONECANPAY,
+                      FromStr("ALL|ANYONECANPAY"));
+    BOOST_CHECK_EQUAL("ALL|ANYONECANPAY",
+                      ToStr(SigHashType::ALL | SigHashType::ANYONECANPAY));
+    // unsupported
+    BOOST_CHECK_THROW(FromStr("SINGLE|NONE"), std::invalid_argument);
+    BOOST_CHECK_THROW(ToStr(SigHashType(0x30)), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(intconverison) {
+    BOOST_CHECK_EQUAL(0x30, ToInt(SigHashType(0x30)));
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -17,6 +17,7 @@
 #include "policy/policy.h"
 #include "script/script.h"
 #include "script/script_error.h"
+#include "script/sighashtype.h"
 #include "script/sign.h"
 
 #include <map>
@@ -362,13 +363,13 @@ BOOST_AUTO_TEST_CASE(test_big_transaction) {
     keystore.AddKeyPubKey(key, key.GetPubKey());
     CScript scriptPubKey = CScript() << ToByteVector(key.GetPubKey()) << OP_CHECKSIG;
 
-    vector<int> sigHashes;
-    sigHashes.push_back(SIGHASH_NONE | SIGHASH_ANYONECANPAY);
-    sigHashes.push_back(SIGHASH_SINGLE | SIGHASH_ANYONECANPAY);
-    sigHashes.push_back(SIGHASH_ALL | SIGHASH_ANYONECANPAY);
-    sigHashes.push_back(SIGHASH_NONE);
-    sigHashes.push_back(SIGHASH_SINGLE);
-    sigHashes.push_back(SIGHASH_ALL);
+    std::vector<SigHashType> sigHashes;
+    sigHashes.push_back(SigHashType::NONE | SigHashType::ANYONECANPAY);
+    sigHashes.push_back(SigHashType::SINGLE | SigHashType::ANYONECANPAY);
+    sigHashes.push_back(SigHashType::ALL | SigHashType::ANYONECANPAY);
+    sigHashes.push_back(SigHashType::NONE);
+    sigHashes.push_back(SigHashType::SINGLE);
+    sigHashes.push_back(SigHashType::ALL);
 
     // create a big transaction of 4500 inputs signed by the same key
     for(uint32_t ij = 0; ij < 4500; ij++) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -16,6 +16,7 @@
 #include "policy/policy.h"
 #include "policy/txpriority.h"
 #include "script/script.h"
+#include "script/sighashtype.h"
 #include "script/sign.h"
 #include "timedata.h"
 #include "util.h"
@@ -2061,9 +2062,9 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                                               std::numeric_limits<unsigned int>::max()-1));
 
                 // Transaction signature hash type changes at hard fork
-                int nHashType = SIGHASH_ALL;
+                SigHashType nHashType = SigHashType::ALL;
                 if ((Opt().UAHFTime() != 0) && (chainActive.Tip()->GetMedianTimePast() >= Opt().UAHFTime())) {
-                    nHashType |= SIGHASH_FORKID;
+                    nHashType |= SigHashType::FORKID;
                 }
 
                 // Sign


### PR DESCRIPTION
Gives signature hash types a typename, thus adding type safety.

This is a less intrusive alternative to the `SigHashType` enum wrapper class introduced by ABC. Also this is an alternative to BU's approach to keep both the enum and introduce ABC's class, as done in their DSV PR https://github.com/BitcoinUnlimited/BitcoinUnlimited/pull/1390

This change makes it easier to port signature encoding tests and DSV.