### PR TITLE
Refactors of signature encoding check

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -332,6 +332,9 @@ libbitcoin_consensus_a_SOURCES = \
   script/script.h \
   script/script_error.cpp \
   script/script_error.h \
+  script/script_flags.h \
+  script/sigencoding.cpp \
+  script/sigencoding.h \
   serialize.h \
   tinyformat.h \
   uint256.cpp \

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -8,6 +8,7 @@
 #include "primitives/transaction.h"
 #include "script/script.h"
 #include "script/standard.h"
+#include "script/sigencoding.h"
 #include "script/sighashtype.h"
 #include "serialize.h"
 #include "streams.h"

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -90,7 +90,8 @@ string ScriptToAsmStr(const CScript& script, const bool fAttemptSighashDecode)
                     // won't decode correctly formatted public keys in Pubkey or
                     // Multisig scripts due to the restrictions on the pubkey
                     // formats (see IsCompressedOrUncompressedPubKey) being
-                    // incongruous with the checks in CheckSignatureEncoding.
+                    // incongruous with the checks in
+                    // CheckTransactionSignatureEncoding.
                     uint32_t flags = SCRIPT_VERIFY_STRICTENC;
                     if (bool(SigHashType(vch.back()) & SigHashType::FORKID)) {
                         // If the transaction is using SIGHASH_FORKID, we need
@@ -98,7 +99,7 @@ string ScriptToAsmStr(const CScript& script, const bool fAttemptSighashDecode)
                         // TODO: Remove after the Hard Fork.
                         flags |= SCRIPT_ENABLE_SIGHASH_FORKID;
                     }
