### PR TITLE
[wallet] Always enable replay protection for BCH

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2063,7 +2063,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
 
                 // Transaction signature hash type changes at hard fork
                 SigHashType nHashType = SigHashType::ALL;
-                if ((Opt().UAHFTime() != 0) && (chainActive.Tip()->GetMedianTimePast() >= Opt().UAHFTime())) {
+                if (Opt().UAHFTime()) {
                     nHashType |= SigHashType::FORKID;
                 }
 


### PR DESCRIPTION
This check as is allowed for transacting before BCH forked from BTC. But now that the fork has happened, we want to always want to sign with FORKID.