### PR TITLE
Introduce BlockBuilder interface

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -129,7 +129,8 @@ testScripts = [
     'bip64.py',
     'p2p-leaktests.py',
     'abc-transaction-ordering.py',
-    'abc-checkdatasig-activation.py'
+    'abc-checkdatasig-activation.py',
+    'ctor-mining.py'
 ]
 
 testScriptsExt = [

--- a/qa/rpc-tests/ctor-mining.py
+++ b/qa/rpc-tests/ctor-mining.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+Test that mining RPC continues to supply correct transaction metadata after
+the Nov 2018 protocol upgrade which engages canonical transaction ordering
+"""
+
+import time
+import random
+import decimal
+
+from test_framework.blocktools import create_coinbase
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+
+class CTORMiningTest(BitcoinTestFramework):
+
+    def set_test_params(self):
+        # Setup two nodes so we can getblocktemplate
+        # it errors out if it is not connected to other nodes
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+        self.block_heights = {}
+        self.tip = None
+        self.blocks = {}
+
+
+    def run_test(self):
+        mining_node = self.nodes[0]
+
+        # Generate some unspent utxos
+        for x in range(150):
+            mining_node.generate(1)
+
+        unspent = mining_node.listunspent()
+
+        transactions = {}
+        # Spend all our coinbases
+        while len(unspent):
+            inputs = []
+            # Grab a random number of inputs
+            for _ in range(random.randrange(1, 5)):
+                txin = unspent.pop()
+                inputs.append({
+                    'txid': txin['txid'],
+                    'vout': txin['vout'],
+                    'amount' : txin['amount']
+                })
+                if len(unspent) == 0:
+                    break
+
+            outputs = {}
+            # Calculate a unique fee for this transaction
+            fee = decimal.Decimal(random.randint(
+                1000, 2000)) / decimal.Decimal(1e8)
+            # Spend to the same number of outputs as inputs, so we can leave
+            # the amounts unchanged and avoid rounding errors.
+            #
+            # NOTE: There will be 1 sigop per output (which equals the number
+            # of inputs now).  We need this randomization to ensure the
+            # numbers are properly following the transactions in the block
+            # template metadata
+            addr = ""
+            for i in inputs:
+                addr = mining_node.getnewaddress()
+                output = {
+                    addr : i['amount']
+                }
+                outputs.update(output)
+
+            # Take the fee off the last output to avoid rounding errors we
+            # need the exact fee later for assertions
+            outputs[addr] -= fee
+
+            rawtx = mining_node.createrawtransaction(inputs, outputs)
+            signedtx = mining_node.signrawtransaction(rawtx)
+            txid = mining_node.sendrawtransaction(signedtx['hex'])
+            # number of outputs is the same as the number of sigops in this
+            # case
+            transactions.update({txid: {'fee': fee, 'sigops': len(outputs)}})
+
+        tmpl = mining_node.getblocktemplate()
+        assert 'proposal' in tmpl['capabilities']
+        assert 'coinbasetxn' not in tmpl
+
+        # Check the template transaction metadata and ordering
+        last_txid = 0
+        for txn in tmpl['transactions'][1:]:
+            txid = txn['hash']
+            txnMetadata = transactions[txid]
+            expectedFeeSats = int(txnMetadata['fee'] * 10**8)
+            expectedSigOps = txnMetadata['sigops']
+
+            txid_decoded = int(txid, 16)
+
+            # Assert we got the expected metadata
+            assert(expectedFeeSats == txn['fee'])
+            assert(expectedSigOps == txn['sigops'])
+            # Assert transaction ids are in order
+            assert(last_txid == 0 or last_txid < txid_decoded)
+            last_txid = txid_decoded
+
+
+if __name__ == '__main__':
+    CTORMiningTest().main()

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -134,6 +134,11 @@ BITCOIN_CORE_H = \
   memusage.h \
   merkleblock.h \
   miner.h \
+  miner/blockbuilder.h \
+  miner/gbtblockbuilder.h \
+  miner/gbtparser.h \
+  miner/serializableblockbuilder.h \
+  miner/utilminer.h \
   net.h \
   netbase.h \
   netmessagemaker.h \
@@ -243,6 +248,10 @@ libbitcoin_server_a_SOURCES = \
   mempoolfeemodifier.cpp \
   merkleblock.cpp \
   miner.cpp \
+  miner/gbtblockbuilder.cpp \
+  miner/gbtparser.cpp \
+  miner/serializableblockbuilder.cpp \
+  miner/utilminer.cpp \
   net.cpp \
   noui.cpp \
   options.cpp \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2919,7 +2919,7 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
     int nHeight = pindexPrev->nHeight+1;
 
     // Check proof of work
-    if (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams))
+    if (block.nBits != GetNextWorkRequired(pindexPrev, block.GetBlockTime(), consensusParams))
         return state.DoS(100, error("%s: incorrect proof of work", __func__),
                          REJECT_INVALID, "bad-diffbits");
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -14,6 +14,9 @@
 #include "hash.h"
 #include "main.h"
 #include "maxblocksize.h"
+#include "miner/blockbuilder.h"
+#include "miner/serializableblockbuilder.h"
+#include "miner/utilminer.h"
 #include "net.h"
 #include "policy/policy.h"
 #include "pow.h"
@@ -52,8 +55,22 @@ void UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, 
     pblock->nTime = std::max(pindexPrev->GetMedianTimePast()+1, GetAdjustedTime());
 
     // Updating time can change work required on testnet:
-    if (consensusParams.fPowAllowMinDifficultyBlocks)
-        pblock->nBits = GetNextWorkRequired(pindexPrev, pblock, consensusParams);
+    if (consensusParams.fPowAllowMinDifficultyBlocks) {
+        pblock->nBits = GetNextWorkRequired(pindexPrev, pblock->GetBlockTime(), consensusParams);
+    }
+}
+
+void UpdateTime(miner::BlockBuilder& block,
+                const Consensus::Params& consensusParams,
+                const CBlockIndex* pindexPrev)
+{
+    CBlockHeader dummy;
+    dummy.nBits = 0;
+    UpdateTime(&dummy, consensusParams, pindexPrev);
+    block.SetTime(dummy.GetBlockTime());
+    if (dummy.nBits != 0) {
+        block.SetBits(dummy.nBits);
+    }
 }
 
 // BIP100 string:
@@ -73,25 +90,9 @@ std::vector<unsigned char> BIP100Str(uint64_t hardLimit) {
     return std::vector<unsigned char>(begin(s), end(s));
 }
 
-// Make sure coinbase is at minimum MIN_TRANSACTION_SIZE
-static void BloatCoinbaseSize(CMutableTransaction& coinbase) {
-    size_t size = ::GetSerializeSize(coinbase, SER_NETWORK, PROTOCOL_VERSION);
-    if (size >= MIN_TRANSACTION_SIZE) {
-        return;
-    }
-    // operator<< prefixes the padding with minimum 1 byte, thus -1
-    size_t padding = MIN_TRANSACTION_SIZE - size - 1;
-    coinbase.vin[0].scriptSig << std::vector<uint8_t>(padding);
-}
-
-CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
+void CreateNewBlock(miner::BlockBuilder& block, const CScript& scriptPubKeyIn, bool checkValidity)
 {
     const CChainParams& chainparams = Params();
-    // Create new block
-    unique_ptr<CBlockTemplate> pblocktemplate(new CBlockTemplate());
-    if(!pblocktemplate.get())
-        return NULL;
-    CBlock *pblock = &pblocktemplate->block; // pointer for convenience
 
     // Create coinbase tx
     CMutableTransaction txNew;
@@ -100,13 +101,8 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
     txNew.vout.resize(1);
     txNew.vout[0].scriptPubKey = scriptPubKeyIn;
 
-    // Add dummy coinbase tx as first transaction
-    pblock->vtx.push_back(CTransaction());
-    pblocktemplate->vTxFees.push_back(-1); // updated at end
-    pblocktemplate->vTxSigOps.push_back(-1); // updated at end
-
     // Largest block you're willing to create:
-    uint64_t hardLimit = GetNextMaxBlockSize(chainActive.Tip(), chainparams.GetConsensus());
+    const uint64_t hardLimit = GetNextMaxBlockSize(chainActive.Tip(), chainparams.GetConsensus());
     uint64_t nBlockMaxSize = GetArg("-blockmaxsize", hardLimit);
     // Limit to between 1K and (hard limit - 1K) for sanity:
     nBlockMaxSize = std::max((uint64_t)1000, std::min((hardLimit - 1000),  nBlockMaxSize));
@@ -125,25 +121,26 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
     int lastFewTxs = 0;
     CAmount nFees = 0;
 
-    int64_t nMedianTimePast = 0;
-
     {
         LOCK2(cs_main, mempool.cs);
         CBlockIndex* pindexPrev = chainActive.Tip();
         const int nHeight = pindexPrev->nHeight + 1;
-        pblock->nTime = GetAdjustedTime();
-        nMedianTimePast = pindexPrev->GetMedianTimePast();
+        block.SetTime(GetAdjustedTime());
+        const int64_t nMedianTimePast = pindexPrev->GetMedianTimePast();
+        if (!IsFourthHFActive(nMedianTimePast)) {
+            block.DisableLTOR();
+        }
 
-        pblock->nVersion = ComputeBlockVersion(pindexPrev, chainparams.GetConsensus());
         // -regtest only: allow overriding block.nVersion with
         // -blockversion=N to test forking scenarios
-        if (Params().MineBlocksOnDemand())
-            pblock->nVersion = GetArg("-blockversion", pblock->nVersion);
-
+        block.SetVersion(ComputeBlockVersion(pindexPrev, chainparams.GetConsensus()));
+        if (Params().MineBlocksOnDemand()) {
+            block.SetVersion(GetArg("-blockversion", block.GetVersion()));
+        }
 
         int64_t nLockTimeCutoff = (STANDARD_LOCKTIME_VERIFY_FLAGS & LOCKTIME_MEDIAN_TIME_PAST)
                                 ? nMedianTimePast
-                                : pblock->GetBlockTime();
+                                : block.GetTime();
 
         CTxMemPool::indexed_transaction_set::nth_index<3>::type::iterator mi = mempool.mapTx.get<3>().begin();
         CTxMemPool::txiter iter;
@@ -163,7 +160,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
                 continue;
             }
 
-            const CTransaction& tx = iter->GetTx();
+            miner::BuilderEntry tx(&(iter->GetTx()), iter->GetSigOpCount(), iter->GetFee());
 
             if (fSkipNegativeDelta && mempool.GetFeeModifier().GetDelta(tx.GetHash()) < 0) {
                 continue;
@@ -206,12 +203,12 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
                 continue;
             }
 
-            if (!IsFinalTx(tx, nHeight, nLockTimeCutoff))
+            if (!tx.IsFinalTx(nHeight, nLockTimeCutoff))
                 continue;
 
             // TODO: with more complexity we could make the block bigger when
             // sigop-constrained and sigop density in later megabytes is low
-            unsigned int nTxSigOps = iter->GetSigOpCount();
+            const uint32_t& nTxSigOps = tx.GetSigOpCount();
             if (nBlockSigOps + nTxSigOps >= MaxBlockSigops(nBlockSize)) {
                 if (nBlockSigOps > MaxBlockSigops(nBlockSize) - 2) {
                     break;
@@ -219,27 +216,14 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
                 continue;
             }
 
-            CAmount nTxFees = iter->GetFee();
             // Added
-            pblock->vtx.push_back(tx);
-            pblocktemplate->vTxFees.push_back(nTxFees);
-            pblocktemplate->vTxSigOps.push_back(nTxSigOps);
+            block.AddTx(std::move(tx));
             nBlockSize += nTxSize;
             ++nBlockTx;
             nBlockSigOps += nTxSigOps;
-            nFees += nTxFees;
+            nFees += tx.GetFee();
 
             inBlock.insert(iter);
-        }
-
-
-        if (IsFourthHFActive(nMedianTimePast)) {
-            // If magnetic anomaly is enabled, we make sure transaction are
-            // lexically ordered.
-            std::sort(std::begin(pblock->vtx) + 1, std::end(pblock->vtx),
-                    [](const CTransaction& a, const CTransaction& b) -> bool {
-                        return a.GetHash() < b.GetHash();
-                    });
         }
 
         nLastBlockTx = nBlockTx;
@@ -249,25 +233,43 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
         // Compute final coinbase transaction.
         txNew.vout[0].nValue = nFees + GetBlockSubsidy(nHeight, chainparams.GetConsensus());
         txNew.vin[0].scriptSig = CScript() << nHeight << BIP100Str(hardLimit) << OP_0;
-        BloatCoinbaseSize(txNew);
-        pblock->vtx[0] = txNew;
-        pblocktemplate->vTxFees[0] = -nFees;
+        miner::BloatCoinbaseSize(txNew);
+        CTransaction coinbaseTx(txNew);
+        miner::BuilderEntry coinbase(&coinbaseTx, GetLegacySigOpCount(txNew, STANDARD_CHECKDATASIG_VERIFY_FLAGS), 0);
+        block.SetCoinbase(std::move(coinbase));
 
         // Fill in header
-        pblock->hashPrevBlock  = pindexPrev->GetBlockHash();
-        UpdateTime(pblock, Params().GetConsensus(), pindexPrev);
-        pblock->nBits          = GetNextWorkRequired(pindexPrev, pblock, Params().GetConsensus());
-        pblock->nNonce         = 0;
-        pblocktemplate->vTxSigOps[0] = GetLegacySigOpCount(pblock->vtx[0],
-                                                           STANDARD_CHECKDATASIG_VERIFY_FLAGS);
+        block.SetHashPrevBlock(pindexPrev->GetBlockHash());
+        UpdateTime(block, Params().GetConsensus(), pindexPrev);
+        block.SetBits(GetNextWorkRequired(pindexPrev, block.GetTime(), Params().GetConsensus()));
 
-        CValidationState state;
-        if (!TestBlockValidity(state, *pblock, pindexPrev, false, false)) {
-            throw std::runtime_error(strprintf("%s: TestBlockValidity failed: %s", __func__, FormatStateMessage(state)));
+        if (block.NeedsGBTMetadata()) {
+            block.SetBlockMinTime(nMedianTimePast + 1);
+            block.SetBlockHeight(nHeight);
+            block.SetBlockSizeLimit(hardLimit);
+            block.SetBlockSigopLimit(MaxBlockSigops(nBlockSize));
+
+            CScript flags = CScript() << BIP100Str(hardLimit);
+            flags +=  COINBASE_FLAGS;
+            block.SetCoinbaseAuxFlags(std::move(flags));
+            std::map<Consensus::DeploymentPos, ThresholdState> bip135state;
+            for (int i = 0; i < static_cast<int>(Consensus::MAX_VERSION_BITS_DEPLOYMENTS); ++i) {
+                Consensus::DeploymentPos pos = Consensus::DeploymentPos(i);
+                if (!IsConfiguredDeployment(chainparams.GetConsensus(), pos)) {
+                    continue;
+                }
+                bip135state[pos] = VersionBitsState(pindexPrev,
+                                                     chainparams.GetConsensus(),
+                                                     pos, versionbitscache);
+            }
+            block.SetBIP135State(bip135state);
+        }
+        block.Finalize(chainparams.GetConsensus());
+
+        if (checkValidity) {
+            block.CheckValidity(pindexPrev);
         }
     }
-
-    return pblocktemplate.release();
 }
 
 void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce, uint64_t nMaxBlockSize)
@@ -386,40 +388,39 @@ void static BitcoinMiner(const CChainParams& chainparams, CConnman* connman)
             unsigned int nTransactionsUpdatedLast = mempool.GetTransactionsUpdated();
             CBlockIndex* pindexPrev = chainActive.Tip();
 
-            unique_ptr<CBlockTemplate> pblocktemplate(CreateNewBlock(coinbaseScript->reserveScript));
-            if (!pblocktemplate.get())
+            CBlock block;
             {
-                LogPrintf("Error in BitcoinMiner: Keypool ran out, please call keypoolrefill before restarting the mining thread\n");
-                return;
+                miner::SerializableBlockBuilder blockbuilder;
+                CreateNewBlock(blockbuilder, coinbaseScript->reserveScript);
+                block = blockbuilder.Release();
             }
-            CBlock *pblock = &pblocktemplate->block;
             uint64_t hardLimit = GetNextMaxBlockSize(pindexPrev, chainparams.GetConsensus());
-            IncrementExtraNonce(pblock, pindexPrev, nExtraNonce, hardLimit);
+            IncrementExtraNonce(&block, pindexPrev, nExtraNonce, hardLimit);
 
-            LogPrintf("Running BitcoinMiner with %u transactions in block (%u bytes)\n", pblock->vtx.size(),
-                ::GetSerializeSize(*pblock, SER_NETWORK, PROTOCOL_VERSION));
+            LogPrintf("Running BitcoinMiner with %u transactions in block (%u bytes)\n", block.vtx.size(),
+                ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION));
 
             //
             // Search
             //
             int64_t nStart = GetTime();
-            arith_uint256 hashTarget = arith_uint256().SetCompact(pblock->nBits);
+            arith_uint256 hashTarget = arith_uint256().SetCompact(block.nBits);
             uint256 hash;
             uint32_t nNonce = 0;
             while (true) {
                 // Check if something found
-                if (ScanHash(pblock, nNonce, &hash))
+                if (ScanHash(&block, nNonce, &hash))
                 {
                     if (UintToArith256(hash) <= hashTarget)
                     {
                         // Found a solution
-                        pblock->nNonce = nNonce;
-                        assert(hash == pblock->GetHash());
+                        block.nNonce = nNonce;
+                        assert(hash == block.GetHash());
 
                         SetThreadPriority(THREAD_PRIORITY_NORMAL);
                         LogPrintf("BitcoinMiner:\n");
                         LogPrintf("proof-of-work found  \n  hash: %s  \ntarget: %s\n", hash.GetHex(), hashTarget.GetHex());
-                        ProcessBlockFound(pblock, chainparams, connman);
+                        ProcessBlockFound(&block, chainparams, connman);
                         SetThreadPriority(THREAD_PRIORITY_LOWEST);
                         coinbaseScript->KeepScript();
 
@@ -444,12 +445,11 @@ void static BitcoinMiner(const CChainParams& chainparams, CConnman* connman)
                 if (pindexPrev != chainActive.Tip())
                     break;
 
-                // Update nTime every few seconds
-                UpdateTime(pblock, chainparams.GetConsensus(), pindexPrev);
+                UpdateTime(&block, chainparams.GetConsensus(), pindexPrev);
                 if (chainparams.GetConsensus().fPowAllowMinDifficultyBlocks)
                 {
                     // Changing pblock->nTime can change work required on testnet:
-                    hashTarget.SetCompact(pblock->nBits);
+                    hashTarget.SetCompact(block.nBits);
                 }
             }
         }

--- a/src/miner.h
+++ b/src/miner.h
@@ -17,6 +17,7 @@ class CReserveKey;
 class CScript;
 class CWallet;
 namespace Consensus { struct Params; };
+namespace miner { class BlockBuilder; }
 
 struct CBlockTemplate
 {
@@ -28,7 +29,7 @@ struct CBlockTemplate
 /** Run the miner threads */
 void GenerateBitcoins(bool fGenerate, int nThreads, const CChainParams& chainparams, CConnman*);
 /** Generate a new block, without valid proof-of-work */
-CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn);
+void CreateNewBlock(miner::BlockBuilder& block, const CScript& scriptPubKeyIn, bool checkValidity = true);
 /** Modify the extranonce in a block */
 void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce, uint64_t nMaxBlockSize);
 void UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);

--- a/src/miner/blockbuilder.h
+++ b/src/miner/blockbuilder.h
@@ -1,0 +1,106 @@
+#ifndef BITCOIN_MINER_BLOCKBUILDER
+#define BITCOIN_MINER_BLOCKBUILDER
+
+#include "consensus/tx_verify.h"
+#include "versionbits.h" // ThresholdState
+
+namespace miner {
+
+class BuilderEntry {
+public:
+
+    BuilderEntry(const CTransaction* t, uint32_t sigopcount, const CAmount& fee)
+        : tx(t), sigOpCount(sigopcount), nFee(fee) {
+    }
+
+    const uint256& GetHash() const {
+        assert(IsValid());
+        return tx->GetHash();
+    }
+
+    bool IsFinalTx(const int nHeight, int64_t nLockTimeCutoff) const {
+        assert(IsValid());
+        return ::IsFinalTx(*tx, nHeight, nLockTimeCutoff);
+    }
+
+    const CTransaction& GetTx() const {
+        assert(IsValid());
+        return *tx;
+    }
+
+    const uint32_t& GetSigOpCount() const {
+        return sigOpCount;
+    }
+
+    const CAmount& GetFee() const {
+        return nFee;
+    }
+
+    bool IsCoinBase() const {
+        assert(IsValid());
+        return tx->IsCoinBase();
+    }
+
+    bool IsValid() const {
+        return tx != nullptr;
+    }
+
+private:
+    const CTransaction* tx;
+    uint32_t sigOpCount;
+    CAmount nFee;
+};
+
+inline bool EntryHashCmp(const BuilderEntry& a, const BuilderEntry& b) {
+    return a.GetHash() < b.GetHash();
+}
+
+class BlockBuilder {
+public:
+    virtual void SetTime(uint32_t t) = 0;
+    virtual uint32_t GetTime() const = 0;
+
+    virtual void SetVersion(uint32_t v) = 0;
+    virtual uint32_t GetVersion() const = 0;
+
+    virtual void SetCoinbase(BuilderEntry tx) = 0;
+    virtual void AddTx(BuilderEntry tx) = 0;
+
+    virtual void SetBits(uint32_t bits) = 0;
+    virtual void SetHashPrevBlock(const uint256& hash) = 0;
+
+    // If LTOR is disabled, it becomes the callers responsiblity to add
+    // transactions in the correct order.
+    virtual void DisableLTOR() = 0;
+
+    // As BlockBuilder only holds references to transactions, this needs to be
+    // called before any of them go out of scope.
+    virtual void Finalize(const Consensus::Params&) = 0;
+
+    // Sanity check.
+    // Validates the block contents and throws if it's not valid.
+    //
+    // This check is optional and can be slow, as
+    // a CBlock needs to be constructed.
+    virtual void CheckValidity(CBlockIndex* pindexPrev) = 0;
+
+    // If the interface requires some or all of the extended metadata required
+    // by 'getblocktemplate' (aka GBT).
+    //
+    // If this functions return false, calling the GBT functions is optional.
+    virtual bool NeedsGBTMetadata() const = 0;
+
+    // Below are methods for feeding GBT with data. If NeedsGBTMetadata is true,
+    // these must be called.
+    virtual void SetBlockMinTime(int64_t) = 0;
+    virtual void SetBlockHeight(int32_t) = 0;
+    virtual void SetBIP135State(const std::map<Consensus::DeploymentPos, ThresholdState>& state) = 0;
+    virtual void SetBlockSizeLimit(uint64_t limit) = 0;
+    virtual void SetBlockSigopLimit(uint64_t limit) = 0;
+    virtual void SetCoinbaseAuxFlags(CScript) = 0;
+
+};
+
+} // ns miner
+
+#endif

--- a/src/miner/gbtblockbuilder.cpp
+++ b/src/miner/gbtblockbuilder.cpp
@@ -1,0 +1,265 @@
+#include "miner/gbtblockbuilder.h"
+
+#include "consensus/validation.h"
+#include "core_io.h" // EncodeHexTx
+#include "main.h" // TestBlockValidity
+#include "miner/gbtparser.h"
+#include "utildebug.h"
+#include "utilhash.h"
+#include "utilstrencodings.h"
+
+#include <unordered_map>
+
+static const Consensus::ForkDeployment& gbt_vb_fork(
+        const Consensus::Params& consensusParams,
+        const Consensus::DeploymentPos pos)
+{
+    return consensusParams.vDeployments.at(pos);
+}
+
+static const std::string gbt_vb_name(const Consensus::ForkDeployment& fork) {
+    std::string s = fork.name;
+    if (!fork.gbt_force) {
+        s.insert(s.begin(), '!');
+    }
+    return s;
+}
+
+namespace miner {
+
+GBTBlockBuilder::GBTBlockBuilder() : block(UniValue::VOBJ), coinbase(nullptr, 0, 0),
+                                     useLTOR(true), nMaxVersionPreVB(-1), blockHeight(-1),
+                                     blockMinTime(-1), blockMaxSize(0), blockMaxSigops(0)
+{
+}
+
+void GBTBlockBuilder::SetTime(uint32_t t) {
+    dummyheader.nTime = t;
+}
+
+uint32_t GBTBlockBuilder::GetTime() const {
+    return dummyheader.GetBlockTime();
+}
+
+void GBTBlockBuilder::SetVersion(uint32_t v) {
+    dummyheader.nVersion = v;
+}
+
+uint32_t GBTBlockBuilder::GetVersion() const {
+    return dummyheader.nVersion;
+}
+
+void GBTBlockBuilder::SetCoinbase(BuilderEntry tx) {
+    coinbase = std::move(tx);
+}
+
+void GBTBlockBuilder::AddTx(BuilderEntry tx) {
+    txs.emplace_back(std::move(tx));
+}
+
+void GBTBlockBuilder::SetBits(uint32_t bits) {
+    dummyheader.nBits = bits;
+}
+
+uint32_t GBTBlockBuilder::GetBits() {
+    return dummyheader.nBits;
+}
+
+void GBTBlockBuilder::SetHashPrevBlock(const uint256& hash) {
+    dummyheader.hashPrevBlock = hash;
+}
+
+// If LTOR is disabled, it becomes the callers responsiblity to add
+// transactions in the correct order.
+void GBTBlockBuilder::DisableLTOR() {
+    useLTOR = false;
+}
+
+void GBTBlockBuilder::Finalize(const Consensus::Params& consensusParams) {
+    THROW_UNLESS(block.empty());
+    THROW_UNLESS(coinbase.IsCoinBase());
+    THROW_UNLESS(blockMinTime != -1);
+    THROW_UNLESS(blockHeight != -1);
+    THROW_UNLESS(blockMaxSize != 0);
+    THROW_UNLESS(blockMaxSigops != 0);
+    THROW_UNLESS(!longpollid.empty());
+
+    if (useLTOR) {
+        std::sort(std::begin(txs), std::end(txs), EntryHashCmp);
+    }
+
+    UniValue aCaps(UniValue::VARR);
+    aCaps.push_back("proposal");
+    UniValue transactions(UniValue::VARR);
+
+    std::unordered_map<uint256, int64_t, SaltedTxIDHasher> setTxIndex;
+    int64_t i = 0;
+    for (const auto& tx : txs) {
+        const uint256& txHash = tx.GetHash();
+        setTxIndex[txHash] = i++;
+
+        THROW_UNLESS(!tx.IsCoinBase());
+
+        UniValue entry(UniValue::VOBJ);
+        entry.push_back(Pair("data", EncodeHexTx(tx.GetTx())));
+        entry.push_back(Pair("hash", txHash.GetHex()));
+
+        UniValue deps(UniValue::VARR);
+        for (const CTxIn &in : tx.GetTx().vin) {
+            if (setTxIndex.count(in.prevout.hash)) {
+                deps.push_back(setTxIndex[in.prevout.hash]);
+            }
+        }
+        entry.push_back(Pair("depends", deps));
+        entry.push_back(Pair("fee", tx.GetFee()));
+        entry.push_back(Pair("sigops", uint64_t(tx.GetSigOpCount())));
+        transactions.push_back(entry);
+    }
+
+    arith_uint256 hashTarget = arith_uint256().SetCompact(GetBits());
+
+    UniValue aMutable(UniValue::VARR);
+    aMutable.push_back("time");
+    aMutable.push_back("transactions");
+    aMutable.push_back("prevblock");
+
+    block.push_back(Pair("capabilities", aCaps));
+
+    UniValue aRules(UniValue::VARR);
+    UniValue vbavailable(UniValue::VOBJ);
+    for (auto& bit_threshold : bip135state) {
+        Consensus::DeploymentPos bit = bit_threshold.first;
+        ThresholdState state = bit_threshold.second;
+
+        switch (state) {
+        case THRESHOLD_DEFINED:
+        case THRESHOLD_FAILED:
+            // Not exposed to GBT at all
+            break;
+        case THRESHOLD_LOCKED_IN:
+            // Ensure bit is set in block version
+            dummyheader.nVersion |= VersionBitsMask(consensusParams, bit);
+            // FALLTHROUGH
+            // to get vbavailable set...
+        case THRESHOLD_STARTED:
+            {
+                const Consensus::ForkDeployment &fork = gbt_vb_fork(consensusParams, bit);
+                std::string forkName = gbt_vb_name(fork);
+                vbavailable.push_back(Pair(forkName, bit));
+                if (clientRules.find(fork.name) == clientRules.end())
+                {
+                    if (!fork.gbt_force)
+                    {
+                        // If the client doesn't support this, don't indicate it
+                        // in the [default] version
+                        dummyheader.nVersion &= ~VersionBitsMask(consensusParams, bit);
+                    }
+                }
+                break;
+            }
+        case THRESHOLD_ACTIVE:
+            {
+                // Add to rules only
+                const Consensus::ForkDeployment &fork = gbt_vb_fork(consensusParams, bit);
+                std::string forkName = gbt_vb_name(fork);
+                aRules.push_back(forkName);
+                if (clientRules.find(fork.name) == clientRules.end()) {
+                    // Not supported by the client; make sure it's safe to
+                    // proceed
+                    if (!fork.gbt_force) {
+                        // If we do anything other than throw an exception here,
+                        // be sure version/force isn't sent to old clients
+                        throw std::invalid_argument(
+                                strprintf("Support for '%s' rule requires explicit client support", fork.name));
+                    }
+                }
+                break;
+            }
+        }
+    }
+    block.push_back(Pair("version", dummyheader.nVersion));
+    block.push_back(Pair("rules", aRules));
+    block.push_back(Pair("vbavailable", vbavailable));
+    block.push_back(Pair("vbrequired", int(0)));
+
+    if (nMaxVersionPreVB >= 2) {
+        // If VB is supported by the client, nMaxVersionPreVB is -1, so we
+        // won't get here Because BIP 34 changed how the generation
+        // transaction is serialised, we can only use version/force back to
+        // v2 blocks This is safe to do [otherwise-]unconditionally only
+        // because we are throwing an exception above if a non-force
+        // deployment gets activated Note that this can probably also be
+        // removed entirely after the first BIP9/BIP135 non-force deployment
+        // (ie, segwit) gets activated
+        aMutable.push_back("version/force");
+    }
+
+    UniValue aux(UniValue::VOBJ);
+    aux.push_back(Pair("flags", HexStr(coinbaseaux.begin(), coinbaseaux.end())));
+
+    block.push_back(Pair("previousblockhash", dummyheader.hashPrevBlock.GetHex()));
+    block.push_back(Pair("transactions", transactions));
+    block.push_back(Pair("coinbaseaux", aux));
+    block.push_back(Pair("coinbasevalue", coinbase.GetFee()));
+    block.push_back(Pair("longpollid", longpollid));
+    block.push_back(Pair("target", hashTarget.GetHex()));
+    block.push_back(Pair("mintime", blockMinTime));
+    block.push_back(Pair("mutable", aMutable));
+    block.push_back(Pair("noncerange", "00000000ffffffff"));
+    block.push_back(Pair("sigoplimit", blockMaxSigops));
+    block.push_back(Pair("sizelimit", blockMaxSize));
+    block.push_back(Pair("curtime", int64_t(GetTime())));
+    block.push_back(Pair("bits", strprintf("%08x", GetBits())));
+    block.push_back(Pair("height", blockHeight));
+}
+
+void GBTBlockBuilder::CheckValidity(CBlockIndex* pindexPrev) {
+    CValidationState state;
+    CBlock b = ParseGBT(block);
+    if (!TestBlockValidity(state, b, pindexPrev, false, false)) {
+        std::stringstream err;
+        err << __func__ << ": TestBlockValidity failed: "
+            << FormatStateMessage(state);
+        throw std::runtime_error(err.str());
+    }
+}
+
+void GBTBlockBuilder::SetBlockMinTime(int64_t t) {
+    blockMinTime = t;
+}
+
+void GBTBlockBuilder::SetBlockHeight(int32_t h) {
+    blockHeight = h;
+}
+
+void GBTBlockBuilder::SetBIP135State(const std::map<Consensus::DeploymentPos,
+                                     ThresholdState>& state) {
+    bip135state = state;
+}
+void GBTBlockBuilder::SetBlockSizeLimit(uint64_t limit) {
+    blockMaxSize = limit;
+}
+
+void GBTBlockBuilder::SetBlockSigopLimit(uint64_t limit) {
+    blockMaxSigops = limit;
+}
+
+void GBTBlockBuilder::SetCoinbaseAuxFlags(CScript flags) {
+    coinbaseaux = std::move(flags);
+}
+
+void GBTBlockBuilder::SetClientRules(std::set<std::string> clientRules) {
+    this->clientRules = std::move(clientRules);
+}
+
+void GBTBlockBuilder::SetMaxVersionPreVB(int64_t v) {
+    nMaxVersionPreVB = v;
+}
+
+void GBTBlockBuilder::SetLongPollID(const uint256& tip, uint32_t mempoolTxUpdated) {
+    std::stringstream ss;
+    ss << tip.GetHex() << mempoolTxUpdated;
+    longpollid = ss.str();
+}
+
+} // ns miner

--- a/src/miner/gbtblockbuilder.h
+++ b/src/miner/gbtblockbuilder.h
@@ -1,0 +1,66 @@
+#ifndef BITCOIN_GBTBLOCKBUILDER_H
+#define BITCOIN_GBTBLOCKBUILDER_H
+
+#include "miner/blockbuilder.h"
+#include <univalue.h>
+
+namespace miner {
+
+class GBTBlockBuilder : public BlockBuilder {
+
+public:
+    GBTBlockBuilder();
+
+    void SetTime(uint32_t t) override;
+    uint32_t GetTime() const override;
+    void SetVersion(uint32_t v) override;
+    uint32_t GetVersion() const override;
+    void SetCoinbase(BuilderEntry tx) override;
+    void AddTx(BuilderEntry tx) override;
+    void SetBits(uint32_t bits) override;
+    uint32_t GetBits();
+    void SetHashPrevBlock(const uint256& hash) override;
+    void DisableLTOR() override;
+    void Finalize(const Consensus::Params& consensusParams) override;
+    void CheckValidity(CBlockIndex* pindexPrev) override;
+
+    // GBT specific
+    virtual bool NeedsGBTMetadata() const { return true; }
+
+    void SetBlockMinTime(int64_t t) override;
+    void SetBlockHeight(int32_t h) override;
+    void SetBIP135State(const std::map<Consensus::DeploymentPos,
+                        ThresholdState>& state) override;
+
+    void SetBlockSizeLimit(uint64_t limit) override;
+    void SetBlockSigopLimit(uint64_t limit) override;
+    void SetCoinbaseAuxFlags(CScript flags) override;
+
+    void SetClientRules(std::set<std::string> clientRules);
+    void SetMaxVersionPreVB(int64_t v);
+    void SetLongPollID(const uint256& tip, uint32_t mempoolTxUpdated);
+
+    UniValue Release() {
+        return std::move(block);
+    }
+
+private:
+    UniValue block;
+    CBlockHeader dummyheader;
+    BuilderEntry coinbase;
+    std::vector<BuilderEntry> txs;
+    std::map<Consensus::DeploymentPos, ThresholdState> bip135state;
+    bool useLTOR;
+    std::set<std::string> clientRules;
+    int64_t nMaxVersionPreVB;
+    CScript coinbaseaux;
+    std::string longpollid;
+    int32_t blockHeight;
+    int64_t blockMinTime;
+    uint64_t blockMaxSize;
+    uint64_t blockMaxSigops;
+};
+
+} // ns miner
+
+#endif

--- a/src/miner/gbtparser.cpp
+++ b/src/miner/gbtparser.cpp
@@ -1,0 +1,75 @@
+#include "miner/gbtparser.h"
+
+#include "core_io.h"
+#include "miner/utilminer.h"
+#include "primitives/block.h"
+#include "primitives/transaction.h"
+#include "utildebug.h"
+#include "utilstrencodings.h"
+
+#include <univalue.h>
+
+namespace miner {
+
+template <class T>
+T get(const UniValue& root, const std::string& key) {
+    UniValue value = find_value(root, key);
+    if (value.isNull()) {
+        throw std::invalid_argument("Could not find key '"
+                                    + key + "' in json object");
+    }
+    return value;
+}
+
+template <>
+int64_t get<int64_t>(const UniValue& root, const std::string& key) {
+    return get<UniValue>(root, key).get_int64();
+}
+
+template <>
+int get<int>(const UniValue& root, const std::string& key) {
+    return get<UniValue>(root, key).get_int();
+}
+
+template <>
+std::string get<std::string>(const UniValue& root, const std::string& key) {
+    return get<UniValue>(root, key).get_str();
+}
+
+CBlock ParseGBT(const UniValue& gbt) {
+
+    CBlock parsed;
+
+    parsed.nVersion = get<int64_t>(gbt, "version");
+    parsed.hashPrevBlock = uint256S(get<std::string>(gbt, "previousblockhash"));
+    parsed.nTime = get<int64_t>(gbt, "curtime");
+
+    const std::string bitsHex = get<std::string>(gbt, "bits");
+    std::stringstream ss;
+    ss << std::hex << bitsHex;
+    ss >> parsed.nBits;
+
+    // Create coinbase
+    CMutableTransaction coinbase;
+    {
+        UniValue coinbaseaux = get<UniValue>(gbt, "coinbaseaux");
+        std::vector<uint8_t> flags = ParseHex(get<std::string>(coinbaseaux, "flags"));
+
+        coinbase.vin.resize(1);
+        coinbase.vin[0].scriptSig = CScript() << get<int>(gbt, "height") << flags;
+        coinbase.vin[0].prevout.SetNull();
+        coinbase.vout.resize(1);
+        coinbase.vout[0].scriptPubKey = CScript() << OP_TRUE;
+        coinbase.vout[0].nValue = get<int64_t>(gbt, "coinbasevalue");
+        BloatCoinbaseSize(coinbase);
+    }
+    parsed.vtx.push_back(CTransaction(coinbase));
+
+    UniValue txs = get<UniValue>(gbt, "transactions");
+    for (auto tx : txs.getValues()) {
+        parsed.vtx.push_back(DecodeHexTx(get<std::string>(tx, "data")));
+    }
+    return parsed;
+}
+
+} // ns miner

--- a/src/miner/gbtparser.h
+++ b/src/miner/gbtparser.h
@@ -1,0 +1,17 @@
+#ifndef BITCOIN_GBT_PARSER_H
+#define BITCOIN_GBT_PARSER_H
+
+class CBlock;
+class UniValue;
+
+namespace miner {
+
+// Given a JSON object compatible with 'getblocktemplate', this will generate
+// a block candidate.
+//
+// Coinbase is anyone-can-spend
+CBlock ParseGBT(const UniValue& gbt);
+
+}
+
+#endif

--- a/src/miner/serializableblockbuilder.cpp
+++ b/src/miner/serializableblockbuilder.cpp
@@ -1,0 +1,93 @@
+#include "miner/serializableblockbuilder.h"
+
+#include "consensus/validation.h"
+#include "utildebug.h"
+#include "main.h" // TestBlockValidity
+
+namespace miner {
+
+SerializableBlockBuilder::SerializableBlockBuilder() :
+    useLTOR(true), isFinalized(false), coinbase(nullptr, 0, 0)
+{
+    block.nNonce = 0;
+}
+
+void SerializableBlockBuilder::SetTime(uint32_t t) {
+    block.nTime = t;
+}
+
+uint32_t SerializableBlockBuilder::GetTime() const {
+    return block.GetBlockTime();
+}
+
+void SerializableBlockBuilder::SetVersion(uint32_t v) {
+    block.nVersion = v;
+}
+
+uint32_t SerializableBlockBuilder::GetVersion() const {
+    return block.nVersion;
+}
+
+void SerializableBlockBuilder::SetCoinbase(BuilderEntry tx) {
+    THROW_UNLESS(!coinbase.IsValid());
+    THROW_UNLESS(tx.IsValid());
+    THROW_UNLESS(tx.IsCoinBase());
+    coinbase = std::move(tx);
+}
+
+void SerializableBlockBuilder::AddTx(BuilderEntry tx) {
+    THROW_UNLESS(tx.IsValid());
+    THROW_UNLESS(!tx.IsCoinBase());
+    txs.emplace_back(std::move(tx));
+}
+
+void SerializableBlockBuilder::SetBits(uint32_t bits) {
+    block.nBits = bits;
+}
+
+void SerializableBlockBuilder::SetHashPrevBlock(const uint256& hash) {
+    block.hashPrevBlock = hash;
+}
+
+void SerializableBlockBuilder::DisableLTOR() {
+    useLTOR = false;
+}
+
+void SerializableBlockBuilder::Finalize(const Consensus::Params&) {
+    THROW_UNLESS(!isFinalized);
+    THROW_UNLESS(block.nTime);
+    THROW_UNLESS(block.nVersion);
+    THROW_UNLESS(block.vtx.empty());
+    THROW_UNLESS(!block.hashPrevBlock.IsNull());
+    THROW_UNLESS(coinbase.IsCoinBase());
+
+    if (useLTOR) {
+        std::sort(std::begin(txs), std::end(txs), EntryHashCmp);
+    }
+
+    block.vtx.reserve(txs.size() + 1);
+    block.vtx.push_back(coinbase.GetTx());
+
+    for (auto& tx : txs) {
+        block.vtx.push_back(tx.GetTx());
+    }
+
+    isFinalized = true;
+}
+
+void SerializableBlockBuilder::CheckValidity(CBlockIndex* pindexPrev) {
+    CValidationState state;
+    if (!TestBlockValidity(state, block, pindexPrev, false, false)) {
+        std::stringstream err;
+        err << __func__ << ": TestBlockValidity failed: "
+            << FormatStateMessage(state);
+        throw std::runtime_error(err.str());
+    }
+}
+
+CBlock SerializableBlockBuilder::Release() {
+    THROW_UNLESS(isFinalized);
+    return std::move(block);
+}
+
+} // ns miner

--- a/src/miner/serializableblockbuilder.h
+++ b/src/miner/serializableblockbuilder.h
@@ -1,0 +1,52 @@
+#ifndef BITCOIN_MINER_SERIALIZABLEBLOCKBUILDER
+#define BITCOIN_MINER_SERIALIZABLEBLOCKBUILDER
+
+#include "miner/blockbuilder.h"
+
+namespace miner {
+
+// This interface creates a 'CBlock', which is serializes to the correct Bitcoin
+// format.
+class SerializableBlockBuilder : public BlockBuilder {
+public:
+    SerializableBlockBuilder();
+
+    void SetTime(uint32_t t) override;
+    uint32_t GetTime() const override;
+    void SetVersion(uint32_t v) override;
+    uint32_t GetVersion() const override;
+    void SetCoinbase(BuilderEntry tx) override;
+    void AddTx(BuilderEntry tx) override;
+    void SetBits(uint32_t bits) override;
+    void SetHashPrevBlock(const uint256& hash) override;
+    void DisableLTOR() override;
+    void Finalize(const Consensus::Params&) override;
+    void CheckValidity(CBlockIndex* pindexPrev) override;
+
+    // GBT stuff. We don't need it.
+    bool NeedsGBTMetadata() const override {
+        return false;
+    }
+
+    void SetBlockMinTime(int64_t) override { }
+    void SetBlockHeight(int32_t) override { }
+    void SetBIP135State(const std::map<Consensus::DeploymentPos, ThresholdState>&) override { }
+    void SetBlockSizeLimit(uint64_t) override { }
+    void SetBlockSigopLimit(uint64_t) override { }
+    void SetCoinbaseAuxFlags(CScript) override { }
+
+    // Takes ownership. Any operations on SerializableBlockBuilder (this) are
+    // undefined after this is called.
+    CBlock Release();
+
+private:
+    bool useLTOR;
+    bool isFinalized;
+    BuilderEntry coinbase;
+    std::vector<BuilderEntry> txs;
+    CBlock block;
+};
+
+} // ns miner
+
+#endif

--- a/src/miner/utilminer.cpp
+++ b/src/miner/utilminer.cpp
@@ -1,0 +1,22 @@
+#include "miner/utilminer.h"
+
+#include "consensus/consensus.h"
+#include "primitives/transaction.h"
+#include "protocol.h"
+#include "serialize.h"
+
+#include <cstddef>
+
+namespace miner {
+
+void BloatCoinbaseSize(CMutableTransaction& coinbase) {
+    size_t size = ::GetSerializeSize(coinbase, SER_NETWORK, PROTOCOL_VERSION);
+    if (size >= MIN_TRANSACTION_SIZE) {
+        return;
+    }
+    // operator<< prefixes the padding with minimum 1 byte, thus -1
+    size_t padding = MIN_TRANSACTION_SIZE - size - 1;
+    coinbase.vin[0].scriptSig << std::vector<uint8_t>(padding);
+}
+
+} // ns miner

--- a/src/miner/utilminer.h
+++ b/src/miner/utilminer.h
@@ -1,0 +1,13 @@
+#ifndef BITCOIN_UTILMINER_H
+#define BITCOIN_UTILMINER_H
+
+class CMutableTransaction;
+
+namespace miner {
+
+// Make sure coinbase is at minimum MIN_TRANSACTION_SIZE
+void BloatCoinbaseSize(CMutableTransaction& coinbase);
+
+} // ns miner
+
+#endif

--- a/src/pow.h
+++ b/src/pow.h
@@ -10,12 +10,11 @@
 
 #include <stdint.h>
 
-class CBlockHeader;
 class CBlockIndex;
 class uint256;
 class arith_uint256;
 
-unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&);
+unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, uint32_t nextblocktime, const Consensus::Params&);
 unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
@@ -29,7 +28,7 @@ int64_t GetBlockProofEquivalentTime(const CBlockIndex& to, const CBlockIndex& fr
  * Bitcoin cash's difficulty adjustment mechanism.
  */
 uint32_t GetNextCashWorkRequired(const CBlockIndex *pindexPrev,
-                                 const CBlockHeader *pblock,
+                                 uint32_t nextblocktime,
                                  const Consensus::Params &params);
 
 #endif // BITCOIN_POW_H

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(retargeting_test) {
     for (size_t i = 100; i < 110; i++) {
         blocks[i] = GetBlockIndex(&blocks[i - 1], 2 * 3600, initialBits);
         BOOST_CHECK_EQUAL(
-            GetNextWorkRequired(&blocks[i], &blkHeaderDummy, params),
+            GetNextWorkRequired(&blocks[i], blkHeaderDummy.nTime, params),
             initialBits);
     }
 
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE(retargeting_test) {
     currentPow.SetCompact(currentPow.GetCompact());
     currentPow += (currentPow >> 2);
     BOOST_CHECK_EQUAL(
-        GetNextWorkRequired(&blocks[110], &blkHeaderDummy, params),
+        GetNextWorkRequired(&blocks[110], blkHeaderDummy.nTime, params),
         currentPow.GetCompact());
 
     // As we continue with 2h blocks, difficulty continue to decrease.
@@ -158,7 +158,7 @@ BOOST_AUTO_TEST_CASE(retargeting_test) {
     currentPow.SetCompact(currentPow.GetCompact());
     currentPow += (currentPow >> 2);
     BOOST_CHECK_EQUAL(
-        GetNextWorkRequired(&blocks[111], &blkHeaderDummy, params),
+        GetNextWorkRequired(&blocks[111], blkHeaderDummy.nTime, params),
         currentPow.GetCompact());
 
     // We decrease again.
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE(retargeting_test) {
     currentPow.SetCompact(currentPow.GetCompact());
     currentPow += (currentPow >> 2);
     BOOST_CHECK_EQUAL(
-        GetNextWorkRequired(&blocks[112], &blkHeaderDummy, params),
+        GetNextWorkRequired(&blocks[112], blkHeaderDummy.nTime, params),
         currentPow.GetCompact());
 
     // We check that we do not go below the minimal difficulty.
@@ -177,14 +177,14 @@ BOOST_AUTO_TEST_CASE(retargeting_test) {
     currentPow += (currentPow >> 2);
     BOOST_CHECK(powLimit.GetCompact() != currentPow.GetCompact());
     BOOST_CHECK_EQUAL(
-        GetNextWorkRequired(&blocks[113], &blkHeaderDummy, params),
+        GetNextWorkRequired(&blocks[113], blkHeaderDummy.nTime, params),
         powLimit.GetCompact());
 
     // Once we reached the minimal difficulty, we stick with it.
     blocks[114] = GetBlockIndex(&blocks[113], 2 * 3600, powLimit.GetCompact());
     BOOST_CHECK(powLimit.GetCompact() != currentPow.GetCompact());
     BOOST_CHECK_EQUAL(
-        GetNextWorkRequired(&blocks[114], &blkHeaderDummy, params),
+        GetNextWorkRequired(&blocks[114], blkHeaderDummy.nTime, params),
         powLimit.GetCompact());
 
     mapArgs.erase("-uahftime");
@@ -219,13 +219,13 @@ BOOST_AUTO_TEST_CASE(cash_difficulty_test) {
 
     CBlockHeader blkHeaderDummy;
     uint32_t nBits =
-        GetNextCashWorkRequired(&blocks[2049], &blkHeaderDummy, params);
+        GetNextCashWorkRequired(&blocks[2049], blkHeaderDummy.nTime, params);
 
     // Difficulty stays the same as long as we produce a block every 10 mins.
     for (size_t j = 0; j < 10; i++, j++) {
         blocks[i] = GetBlockIndex(&blocks[i - 1], 600, nBits);
         BOOST_CHECK_EQUAL(
-            GetNextCashWorkRequired(&blocks[i], &blkHeaderDummy, params),
+            GetNextCashWorkRequired(&blocks[i], blkHeaderDummy.nTime, params),
             nBits);
     }
 
@@ -234,30 +234,30 @@ BOOST_AUTO_TEST_CASE(cash_difficulty_test) {
     // expected timestamp.
     blocks[i] = GetBlockIndex(&blocks[i - 1], 6000, nBits);
     BOOST_CHECK_EQUAL(
-        GetNextCashWorkRequired(&blocks[i++], &blkHeaderDummy, params), nBits);
+        GetNextCashWorkRequired(&blocks[i++], blkHeaderDummy.nTime, params), nBits);
     blocks[i] = GetBlockIndex(&blocks[i - 1], 2 * 600 - 6000, nBits);
     BOOST_CHECK_EQUAL(
-        GetNextCashWorkRequired(&blocks[i++], &blkHeaderDummy, params), nBits);
+        GetNextCashWorkRequired(&blocks[i++], blkHeaderDummy.nTime, params), nBits);
 
     // The system should continue unaffected by the block with a bogous
     // timestamps.
     for (size_t j = 0; j < 20; i++, j++) {
         blocks[i] = GetBlockIndex(&blocks[i - 1], 600, nBits);
         BOOST_CHECK_EQUAL(
-            GetNextCashWorkRequired(&blocks[i], &blkHeaderDummy, params),
+            GetNextCashWorkRequired(&blocks[i], blkHeaderDummy.nTime, params),
             nBits);
     }
 
     // We start emitting blocks slightly faster. The first block has no impact.
     blocks[i] = GetBlockIndex(&blocks[i - 1], 550, nBits);
     BOOST_CHECK_EQUAL(
-        GetNextCashWorkRequired(&blocks[i++], &blkHeaderDummy, params), nBits);
+        GetNextCashWorkRequired(&blocks[i++], blkHeaderDummy.nTime, params), nBits);
 
     // Now we should see difficulty increase slowly.
     for (size_t j = 0; j < 10; i++, j++) {
         blocks[i] = GetBlockIndex(&blocks[i - 1], 550, nBits);
         const uint32_t nextBits =
-            GetNextCashWorkRequired(&blocks[i], &blkHeaderDummy, params);
+            GetNextCashWorkRequired(&blocks[i], blkHeaderDummy.nTime, params);
 
         arith_uint256 currentTarget;
         currentTarget.SetCompact(nBits);
@@ -278,7 +278,7 @@ BOOST_AUTO_TEST_CASE(cash_difficulty_test) {
     for (size_t j = 0; j < 20; i++, j++) {
         blocks[i] = GetBlockIndex(&blocks[i - 1], 10, nBits);
         const uint32_t nextBits =
-            GetNextCashWorkRequired(&blocks[i], &blkHeaderDummy, params);
+            GetNextCashWorkRequired(&blocks[i], blkHeaderDummy.nTime, params);
 
         arith_uint256 currentTarget;
         currentTarget.SetCompact(nBits);
@@ -298,7 +298,7 @@ BOOST_AUTO_TEST_CASE(cash_difficulty_test) {
     // We start to emit blocks significantly slower. The first block has no
     // impact.
     blocks[i] = GetBlockIndex(&blocks[i - 1], 6000, nBits);
-    nBits = GetNextCashWorkRequired(&blocks[i++], &blkHeaderDummy, params);
+    nBits = GetNextCashWorkRequired(&blocks[i++], blkHeaderDummy.nTime, params);
 
     // Check the actual value.
     BOOST_CHECK_EQUAL(nBits, 0x1c0d9222u);
@@ -307,7 +307,7 @@ BOOST_AUTO_TEST_CASE(cash_difficulty_test) {
     for (size_t j = 0; j < 93; i++, j++) {
         blocks[i] = GetBlockIndex(&blocks[i - 1], 6000, nBits);
         const uint32_t nextBits =
-            GetNextCashWorkRequired(&blocks[i], &blkHeaderDummy, params);
+            GetNextCashWorkRequired(&blocks[i], blkHeaderDummy.nTime, params);
 
         arith_uint256 currentTarget;
         currentTarget.SetCompact(nBits);
@@ -328,7 +328,7 @@ BOOST_AUTO_TEST_CASE(cash_difficulty_test) {
     // Due to the window of time being bounded, next block's difficulty actually
     // gets harder.
     blocks[i] = GetBlockIndex(&blocks[i - 1], 6000, nBits);
-    nBits = GetNextCashWorkRequired(&blocks[i++], &blkHeaderDummy, params);
+    nBits = GetNextCashWorkRequired(&blocks[i++], blkHeaderDummy.nTime, params);
     BOOST_CHECK_EQUAL(nBits, 0x1c2ee9bfu);
 
     // And goes down again. It takes a while due to the window being bounded and
@@ -336,7 +336,7 @@ BOOST_AUTO_TEST_CASE(cash_difficulty_test) {
     for (size_t j = 0; j < 192; i++, j++) {
         blocks[i] = GetBlockIndex(&blocks[i - 1], 6000, nBits);
         const uint32_t nextBits =
-            GetNextCashWorkRequired(&blocks[i], &blkHeaderDummy, params);
+            GetNextCashWorkRequired(&blocks[i], blkHeaderDummy.nTime, params);
 
         arith_uint256 currentTarget;
         currentTarget.SetCompact(nBits);
@@ -359,7 +359,7 @@ BOOST_AUTO_TEST_CASE(cash_difficulty_test) {
     for (size_t j = 0; j < 5; i++, j++) {
         blocks[i] = GetBlockIndex(&blocks[i - 1], 6000, nBits);
         const uint32_t nextBits =
-            GetNextCashWorkRequired(&blocks[i], &blkHeaderDummy, params);
+            GetNextCashWorkRequired(&blocks[i], blkHeaderDummy.nTime, params);
 
         // Check the difficulty stays constant.
         BOOST_CHECK_EQUAL(nextBits, powLimitBits);

--- a/src/utildebug.cpp
+++ b/src/utildebug.cpp
@@ -1,4 +1,5 @@
 #include "utildebug.h"
+#include "util.h"
 
 #ifdef __linux__
 #include <execinfo.h>
@@ -25,4 +26,15 @@ void dump_backtrace_stderr() {
 #else
     std::cerr << "Backtrace not available on this platform" << std::endl;
 #endif
+}
+
+void throw_bad_state(const char* why, const char* func,
+                            const char* file, int line)
+{
+    std::stringstream err;
+    err << "Bad state - expectation '" << why << "' failed at  "
+        << func << " in " << file << ":" << line;
+
+    LogPrintf("ERROR: %s", err.str());
+    throw bad_state_error(err.str());
 }

--- a/src/utildebug.h
+++ b/src/utildebug.h
@@ -1,6 +1,18 @@
 #ifndef BITCOIN_UTILDEBUG_H
 #define BITCOIN_UTILDEBUG_H
 
+#include <stdexcept>
+
 void dump_backtrace_stderr();
+
+class bad_state_error : public std::runtime_error {
+    using std::runtime_error::runtime_error; // inherit constructors
+};
+
+void throw_bad_state(const char* why,
+                            const char* func, const char* file, int line);
+
+// Can be used instead of assert where we are able to recover from an exception.
+#define THROW_UNLESS(cond) { if (!(cond)) { throw_bad_state(#cond, __func__, __FILE__, __LINE__); } }
 
 #endif

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -184,3 +184,15 @@ void VersionBitsCache::Clear()
         caches[d].clear();
     }
 }
+
+Consensus::ForkDeployment GetBIP135ForkByName(const Consensus::Params& params,
+                                            const std::string& name)
+{
+    const auto& deployments = params.vDeployments;
+    for (auto& d : deployments) {
+        if (std::string(d.second.name) == name) {
+            return d.second;
+        }
+    }
+    throw std::invalid_argument("Bit '" + name + "' does not exist");
+}

--- a/src/versionbits.h
+++ b/src/versionbits.h
@@ -70,4 +70,7 @@ struct VersionBitsCache
 ThresholdState VersionBitsState(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::DeploymentPos pos, VersionBitsCache& cache);
 uint32_t VersionBitsMask(const Consensus::Params& params, Consensus::DeploymentPos pos);
 
+Consensus::DeploymentPos GetBIP135BitByName(const Consensus::Params& params,
+                                            const std::string& name);
+
 #endif


### PR DESCRIPTION
The interface replaces use of CBlockTemplate. The interface allows for building different representations of a new block without going through CBlock.

Before, transactions in `getblocktemplate` would pass two steps:
>    Mempool -> (copy to) CBlock -> (copy to) JSON

Now it is:
>    Mempool -> (copy to) JSON

For now, for sanity check, the JSON is converted to CBlock for the purpose of validations. This should be skipped in the future.

Also fixes a bug where sigop and txfees are counted wrong in 'getblocktemplate' after CTOR.