-                    if (CheckSignatureEncoding(vch, flags, nullptr)) {
+                    if (CheckTransactionSignatureEncoding(vch, flags, nullptr)) {
                         const SigHashType chSigHashType = SigHashType(vch.back());
                         try {
                             strSigHashDecode = "[" + ToStr(chSigHashType) + "]";

--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -272,7 +272,8 @@ bool CExtPubKey::Derive(CExtPubKey &out, unsigned int nChild) const {
     return pubkey.Derive(out.pubkey, out.chaincode, nChild, chaincode);
 }
 
-/* static */ bool CPubKey::CheckLowS(const std::vector<unsigned char>& vchSig) {
+bool CPubKey::CheckLowS(
+    const boost::sliced_range<const std::vector<uint8_t>> &vchSig) {
     secp256k1_ecdsa_signature sig;
     if (!ecdsa_signature_parse_der_lax(secp256k1_context_verify, &sig, &vchSig[0], vchSig.size())) {
         return false;

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -10,10 +10,12 @@
 #include "serialize.h"
 #include "uint256.h"
 
+#include <boost/range/adaptor/sliced.hpp>
+
 #include <stdexcept>
 #include <vector>
 
-/** 
+/**
  * secp256k1:
  * const unsigned int PRIVATE_KEY_SIZE = 279;
  * const unsigned int PUBLIC_KEY_SIZE  = 65;
@@ -150,7 +152,7 @@ public:
 
     /*
      * Check syntactic correctness.
-     * 
+     *
      * Note that this is consensus critical as CheckSig() calls it!
      */
     bool IsValid() const
@@ -176,7 +178,11 @@ public:
     /**
      * Check whether a signature is normalized (lower-S).
      */
-    static bool CheckLowS(const std::vector<unsigned char>& vchSig);
+    static bool
+    CheckLowS(const boost::sliced_range<const std::vector<uint8_t>> &vchSig);
+    static bool CheckLowS(const std::vector<uint8_t> &vchSig) {
+        return CheckLowS(vchSig | boost::adaptors::sliced(0, vchSig.size()));
+    }
 
     //! Recover a public key from a compact signature.
     bool RecoverCompact(const uint256& hash, const std::vector<unsigned char>& vchSig);

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -177,14 +177,11 @@ bool static IsValidSignatureEncoding(const std::vector<unsigned char> &sig) {
 }
 
 bool static IsLowDERSignature(const valtype &vchSig, ScriptError* serror) {
-    if (!IsValidSignatureEncoding(vchSig)) {
-        return set_error(serror, SCRIPT_ERR_SIG_DER);
+    assert(vchSig.size() > 0);
+    if (CPubKey::CheckLowS(vchSig | boost::adaptors::sliced(0, vchSig.size() - 1))) {
+        return true;
     }
-    std::vector<unsigned char> vchSigCopy(vchSig.begin(), vchSig.begin() + vchSig.size() - 1);
-    if (!CPubKey::CheckLowS(vchSigCopy)) {
-        return set_error(serror, SCRIPT_ERR_SIG_HIGH_S);
-    }
-    return true;
+    return set_error(serror, SCRIPT_ERR_SIG_HIGH_S);
 }
 
 static SigHashType GetHashType(const valtype &vchSig) {

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -11,30 +11,13 @@
 #include "crypto/sha256.h"
 #include "pubkey.h"
 #include "script/script.h"
+#include "script/sigencoding.h"
 #include "script/sighashtype.h"
 #include "uint256.h"
 
 using namespace std;
 
 typedef vector<unsigned char> valtype;
-
-namespace {
-
-inline bool set_success(ScriptError* ret)
-{
-    if (ret)
-        *ret = SCRIPT_ERR_OK;
-    return true;
-}
-
-inline bool set_error(ScriptError* ret, const ScriptError serror)
-{
-    if (ret)
-        *ret = serror;
-    return false;
-}
-
-} // anon namespace
 
 bool CastToBool(const valtype& vch)
 {
@@ -64,134 +47,6 @@ static inline void popstack(vector<valtype>& stack)
     stack.pop_back();
 }
 
-bool static IsCompressedOrUncompressedPubKey(const valtype &vchPubKey) {
-    if (vchPubKey.size() < 33) {
-        //  Non-canonical public key: too short
-        return false;
-    }
-    if (vchPubKey[0] == 0x04) {
-        if (vchPubKey.size() != 65) {
-            //  Non-canonical public key: invalid length for uncompressed key
-            return false;
-        }
-    } else if (vchPubKey[0] == 0x02 || vchPubKey[0] == 0x03) {
-        if (vchPubKey.size() != 33) {
-            //  Non-canonical public key: invalid length for compressed key
-            return false;
-        }
-    } else {
-          //  Non-canonical public key: neither compressed nor uncompressed
-          return false;
-    }
-    return true;
-}
-
-static bool IsCompressedPubKey(const valtype &vchPubKey)
-{
-    if (vchPubKey.size() != 33)
-    {
-        //  Non-canonical public key: invalid length for compressed key
-        return false;
-    }
-    if (vchPubKey[0] != 0x02 && vchPubKey[0] != 0x03)
-    {
-        //  Non-canonical public key: invalid prefix for compressed key
-        return false;
-    }
-    return true;
-}
-
-/**
- * A canonical signature exists of: <30> <total len> <02> <len R> <R> <02> <len S> <S> <hashtype>
- * Where R and S are not negative (their first byte has its highest bit not set), and not
- * excessively padded (do not start with a 0 byte, unless an otherwise negative number follows,
- * in which case a single 0 byte is necessary and even required).
- *
- * See https://bitcointalk.org/index.php?topic=8392.msg127623#msg127623
- *
- * This function is consensus-critical since BIP66.
- */
-bool static IsValidSignatureEncoding(const std::vector<unsigned char> &sig) {
-    // Format: 0x30 [total-length] 0x02 [R-length] [R] 0x02 [S-length] [S] [sighash]
-    // * total-length: 1-byte length descriptor of everything that follows,
-    //   excluding the sighash byte.
-    // * R-length: 1-byte length descriptor of the R value that follows.
-    // * R: arbitrary-length big-endian encoded R value. It must use the shortest
-    //   possible encoding for a positive integers (which means no null bytes at
-    //   the start, except a single one when the next byte has its highest bit set).
-    // * S-length: 1-byte length descriptor of the S value that follows.
-    // * S: arbitrary-length big-endian encoded S value. The same rules apply.
-    // * sighash: 1-byte value indicating what data is hashed (not part of the DER
-    //   signature)
-
-    // Minimum and maximum size constraints.
-    if (sig.size() < 9) return false;
-    if (sig.size() > 73) return false;
-
-    // A signature is of type 0x30 (compound).
-    if (sig[0] != 0x30) return false;
-
-    // Make sure the length covers the entire signature.
-    if (sig[1] != sig.size() - 3) return false;
-
-    // Extract the length of the R element.
-    unsigned int lenR = sig[3];
-
-    // Make sure the length of the S element is still inside the signature.
-    if (5 + lenR >= sig.size()) return false;
-
-    // Extract the length of the S element.
-    unsigned int lenS = sig[5 + lenR];
-
-    // Verify that the length of the signature matches the sum of the length
-    // of the elements.
-    if ((size_t)(lenR + lenS + 7) != sig.size()) return false;
-
-    // Check whether the R element is an integer.
-    if (sig[2] != 0x02) return false;
-
-    // Zero-length integers are not allowed for R.
-    if (lenR == 0) return false;
-
-    // Negative numbers are not allowed for R.
-    if (sig[4] & 0x80) return false;
-
-    // Null bytes at the start of R are not allowed, unless R would
-    // otherwise be interpreted as a negative number.
-    if (lenR > 1 && (sig[4] == 0x00) && !(sig[5] & 0x80)) return false;
-
-    // Check whether the S element is an integer.
-    if (sig[lenR + 4] != 0x02) return false;
-
-    // Zero-length integers are not allowed for S.
-    if (lenS == 0) return false;
-
-    // Negative numbers are not allowed for S.
-    if (sig[lenR + 6] & 0x80) return false;
-
-    // Null bytes at the start of S are not allowed, unless S would otherwise be
-    // interpreted as a negative number.
-    if (lenS > 1 && (sig[lenR + 6] == 0x00) && !(sig[lenR + 7] & 0x80)) return false;
-
-    return true;
-}
-
-bool static IsLowDERSignature(const valtype &vchSig, ScriptError* serror) {
-    assert(vchSig.size() > 0);
-    if (CPubKey::CheckLowS(vchSig | boost::adaptors::sliced(0, vchSig.size() - 1))) {
-        return true;
-    }
-    return set_error(serror, SCRIPT_ERR_SIG_HIGH_S);
-}
-
-static SigHashType GetHashType(const valtype &vchSig) {
-    if (vchSig.size() == 0) {
-        return SigHashType::UNDEFINED;
-    }
-
-    return SigHashType(vchSig[vchSig.size() - 1]);
-}
-
 static void CleanupScriptCode(CScript &scriptCode,
                               const std::vector<unsigned char> &vchSig,
                               uint32_t flags) {
@@ -201,63 +56,6 @@ static void CleanupScriptCode(CScript &scriptCode,
         !(nHashType & SigHashType::FORKID)) {
         scriptCode.FindAndDelete(CScript(vchSig));
     }
-}
-
-static bool IsDefinedHashtypeSignature(const valtype &vchSig) {
-    if (vchSig.size() == 0) {
-        return false;
-    }
-    SigHashType nHashType = GetHashType(vchSig)
-        & ~(SigHashType::ANYONECANPAY | SigHashType::FORKID);
-
-    if (nHashType < SigHashType::ALL || nHashType > SigHashType::SINGLE)
-        return false;
-
-    return true;
-}
-
-bool CheckSignatureEncoding(const vector<unsigned char> &vchSig, unsigned int flags, ScriptError* serror) {
-    // Empty signature. Not strictly DER encoded, but allowed to provide a
-    // compact way to provide an invalid signature for use with CHECK(MULTI)SIG
-    if (vchSig.size() == 0) {
-        return true;
-    }
-    if ((flags & (SCRIPT_VERIFY_DERSIG | SCRIPT_VERIFY_LOW_S | SCRIPT_VERIFY_STRICTENC)) != 0 && !IsValidSignatureEncoding(vchSig)) {
-        return set_error(serror, SCRIPT_ERR_SIG_DER);
-    }
-    if ((flags & SCRIPT_VERIFY_LOW_S) != 0 && !IsLowDERSignature(vchSig, serror)) {
-        // serror is set
-        return false;
-    }
-    if ((flags & SCRIPT_VERIFY_STRICTENC) != 0) {
-        if (!IsDefinedHashtypeSignature(vchSig)) {
-            return set_error(serror, SCRIPT_ERR_SIG_HASHTYPE);
-        }
-        bool usesForkId = bool(GetHashType(vchSig) & SigHashType::FORKID);
-        bool forkIdEnabled = flags & SCRIPT_ENABLE_SIGHASH_FORKID;
-        if (!forkIdEnabled && usesForkId) {
-            return set_error(serror, SCRIPT_ERR_ILLEGAL_FORKID);
-        }
-        if (forkIdEnabled && !usesForkId) {
-            return set_error(serror, SCRIPT_ERR_MUST_USE_FORKID);
-        }
-    }
-    return true;
-}
-
-bool CheckPubKeyEncoding(const valtype &vchPubKey, unsigned int flags, ScriptError *serror)
-{
-    if ((flags & SCRIPT_VERIFY_STRICTENC) != 0 && !IsCompressedOrUncompressedPubKey(vchPubKey)) {
-        return set_error(serror, SCRIPT_ERR_PUBKEYTYPE);
-    }
-
-    // Only compressed keys are accepted when
-    // SCRIPT_VERIFY_COMPRESSED_PUBKEYTYPE is enabled.
-    if (flags & SCRIPT_VERIFY_COMPRESSED_PUBKEYTYPE && !IsCompressedPubKey(vchPubKey))
-    {
-        return set_error(serror, SCRIPT_ERR_NONCOMPRESSED_PUBKEY);
-    }
-    return true;
 }
 
 bool static CheckMinimalPush(const valtype& data, opcodetype opcode) {

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -795,7 +795,7 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
                     valtype& vchPubKey = stacktop(-1);
 
 
-                    if (!CheckSignatureEncoding(vchSig, flags, serror) || !CheckPubKeyEncoding(vchPubKey, flags, serror)) {
+                    if (!CheckTransactionSignatureEncoding(vchSig, flags, serror) || !CheckPubKeyEncoding(vchPubKey, flags, serror)) {
                         //serror is set
                         return false;
                     }
@@ -872,7 +872,7 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
                         // Note how this makes the exact order of pubkey/signature evaluation
                         // distinguishable by CHECKMULTISIG NOT if the STRICTENC flag is set.
                         // See the script_(in)valid tests for details.
-                        if (!CheckSignatureEncoding(vchSig, flags, serror) || !CheckPubKeyEncoding(vchPubKey, flags, serror)) {
+                        if (!CheckTransactionSignatureEncoding(vchSig, flags, serror) || !CheckPubKeyEncoding(vchPubKey, flags, serror)) {
                             // serror is set
                             return false;
                         }

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_SCRIPT_INTERPRETER_H
 #define BITCOIN_SCRIPT_INTERPRETER_H
 
+#include "script/script_flags.h"
 #include "script_error.h"
 #include "primitives/transaction.h"
 
@@ -19,88 +20,6 @@ class CTransaction;
 class uint256;
 enum class SigHashType : uint32_t;
 
-/** Script verification flags */
-enum
-{
-    SCRIPT_VERIFY_NONE      = 0,
-
-    // Evaluate P2SH subscripts (softfork safe, BIP16).
-    SCRIPT_VERIFY_P2SH      = (1U << 0),
-
-    // Passing a non-strict-DER signature or one with undefined hashtype to a checksig operation causes script failure.
-    // Evaluating a pubkey that is not (0x04 + 64 bytes) or (0x02 or 0x03 + 32 bytes) by checksig causes script failure.
-    // (softfork safe, but not used or intended as a consensus rule).
-    SCRIPT_VERIFY_STRICTENC = (1U << 1),
-
-    // Passing a non-strict-DER signature to a checksig operation causes script failure (softfork safe, BIP62 rule 1)
-    SCRIPT_VERIFY_DERSIG    = (1U << 2),
-
-    // Passing a non-strict-DER signature or one with S > order/2 to a checksig operation causes script failure
-    // (softfork safe, BIP62 rule 5).
-    SCRIPT_VERIFY_LOW_S     = (1U << 3),
-
-    // verify dummy stack item consumed by CHECKMULTISIG is of zero-length (softfork safe, BIP62 rule 7).
-    SCRIPT_VERIFY_NULLDUMMY = (1U << 4),
-
-    // Using a non-push operator in the scriptSig causes script failure (softfork safe, BIP62 rule 2).
-    SCRIPT_VERIFY_SIGPUSHONLY = (1U << 5),
-
-    // Require minimal encodings for all push operations (OP_0... OP_16, OP_1NEGATE where possible, direct
-    // pushes up to 75 bytes, OP_PUSHDATA up to 255 bytes, OP_PUSHDATA2 for anything larger). Evaluating
-    // any other push causes the script to fail (BIP62 rule 3).
-    // In addition, whenever a stack element is interpreted as a number, it must be of minimal length (BIP62 rule 4).
-    // (softfork safe)
-    SCRIPT_VERIFY_MINIMALDATA = (1U << 6),
-
-    // Discourage use of NOPs reserved for upgrades (NOP1-10)
-    //
-    // Provided so that nodes can avoid accepting or mining transactions
-    // containing executed NOP's whose meaning may change after a soft-fork,
-    // thus rendering the script invalid; with this flag set executing
-    // discouraged NOPs fails the script. This verification flag will never be
-    // a mandatory flag applied to scripts in a block. NOPs that are not
-    // executed, e.g.  within an unexecuted IF ENDIF block, are *not* rejected.
-    SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS  = (1U << 7),
-
-    // Require that only a single stack element remains after evaluation. This changes the success criterion from
-    // "At least one stack element must remain, and when interpreted as a boolean, it must be true" to
-    // "Exactly one stack element must remain, and when interpreted as a boolean, it must be true".
-    // (softfork safe, BIP62 rule 6)
-    // Note: CLEANSTACK should never be used without P2SH.
-    SCRIPT_VERIFY_CLEANSTACK = (1U << 8),
-
-    // Verify CHECKLOCKTIMEVERIFY
-    //
-    // See BIP65 for details.
-    SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY = (1U << 9),
-
-    // support CHECKSEQUENCEVERIFY opcode
-    //
-    // See BIP112 for details
-    SCRIPT_VERIFY_CHECKSEQUENCEVERIFY = (1U << 10),
-
-    // Signature(s) must be empty vector if an CHECK(MULTI)SIG operation failed
-    SCRIPT_VERIFY_NULLFAIL = (1U << 14),
-
-
-    // Do we accept signature using SIGHASH_FORKID
-    //
-    SCRIPT_ENABLE_SIGHASH_FORKID = (1U << 16),
-
-    // Public keys in scripts must be compressed
-    //
-    SCRIPT_VERIFY_COMPRESSED_PUBKEYTYPE = (1U << 15),
-
-    // Placeholder. This flag is used by Bitcoin ABC only.
-    //
-    SCRIPT_ENABLE_REPLAY_PROTECTION = (1U << 17),
-
-    // Enable new opcodes.
-    //
-    SCRIPT_ENABLE_MONOLITH_OPCODES = (1U << 18),
-};
-
-bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, unsigned int flags, ScriptError* serror);
 bool CheckPubKeyEncoding(const std::vector<unsigned char> &vchPubKey, unsigned int flags, ScriptError *serror);
 
 struct PrecomputedTransactionData

--- a/src/script/script_error.h
+++ b/src/script/script_error.h
@@ -78,4 +78,18 @@ typedef enum ScriptError_t
 
 const char* ScriptErrorString(const ScriptError error);
 
+inline bool set_success(ScriptError* ret)
+{
+    if (ret)
+        *ret = SCRIPT_ERR_OK;
+    return true;
+}
+
+inline bool set_error(ScriptError* ret, const ScriptError serror)
+{
+    if (ret)
+        *ret = serror;
+    return false;
+}
+
 #endif // BITCOIN_SCRIPT_SCRIPT_ERROR_H

--- a/src/script/script_flags.h
+++ b/src/script/script_flags.h
@@ -1,0 +1,91 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2016 The Bitcoin Core developers
+// Copyright (c) 2017-2018 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SCRIPT_SCRIPTFLAGS_H
+#define BITCOIN_SCRIPT_SCRIPTFLAGS_H
+
+/** Script verification flags */
+enum
+{
+    SCRIPT_VERIFY_NONE      = 0,
+
+    // Evaluate P2SH subscripts (softfork safe, BIP16).
+    SCRIPT_VERIFY_P2SH      = (1U << 0),
+
+    // Passing a non-strict-DER signature or one with undefined hashtype to a checksig operation causes script failure.
+    // Evaluating a pubkey that is not (0x04 + 64 bytes) or (0x02 or 0x03 + 32 bytes) by checksig causes script failure.
+    // (softfork safe, but not used or intended as a consensus rule).
+    SCRIPT_VERIFY_STRICTENC = (1U << 1),
+
+    // Passing a non-strict-DER signature to a checksig operation causes script failure (softfork safe, BIP62 rule 1)
+    SCRIPT_VERIFY_DERSIG    = (1U << 2),
+
+    // Passing a non-strict-DER signature or one with S > order/2 to a checksig operation causes script failure
+    // (softfork safe, BIP62 rule 5).
+    SCRIPT_VERIFY_LOW_S     = (1U << 3),
+
+    // verify dummy stack item consumed by CHECKMULTISIG is of zero-length (softfork safe, BIP62 rule 7).
+    SCRIPT_VERIFY_NULLDUMMY = (1U << 4),
+
+    // Using a non-push operator in the scriptSig causes script failure (softfork safe, BIP62 rule 2).
+    SCRIPT_VERIFY_SIGPUSHONLY = (1U << 5),
+
+    // Require minimal encodings for all push operations (OP_0... OP_16, OP_1NEGATE where possible, direct
+    // pushes up to 75 bytes, OP_PUSHDATA up to 255 bytes, OP_PUSHDATA2 for anything larger). Evaluating
+    // any other push causes the script to fail (BIP62 rule 3).
+    // In addition, whenever a stack element is interpreted as a number, it must be of minimal length (BIP62 rule 4).
+    // (softfork safe)
+    SCRIPT_VERIFY_MINIMALDATA = (1U << 6),
+
+    // Discourage use of NOPs reserved for upgrades (NOP1-10)
+    //
+    // Provided so that nodes can avoid accepting or mining transactions
+    // containing executed NOP's whose meaning may change after a soft-fork,
+    // thus rendering the script invalid; with this flag set executing
+    // discouraged NOPs fails the script. This verification flag will never be
+    // a mandatory flag applied to scripts in a block. NOPs that are not
+    // executed, e.g.  within an unexecuted IF ENDIF block, are *not* rejected.
+    SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS  = (1U << 7),
+
+    // Require that only a single stack element remains after evaluation. This changes the success criterion from
+    // "At least one stack element must remain, and when interpreted as a boolean, it must be true" to
+    // "Exactly one stack element must remain, and when interpreted as a boolean, it must be true".
+    // (softfork safe, BIP62 rule 6)
+    // Note: CLEANSTACK should never be used without P2SH.
+    SCRIPT_VERIFY_CLEANSTACK = (1U << 8),
+
+    // Verify CHECKLOCKTIMEVERIFY
+    //
+    // See BIP65 for details.
+    SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY = (1U << 9),
+
+    // support CHECKSEQUENCEVERIFY opcode
+    //
+    // See BIP112 for details
+    SCRIPT_VERIFY_CHECKSEQUENCEVERIFY = (1U << 10),
+
+    // Signature(s) must be empty vector if an CHECK(MULTI)SIG operation failed
+    SCRIPT_VERIFY_NULLFAIL = (1U << 14),
+
+
+    // Do we accept signature using SIGHASH_FORKID
+    //
+    SCRIPT_ENABLE_SIGHASH_FORKID = (1U << 16),
+
+    // Public keys in scripts must be compressed
+    //
+    SCRIPT_VERIFY_COMPRESSED_PUBKEYTYPE = (1U << 15),
+
+    // Placeholder. This flag is used by Bitcoin ABC only.
+    //
+    SCRIPT_ENABLE_REPLAY_PROTECTION = (1U << 17),
+
+    // Enable new opcodes.
+    //
+    SCRIPT_ENABLE_MONOLITH_OPCODES = (1U << 18),
+};
+
+#endif

--- a/src/script/sigencoding.cpp
+++ b/src/script/sigencoding.cpp
@@ -74,53 +74,121 @@ bool static IsValidSignatureEncoding(const std::vector<unsigned char> &sig) {
     //   signature)
 
     // Minimum and maximum size constraints.
-    if (sig.size() < 9) return false;
-    if (sig.size() > 73) return false;
+    if (sig.size() < 9 || sig.size() > 73) {
+        return false;
+    }
+
+    //
+    // Check that the signature is a coumpound structure of proper size.
+    //
 
     // A signature is of type 0x30 (compound).
-    if (sig[0] != 0x30) return false;
+    if (sig[0] != 0x30) {
+        return false;
+    }
 
     // Make sure the length covers the entire signature.
-    if (sig[1] != sig.size() - 3) return false;
+    // Remove:
+    // * 1 byte for the coupound type.
+    // * 1 byte for the length of the signature.
+    // * 1 byte for the sighash type.
+    if (sig[1] != sig.size() - 3) {
+        return false;
+    }
 
-    // Extract the length of the R element.
-    unsigned int lenR = sig[3];
-
-    // Make sure the length of the S element is still inside the signature.
-    if (5 + lenR >= sig.size()) return false;
-
-    // Extract the length of the S element.
-    unsigned int lenS = sig[5 + lenR];
-
-    // Verify that the length of the signature matches the sum of the length
-    // of the elements.
-    if ((size_t)(lenR + lenS + 7) != sig.size()) return false;
+    //
+    // Check that R is an positive integer of sensible size.
+    //
 
     // Check whether the R element is an integer.
-    if (sig[2] != 0x02) return false;
+    if (sig[2] != 0x02) {
+        return false;
+    }
+
+    // Extract the length of the R element.
+    const uint32_t lenR = sig[3];
 
     // Zero-length integers are not allowed for R.
-    if (lenR == 0) return false;
+    if (lenR == 0) {
+        return false;
+    }
 
     // Negative numbers are not allowed for R.
-    if (sig[4] & 0x80) return false;
+    if (sig[4] & 0x80) {
+        return false;
+    }
 
-    // Null bytes at the start of R are not allowed, unless R would
-    // otherwise be interpreted as a negative number.
-    if (lenR > 1 && (sig[4] == 0x00) && !(sig[5] & 0x80)) return false;
+    // Make sure the length of the R element is consistent with the signature
+    // size.
+    // Remove:
+    // * 1 byte for the coumpound type.
+    // * 1 byte for the length of the signature.
+    // * 2 bytes for the integer type of R and S.
+    // * 2 bytes for the size of R and S.
+    // * 1 byte for S itself.
+    // * 1 byte for the sighash type.
+    if (lenR > (sig.size() - 8)) {
+        return false;
+    }
+
+    // Null bytes at the start of R are not allowed, unless R would otherwise be
+    // interpreted as a negative number.
+    //
+    // /!\ This check can only be performed after we checked that lenR is
+    //     consistent with the size of the signature or we risk to access out of
+    //     bound elements.
+    if (lenR > 1 && (sig[4] == 0x00) && !(sig[5] & 0x80)) {
+        return false;
+    }
+
+    //
+    // Check that S is an positive integer of sensible size.
+    //
+
+    // S's definition starts after R's definition:
+    // * 1 byte for the coumpound type.
+    // * 1 byte for the length of the signature.
+    // * 1 byte for the size of R.
+    // * lenR bytes for R itself.
+    // * 1 byte to get to S.
+    const uint32_t startS = lenR + 4;
 
     // Check whether the S element is an integer.
-    if (sig[lenR + 4] != 0x02) return false;
+    if (sig[startS] != 0x02) {
+        return false;
+    }
+
+    // Extract the length of the S element.
+    const uint32_t lenS = sig[startS + 1];
 
     // Zero-length integers are not allowed for S.
-    if (lenS == 0) return false;
+    if (lenS == 0) {
+        return false;
+    }
 
     // Negative numbers are not allowed for S.
-    if (sig[lenR + 6] & 0x80) return false;
+    if (sig[startS + 2] & 0x80) {
+        return false;
+    }
+
+    // Verify that the length of S is consistent with the size of the signature
+    // including metadatas:
+    // * 1 byte for the integer type of S.
+    // * 1 byte for the size of S.
+    // * 1 byte for the sighash type.
+    if (size_t(startS + lenS + 3) != sig.size()) {
+        return false;
+    }
 
     // Null bytes at the start of S are not allowed, unless S would otherwise be
     // interpreted as a negative number.
-    if (lenS > 1 && (sig[lenR + 6] == 0x00) && !(sig[lenR + 7] & 0x80)) return false;
+    //
+    // /!\ This check can only be performed after we checked that lenR and lenS
+    //     are consistent with the size of the signature or we risk to access
+    //     out of bound elements.
+    if (lenS > 1 && (sig[startS + 2] == 0x00) && !(sig[startS + 3] & 0x80)) {
+        return false;
+    }
 
     return true;
 }

--- a/src/script/sigencoding.cpp
+++ b/src/script/sigencoding.cpp
@@ -1,0 +1,191 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2016 The Bitcoin Core developers
+// Copyright (c) 2017-2018 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "script/sigencoding.h"
+
+#include "pubkey.h"
+#include "script/script_flags.h"
+
+#include <vector>
+
+typedef std::vector<unsigned char> valtype;
+
+bool static IsCompressedOrUncompressedPubKey(const valtype &vchPubKey) {
+    if (vchPubKey.size() < 33) {
+        //  Non-canonical public key: too short
+        return false;
+    }
+    if (vchPubKey[0] == 0x04) {
+        if (vchPubKey.size() != 65) {
+            //  Non-canonical public key: invalid length for uncompressed key
+            return false;
+        }
+    } else if (vchPubKey[0] == 0x02 || vchPubKey[0] == 0x03) {
+        if (vchPubKey.size() != 33) {
+            //  Non-canonical public key: invalid length for compressed key
+            return false;
+        }
+    } else {
+          //  Non-canonical public key: neither compressed nor uncompressed
+          return false;
+    }
+    return true;
+}
+
+static bool IsCompressedPubKey(const valtype &vchPubKey)
+{
+    if (vchPubKey.size() != 33)
+    {
+        //  Non-canonical public key: invalid length for compressed key
+        return false;
+    }
+    if (vchPubKey[0] != 0x02 && vchPubKey[0] != 0x03)
+    {
+        //  Non-canonical public key: invalid prefix for compressed key
+        return false;
+    }
+    return true;
+}
+
+/**
+ * A canonical signature exists of: <30> <total len> <02> <len R> <R> <02> <len S> <S> <hashtype>
+ * Where R and S are not negative (their first byte has its highest bit not set), and not
+ * excessively padded (do not start with a 0 byte, unless an otherwise negative number follows,
+ * in which case a single 0 byte is necessary and even required).
+ *
+ * See https://bitcointalk.org/index.php?topic=8392.msg127623#msg127623
+ *
+ * This function is consensus-critical since BIP66.
+ */
+bool static IsValidSignatureEncoding(const std::vector<unsigned char> &sig) {
+    // Format: 0x30 [total-length] 0x02 [R-length] [R] 0x02 [S-length] [S] [sighash]
+    // * total-length: 1-byte length descriptor of everything that follows,
+    //   excluding the sighash byte.
+    // * R-length: 1-byte length descriptor of the R value that follows.
+    // * R: arbitrary-length big-endian encoded R value. It must use the shortest
+    //   possible encoding for a positive integers (which means no null bytes at
+    //   the start, except a single one when the next byte has its highest bit set).
+    // * S-length: 1-byte length descriptor of the S value that follows.
+    // * S: arbitrary-length big-endian encoded S value. The same rules apply.
+    // * sighash: 1-byte value indicating what data is hashed (not part of the DER
+    //   signature)
+
+    // Minimum and maximum size constraints.
+    if (sig.size() < 9) return false;
+    if (sig.size() > 73) return false;
+
+    // A signature is of type 0x30 (compound).
+    if (sig[0] != 0x30) return false;
+
+    // Make sure the length covers the entire signature.
+    if (sig[1] != sig.size() - 3) return false;
+
+    // Extract the length of the R element.
+    unsigned int lenR = sig[3];
+
+    // Make sure the length of the S element is still inside the signature.
+    if (5 + lenR >= sig.size()) return false;
+
+    // Extract the length of the S element.
+    unsigned int lenS = sig[5 + lenR];
+
+    // Verify that the length of the signature matches the sum of the length
+    // of the elements.
+    if ((size_t)(lenR + lenS + 7) != sig.size()) return false;
+
+    // Check whether the R element is an integer.
+    if (sig[2] != 0x02) return false;
+
+    // Zero-length integers are not allowed for R.
+    if (lenR == 0) return false;
+
+    // Negative numbers are not allowed for R.
+    if (sig[4] & 0x80) return false;
+
+    // Null bytes at the start of R are not allowed, unless R would
+    // otherwise be interpreted as a negative number.
+    if (lenR > 1 && (sig[4] == 0x00) && !(sig[5] & 0x80)) return false;
+
+    // Check whether the S element is an integer.
+    if (sig[lenR + 4] != 0x02) return false;
+
+    // Zero-length integers are not allowed for S.
+    if (lenS == 0) return false;
+
+    // Negative numbers are not allowed for S.
+    if (sig[lenR + 6] & 0x80) return false;
+
+    // Null bytes at the start of S are not allowed, unless S would otherwise be
+    // interpreted as a negative number.
+    if (lenS > 1 && (sig[lenR + 6] == 0x00) && !(sig[lenR + 7] & 0x80)) return false;
+
+    return true;
+}
+
+bool static IsLowDERSignature(const valtype &vchSig, ScriptError* serror) {
+    assert(vchSig.size() > 0);
+    if (CPubKey::CheckLowS(vchSig | boost::adaptors::sliced(0, vchSig.size() - 1))) {
+        return true;
+    }
+    return set_error(serror, SCRIPT_ERR_SIG_HIGH_S);
+}
+
+static bool IsDefinedHashtypeSignature(const valtype &vchSig) {
+    if (vchSig.size() == 0) {
+        return false;
+    }
+    SigHashType nHashType = GetHashType(vchSig)
+        & ~(SigHashType::ANYONECANPAY | SigHashType::FORKID);
+
+    if (nHashType < SigHashType::ALL || nHashType > SigHashType::SINGLE)
+        return false;
+
+    return true;
+}
+
+bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, unsigned int flags, ScriptError* serror) {
+    // Empty signature. Not strictly DER encoded, but allowed to provide a
+    // compact way to provide an invalid signature for use with CHECK(MULTI)SIG
+    if (vchSig.size() == 0) {
+        return true;
+    }
+    if ((flags & (SCRIPT_VERIFY_DERSIG | SCRIPT_VERIFY_LOW_S | SCRIPT_VERIFY_STRICTENC)) != 0 && !IsValidSignatureEncoding(vchSig)) {
+        return set_error(serror, SCRIPT_ERR_SIG_DER);
+    }
+    if ((flags & SCRIPT_VERIFY_LOW_S) != 0 && !IsLowDERSignature(vchSig, serror)) {
+        // serror is set
+        return false;
+    }
+    if ((flags & SCRIPT_VERIFY_STRICTENC) != 0) {
+        if (!IsDefinedHashtypeSignature(vchSig)) {
+            return set_error(serror, SCRIPT_ERR_SIG_HASHTYPE);
+        }
+        bool usesForkId = bool(GetHashType(vchSig) & SigHashType::FORKID);
+        bool forkIdEnabled = flags & SCRIPT_ENABLE_SIGHASH_FORKID;
+        if (!forkIdEnabled && usesForkId) {
+            return set_error(serror, SCRIPT_ERR_ILLEGAL_FORKID);
+        }
+        if (forkIdEnabled && !usesForkId) {
+            return set_error(serror, SCRIPT_ERR_MUST_USE_FORKID);
+        }
+    }
+    return true;
+}
+
+bool CheckPubKeyEncoding(const valtype &vchPubKey, unsigned int flags, ScriptError *serror)
+{
+    if ((flags & SCRIPT_VERIFY_STRICTENC) != 0 && !IsCompressedOrUncompressedPubKey(vchPubKey)) {
+        return set_error(serror, SCRIPT_ERR_PUBKEYTYPE);
+    }
+
+    // Only compressed keys are accepted when
+    // SCRIPT_VERIFY_COMPRESSED_PUBKEYTYPE is enabled.
+    if (flags & SCRIPT_VERIFY_COMPRESSED_PUBKEYTYPE && !IsCompressedPubKey(vchPubKey))
+    {
+        return set_error(serror, SCRIPT_ERR_NONCOMPRESSED_PUBKEY);
+    }
+    return true;
+}

--- a/src/script/sigencoding.cpp
+++ b/src/script/sigencoding.cpp
@@ -50,6 +50,8 @@ static bool IsCompressedPubKey(const valtype &vchPubKey)
     return true;
 }
 
+typedef boost::sliced_range<const valtype> slicedvaltype;
+
 /**
  * A canonical signature exists of: <30> <total len> <02> <len R> <R> <02> <len S> <S> <hashtype>
  * Where R and S are not negative (their first byte has its highest bit not set), and not
@@ -60,8 +62,7 @@ static bool IsCompressedPubKey(const valtype &vchPubKey)
  *
  * This function is consensus-critical since BIP66.
  */
-static bool
-IsValidSignatureEncoding(const boost::sliced_range<const valtype> &sig) {
+static bool IsValidSignatureEncoding(const slicedvaltype &sig) {
     // Format: 0x30 [total-length] 0x02 [R-length] [R] 0x02 [S-length] [S]
     // * total-length: 1-byte length descriptor of everything that follows,
     //   excluding the sighash byte.
@@ -189,12 +190,19 @@ IsValidSignatureEncoding(const boost::sliced_range<const valtype> &sig) {
     return true;
 }
 
-bool static IsLowDERSignature(const valtype &vchSig, ScriptError* serror) {
-    assert(vchSig.size() > 0);
-    if (CPubKey::CheckLowS(vchSig | boost::adaptors::sliced(0, vchSig.size() - 1))) {
-        return true;
+static bool CheckRawSignatureEncoding(const slicedvaltype &sig, uint32_t flags,
+                                      ScriptError *serror) {
+    if ((flags & (SCRIPT_VERIFY_DERSIG | SCRIPT_VERIFY_LOW_S |
+                  SCRIPT_VERIFY_STRICTENC)) &&
+        !IsValidSignatureEncoding(sig)) {
+        return set_error(serror, SCRIPT_ERR_SIG_DER);
     }
-    return set_error(serror, SCRIPT_ERR_SIG_HIGH_S);
+
+    if ((flags & SCRIPT_VERIFY_LOW_S) && !CPubKey::CheckLowS(sig)) {
+        return set_error(serror, SCRIPT_ERR_SIG_HIGH_S);
+    }
+
+    return true;
 }
 
 static bool IsDefinedHashtypeSignature(const valtype &vchSig) {
@@ -210,35 +218,37 @@ static bool IsDefinedHashtypeSignature(const valtype &vchSig) {
     return true;
 }
 
-bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, unsigned int flags, ScriptError* serror) {
+bool CheckTransactionSignatureEncoding(const valtype &vchSig, uint32_t flags,
+                                       ScriptError *serror) {
     // Empty signature. Not strictly DER encoded, but allowed to provide a
     // compact way to provide an invalid signature for use with CHECK(MULTI)SIG
     if (vchSig.size() == 0) {
         return true;
     }
-    if ((flags & (SCRIPT_VERIFY_DERSIG | SCRIPT_VERIFY_LOW_S |
-                  SCRIPT_VERIFY_STRICTENC)) != 0 &&
-        !IsValidSignatureEncoding(
-            vchSig | boost::adaptors::sliced(0, vchSig.size() - 1))) {
-        return set_error(serror, SCRIPT_ERR_SIG_DER);
-    }
-    if ((flags & SCRIPT_VERIFY_LOW_S) != 0 && !IsLowDERSignature(vchSig, serror)) {
+
+    if (!CheckRawSignatureEncoding(
+            vchSig | boost::adaptors::sliced(0, vchSig.size() - 1), flags,
+            serror)) {
         // serror is set
         return false;
     }
-    if ((flags & SCRIPT_VERIFY_STRICTENC) != 0) {
+
+    if (flags & SCRIPT_VERIFY_STRICTENC) {
         if (!IsDefinedHashtypeSignature(vchSig)) {
             return set_error(serror, SCRIPT_ERR_SIG_HASHTYPE);
         }
+
         bool usesForkId = bool(GetHashType(vchSig) & SigHashType::FORKID);
         bool forkIdEnabled = flags & SCRIPT_ENABLE_SIGHASH_FORKID;
         if (!forkIdEnabled && usesForkId) {
             return set_error(serror, SCRIPT_ERR_ILLEGAL_FORKID);
         }
+
         if (forkIdEnabled && !usesForkId) {
             return set_error(serror, SCRIPT_ERR_MUST_USE_FORKID);
         }
     }
+
     return true;
 }
 

--- a/src/script/sigencoding.cpp
+++ b/src/script/sigencoding.cpp
@@ -218,6 +218,18 @@ static bool IsDefinedHashtypeSignature(const valtype &vchSig) {
     return true;
 }
 
+bool CheckDataSignatureEncoding(const valtype &vchSig, uint32_t flags,
+                                ScriptError *serror) {
+    // Empty signature. Not strictly DER encoded, but allowed to provide a
+    // compact way to provide an invalid signature for use with CHECK(MULTI)SIG
+    if (vchSig.size() == 0) {
+        return true;
+    }
+
+    return CheckRawSignatureEncoding(
+        vchSig | boost::adaptors::sliced(0, vchSig.size()), flags, serror);
+}
+
 bool CheckTransactionSignatureEncoding(const valtype &vchSig, uint32_t flags,
                                        ScriptError *serror) {
     // Empty signature. Not strictly DER encoded, but allowed to provide a

--- a/src/script/sigencoding.h
+++ b/src/script/sigencoding.h
@@ -20,7 +20,12 @@ inline SigHashType GetHashType(const std::vector<unsigned char> &vchSig) {
     return SigHashType(vchSig[vchSig.size() - 1]);
 }
 
-bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig,
-        unsigned int flags, ScriptError* serror);
+/**
+ * Check that the signature provided to authentify a transaction is properly
+ * encoded. Signatures passed to OP_CHECKSIG, OP_CHECKMULTISIG and their verify
+ * variants must be checked using this function.
+ */
+bool CheckTransactionSignatureEncoding(const std::vector<unsigned char> &vchSig, uint32_t flags,
+                                       ScriptError *serror);
 
 #endif

--- a/src/script/sigencoding.h
+++ b/src/script/sigencoding.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2016 The Bitcoin Core developers
+// Copyright (c) 2017-2018 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SCRIPT_SIGENCODING_H
+#define BITCOIN_SCRIPT_SIGENCODING_H
+
+#include "script/sighashtype.h"
+#include "script/script_error.h"
+
+#include <vector>
+
+inline SigHashType GetHashType(const std::vector<unsigned char> &vchSig) {
+    if (vchSig.size() == 0) {
+        return SigHashType::UNDEFINED;
+    }
+
+    return SigHashType(vchSig[vchSig.size() - 1]);
+}
+
+bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig,
+        unsigned int flags, ScriptError* serror);
+
+#endif

--- a/src/script/sigencoding.h
+++ b/src/script/sigencoding.h
@@ -21,6 +21,14 @@ inline SigHashType GetHashType(const std::vector<unsigned char> &vchSig) {
 }
 
 /**
+ * Check that the signature provided on some data is properly encoded.
+ * Signatures passed to OP_CHECKDATASIG and its verify variant must be checked
+ * using this function.
+ */
+bool CheckDataSignatureEncoding(const std::vector<unsigned char> &vchSig, uint32_t flags,
+                                ScriptError *serror);
+
+/**
  * Check that the signature provided to authentify a transaction is properly
  * encoded. Signatures passed to OP_CHECKSIG, OP_CHECKMULTISIG and their verify
  * variants must be checked using this function.

--- a/src/test/sigencoding_tests.cpp
+++ b/src/test/sigencoding_tests.cpp
@@ -20,20 +20,6 @@ static valtype SignatureWithHashType(valtype vchSig, SigHashType sigHash) {
     return vchSig;
 }
 
-static void
-CheckSignatureErrorForAllSigHashType(const valtype &vchSig, uint32_t flags,
-                                     const ScriptError expected_error) {
-    ScriptError err = SCRIPT_ERR_OK;
-    BOOST_CHECK(!CheckDataSignatureEncoding(vchSig, flags, &err));
-    BOOST_CHECK_EQUAL(err, expected_error);
-
-    for (int i = 0; i <= 0xff; i++) {
-        valtype sig = SignatureWithHashType(vchSig, SigHashType(i));
-        BOOST_CHECK(!CheckTransactionSignatureEncoding(sig, flags, &err));
-        BOOST_CHECK_EQUAL(err, expected_error);
-    }
-}
-
 static void CheckSignatureEncodingWithSigHashType(const valtype &vchSig,
                                                   uint32_t flags) {
     ScriptError err = SCRIPT_ERR_OK;
@@ -168,6 +154,8 @@ BOOST_AUTO_TEST_CASE(checksignatureencoding_test) {
         // Invalid R and S types.
         {0x30, 0x06, 0x42, 0x01, 0x01, 0x02, 0x01, 0x01},
         {0x30, 0x06, 0x02, 0x01, 0x01, 0x42, 0x01, 0x01},
+        // S out of bounds.
+        {0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x02, 0x00},
         // Too long.
         {0x30, 0x47, 0x02, 0x21, 0x00, 0x8e, 0x45, 0x16, 0xda, 0x72, 0x53,
          0xcf, 0x06, 0x8e, 0xff, 0xec, 0x6b, 0x95, 0xc4, 0x12, 0x21, 0xc0,
@@ -192,8 +180,8 @@ BOOST_AUTO_TEST_CASE(checksignatureencoding_test) {
 
         if (flags & SCRIPT_VERIFY_LOW_S) {
             // If we do enforce low S, then high S sigs are rejected.
-            CheckSignatureErrorForAllSigHashType(highSSig, flags,
-                                                 SCRIPT_ERR_SIG_HIGH_S);
+            BOOST_CHECK(!CheckDataSignatureEncoding(highSSig, flags, &err));
+            BOOST_CHECK_EQUAL(err, SCRIPT_ERR_SIG_HIGH_S);
         } else {
             // If we do not enforce low S, then high S sigs are accepted.
             CheckSignatureEncodingWithSigHashType(highSSig, flags);
@@ -204,25 +192,26 @@ BOOST_AUTO_TEST_CASE(checksignatureencoding_test) {
                          SCRIPT_VERIFY_STRICTENC)) {
                 // If we get any of the dersig flags, the non canonical dersig
                 // signature fails.
-                CheckSignatureErrorForAllSigHashType(nonDERSig, flags,
-                                                     SCRIPT_ERR_SIG_DER);
+                BOOST_CHECK(
+                    !CheckDataSignatureEncoding(nonDERSig, flags, &err));
+                BOOST_CHECK_EQUAL(err, SCRIPT_ERR_SIG_DER);
             } else {
                 // If we do not check, then it is accepted.
-                CheckSignatureEncodingWithSigHashType(nonDERSig, flags);
+                BOOST_CHECK(CheckDataSignatureEncoding(nonDERSig, flags, &err));
             }
         }
 
         for (const valtype &nonDERSig : nonParsableSigs) {
             if (flags & (SCRIPT_VERIFY_DERSIG | SCRIPT_VERIFY_LOW_S |
                          SCRIPT_VERIFY_STRICTENC)) {
-                // If we get any of the dersig flags, the invalid signature
-                // fails.
-                CheckSignatureErrorForAllSigHashType(nonDERSig, flags,
-                                                     SCRIPT_ERR_SIG_DER);
+                // If we get any of the dersig flags, the high S but non dersig
+                // signature fails.
+                BOOST_CHECK(
+                    !CheckDataSignatureEncoding(nonDERSig, flags, &err));
+                BOOST_CHECK_EQUAL(err, SCRIPT_ERR_SIG_DER);
             } else {
-                // If we do not check, then it is accepted even though it cannot
-                // even be parsed.
-                CheckSignatureEncodingWithSigHashType(nonDERSig, flags);
+                // If we do not check, then it is accepted.
+                BOOST_CHECK(CheckDataSignatureEncoding(nonDERSig, flags, &err));
             }
         }
     }

--- a/src/test/sigencoding_tests.cpp
+++ b/src/test/sigencoding_tests.cpp
@@ -23,8 +23,11 @@ static valtype SignatureWithHashType(valtype vchSig, SigHashType sigHash) {
 static void
 CheckSignatureErrorForAllSigHashType(const valtype &vchSig, uint32_t flags,
                                      const ScriptError expected_error) {
+    ScriptError err = SCRIPT_ERR_OK;
+    BOOST_CHECK(!CheckDataSignatureEncoding(vchSig, flags, &err));
+    BOOST_CHECK_EQUAL(err, expected_error);
+
     for (int i = 0; i <= 0xff; i++) {
-        ScriptError err = SCRIPT_ERR_OK;
         valtype sig = SignatureWithHashType(vchSig, SigHashType(i));
         BOOST_CHECK(!CheckTransactionSignatureEncoding(sig, flags, &err));
         BOOST_CHECK_EQUAL(err, expected_error);
@@ -33,6 +36,9 @@ CheckSignatureErrorForAllSigHashType(const valtype &vchSig, uint32_t flags,
 
 static void CheckSignatureEncodingWithSigHashType(const valtype &vchSig,
                                                   uint32_t flags) {
+    ScriptError err = SCRIPT_ERR_OK;
+    BOOST_CHECK(CheckDataSignatureEncoding(vchSig, flags, &err));
+
     const bool hasForkId = (flags & SCRIPT_ENABLE_SIGHASH_FORKID) != 0;
     const bool hasStrictEnc = (flags & SCRIPT_VERIFY_STRICTENC) != 0;
 
@@ -46,8 +52,6 @@ static void CheckSignatureEncodingWithSigHashType(const valtype &vchSig,
     }
 
     for (const SigHashType baseSigHash : baseSigHashes) {
-        ScriptError err = SCRIPT_ERR_OK;
-
         // Check the signature with the proper forkid flag.
         SigHashType sigHash = baseSigHash;
         if (hasForkId) {
@@ -180,6 +184,7 @@ BOOST_AUTO_TEST_CASE(checksignatureencoding_test) {
         ScriptError err = SCRIPT_ERR_OK;
 
         // Empty sig is always valid.
+        BOOST_CHECK(CheckDataSignatureEncoding({}, flags, &err));
         BOOST_CHECK(CheckTransactionSignatureEncoding({}, flags, &err));
 
         // Signature are valid as long as the forkid flag is correct.

--- a/src/test/sigencoding_tests.cpp
+++ b/src/test/sigencoding_tests.cpp
@@ -26,7 +26,7 @@ CheckSignatureErrorForAllSigHashType(const valtype &vchSig, uint32_t flags,
     for (int i = 0; i <= 0xff; i++) {
         ScriptError err = SCRIPT_ERR_OK;
         valtype sig = SignatureWithHashType(vchSig, SigHashType(i));
-        BOOST_CHECK(!CheckSignatureEncoding(sig, flags, &err));
+        BOOST_CHECK(!CheckTransactionSignatureEncoding(sig, flags, &err));
         BOOST_CHECK_EQUAL(err, expected_error);
     }
 }
@@ -54,7 +54,7 @@ static void CheckSignatureEncodingWithSigHashType(const valtype &vchSig,
             sigHash |= SigHashType::FORKID;
         }
         valtype validSig = SignatureWithHashType(vchSig, sigHash);
-        BOOST_CHECK(CheckSignatureEncoding(validSig, flags, &err));
+        BOOST_CHECK(CheckTransactionSignatureEncoding(validSig, flags, &err));
 
         // If we have strict encoding, we prevent the use of undefined flags.
         std::array<SigHashType, 2> undefSigHashes{
@@ -64,8 +64,9 @@ static void CheckSignatureEncodingWithSigHashType(const valtype &vchSig,
 
         for (SigHashType undefSigHash : undefSigHashes) {
             valtype undefSighash = SignatureWithHashType(vchSig, undefSigHash);
-            BOOST_CHECK_EQUAL(CheckSignatureEncoding(undefSighash, flags, &err),
-                              !hasStrictEnc);
+            BOOST_CHECK_EQUAL(
+                CheckTransactionSignatureEncoding(undefSighash, flags, &err),
+                !hasStrictEnc);
             if (hasStrictEnc) {
                 BOOST_CHECK_EQUAL(err, SCRIPT_ERR_SIG_HASHTYPE);
             }
@@ -77,8 +78,9 @@ static void CheckSignatureEncodingWithSigHashType(const valtype &vchSig,
             : baseSigHash | SigHashType::FORKID;
         valtype invalidSig = SignatureWithHashType(vchSig, invalidSigHash);
 
-        BOOST_CHECK_EQUAL(CheckSignatureEncoding(invalidSig, flags, &err),
-                          !hasStrictEnc);
+        BOOST_CHECK_EQUAL(
+            CheckTransactionSignatureEncoding(invalidSig, flags, &err),
+            !hasStrictEnc);
         if (hasStrictEnc) {
             BOOST_CHECK_EQUAL(err,
                               hasForkId ? SCRIPT_ERR_MUST_USE_FORKID
@@ -178,7 +180,7 @@ BOOST_AUTO_TEST_CASE(checksignatureencoding_test) {
         ScriptError err = SCRIPT_ERR_OK;
 
         // Empty sig is always valid.
-        BOOST_CHECK(CheckSignatureEncoding({}, flags, &err));
+        BOOST_CHECK(CheckTransactionSignatureEncoding({}, flags, &err));
 
         // Signature are valid as long as the forkid flag is correct.
         CheckSignatureEncodingWithSigHashType(minimalSig, flags);

--- a/src/test/sigencoding_tests.cpp
+++ b/src/test/sigencoding_tests.cpp
@@ -5,6 +5,8 @@
 #include "test/test_bitcoin.h"
 
 #include "script/interpreter.h"
+#include "script/script_flags.h"
+#include "script/sigencoding.h"
 #include "script/sighashtype.h"
 
 #include <boost/test/unit_test.hpp>


### PR DESCRIPTION
On top of #500 

* Use sliced to remove the sighash byte from a signature to check for low S - https://reviews.bitcoinabc.org/D1572
* Refactor IsValidSignatureEncoding - https://reviews.bitcoinabc.org/D1576
* Ignore sighash when checking for DER encoding. - https://reviews.bitcoinabc.org/D1577
* Refactor signature encoding checks to separates checks of the SigHashType and other checks - https://reviews.bitcoinabc.org/D1578
* Add CheckDataSignatureEncoding to check signature with a sighashtype. - https://reviews.bitcoinabc.org/D1579
* Make sigencoding_tests significantly faster by not checking the full sigashtype/flags combinatorial - https://reviews.bitcoinabc.org/D1580

Also includes a MOVEONLY commit for signature encoding stuff to ease cherry picking.