### PR TITLE
Eliminate artificial transaction relay delays

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -90,9 +90,6 @@ static const unsigned int MAX_REJECT_MESSAGE_LENGTH = 111;
 static const unsigned int AVG_LOCAL_ADDRESS_BROADCAST_INTERVAL = 24 * 60 * 60;
 /** Average delay between peer address broadcasts in seconds. */
 static const unsigned int AVG_ADDRESS_BROADCAST_INTERVAL = 30;
-/** Average delay between trickled inventory broadcasts in seconds.
- *  Blocks, whitelisted receivers, and a random 25% of transactions bypass this. */
-static const unsigned int AVG_INVENTORY_BROADCAST_INTERVAL = 5;
 
 /** Default for -stopatheight */
 static const int DEFAULT_STOPATHEIGHT = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2174,7 +2174,6 @@ CNode::CNode(NodeId idIn, uint64_t nLocalServicesIn, int nMyStartingHeightIn, SO
     fGetAddr = false;
     nNextLocalAddrSend = 0;
     nNextAddrSend = 0;
-    nNextInvSend = 0;
     fRelayTxes = false;
     fSentAddr = false;
     pfilter.reset(new CBloomFilter);

--- a/src/net.h
+++ b/src/net.h
@@ -569,7 +569,6 @@ public:
     std::vector<CInv> vInventoryToSend;
     CCriticalSection cs_inventory;
     std::multimap<int64_t, CInv> mapAskFor;
-    int64_t nNextInvSend;
     // Used for headers announcements - unfiltered blocks to relay
     // Also protected by cs_inventory
     std::vector<uint256> blocksToAnnounce;


### PR DESCRIPTION
Eliminate artificial delays from transaction relay.

Relay delays were added by Bitcoin Core to improve certain kinds of privacy, but the delays were never quantitatively justified.  At the recent BCH instant transactions development conference, there was universal agreement that Bitcoin Cash cannot afford to sacrifice any tx relay speed as it strives for instantly reliable transactions.  Users have several independent avenues for protecting their privacy.

Bitcoin Unlimited has already deployed essentially the policy that results from this change.

The trickle code did not have test coverage, so no test modifications were needed. However, in my trials, the qa test suite as a whole runs over 10 minutes faster with this change.
