### PR TITLE
[rpc] Return tx-per-second in getmempoolinfo response

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -918,11 +918,11 @@ bool AppInit2()
         fCheckpointsEnabled = false;
     }
 
-    // -mempoollimit limits
-    int64_t nMempoolSizeLimit = GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
-    int64_t nMempoolDescendantSizeLimit = GetArg("-limitdescendantsize", DEFAULT_DESCENDANT_SIZE_LIMIT) * 1000;
-    if (nMempoolSizeLimit < 0 || nMempoolSizeLimit < nMempoolDescendantSizeLimit * 40)
-        return InitError(strprintf(_("Error: -maxmempool must be at least %d MB"), GetArg("-limitdescendantsize", DEFAULT_DESCENDANT_SIZE_LIMIT) / 25));
+    // mempool limits
+    int64_t nMempoolSizeMax = GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
+    int64_t nMempoolSizeMin = GetArg("-limitdescendantsize", DEFAULT_DESCENDANT_SIZE_LIMIT) * 1000 * 40;
+    if (nMempoolSizeMax < 0 || nMempoolSizeMax < nMempoolSizeMin)
+        return InitError(strprintf(_("-maxmempool must be at least %d MB"), std::ceil(nMempoolSizeMin / 1000.0)));
 
     fServer = GetBoolArg("-server", false);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1060,6 +1060,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
                 return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "mempool full");
         }
 
+        pool.UpdateTransactionsPerSecond();
         SyncWithWallets(tx, NULL, false);
     }
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -12,6 +12,7 @@
 #include "clientversion.h"
 #include "main.h"
 #include "net.h"
+#include "txmempool.h"
 #include "ui_interface.h"
 #include "util.h"
 #include "options.h"
@@ -94,6 +95,16 @@ QDateTime ClientModel::getLastBlockDate() const
     return QDateTime::fromTime_t(Params().GenesisBlock().GetBlockTime()); // Genesis block's time of current network
 }
 
+long ClientModel::getMempoolSize() const
+{
+    return mempool.size();
+}
+
+size_t ClientModel::getMempoolDynamicUsage() const
+{
+    return mempool.DynamicMemoryUsage();
+}
+
 double ClientModel::getVerificationProgress() const
 {
     LOCK(cs_main);
@@ -128,6 +139,7 @@ void ClientModel::updateTimer()
         Q_EMIT numBlocksChanged(newNumBlocks, newBlockDate);
     }
 
+    Q_EMIT mempoolSizeChanged(getMempoolSize(), getMempoolDynamicUsage());
     Q_EMIT bytesChanged(getTotalBytesRecv(), getTotalBytesSent());
 }
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -14,6 +14,7 @@
 #include "net.h"
 #include "ui_interface.h"
 #include "util.h"
+#include "options.h"
 
 #include <stdint.h>
 
@@ -175,6 +176,14 @@ PeerTableModel *ClientModel::getPeerTableModel()
 QString ClientModel::formatFullVersion() const
 {
     return QString::fromStdString(FormatFullVersion());
+}
+
+QString ClientModel::formatSubVersion() const
+{
+    return QString::fromStdString(XTSubVersion(GetNodeSignals().GetMaxBlockSizeInsecure().get(),
+                                               Opt().UserAgent(),
+                                               Opt().UAComment(),
+                                               Opt().HidePlatform()));
 }
 
 QString ClientModel::formatBuildDate() const

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -105,6 +105,11 @@ size_t ClientModel::getMempoolDynamicUsage() const
     return mempool.DynamicMemoryUsage();
 }
 
+double ClientModel::getTransactionsPerSecond() const
+{
+    return mempool.TransactionsPerSecond();
+}
+
 double ClientModel::getVerificationProgress() const
 {
     LOCK(cs_main);
@@ -141,6 +146,7 @@ void ClientModel::updateTimer()
 
     Q_EMIT mempoolSizeChanged(getMempoolSize(), getMempoolDynamicUsage());
     Q_EMIT bytesChanged(getTotalBytesRecv(), getTotalBytesSent());
+    Q_EMIT transactionsPerSecondChanged(getTransactionsPerSecond()); // BU:
 }
 
 void ClientModel::updateNumConnections(int numConnections)

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -146,7 +146,7 @@ void ClientModel::updateTimer()
 
     Q_EMIT mempoolSizeChanged(getMempoolSize(), getMempoolDynamicUsage());
     Q_EMIT bytesChanged(getTotalBytesRecv(), getTotalBytesSent());
-    Q_EMIT transactionsPerSecondChanged(getTransactionsPerSecond()); // BU:
+    Q_EMIT transactionsPerSecondChanged(getTransactionsPerSecond());
 }
 
 void ClientModel::updateNumConnections(int numConnections)

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -63,6 +63,7 @@ public:
     QString getStatusBarWarnings() const;
 
     QString formatFullVersion() const;
+    QString formatSubVersion() const;
     QString formatBuildDate() const;
     bool isReleaseVersion() const;
     QString clientName() const;

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -54,6 +54,9 @@ public:
     //! Return the dynamic memory usage of the mempool
     size_t getMempoolDynamicUsage() const;
     
+    //! BU: Return the transactions per second that are accepted into the mempool
+    double getTransactionsPerSecond() const;
+
     quint64 getTotalBytesRecv() const;
     quint64 getTotalBytesSent() const;
 
@@ -94,6 +97,7 @@ Q_SIGNALS:
     void mempoolSizeChanged(long count, size_t mempoolSizeInBytes);
     void alertsChanged(const QString &warnings);
     void bytesChanged(quint64 totalBytesIn, quint64 totalBytesOut);
+    void transactionsPerSecondChanged(double tansactionsPerSecond);  // BU:
 
     //! Fired when a message should be reported to the user
     void message(const QString &title, const QString &message, unsigned int style);

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -54,7 +54,7 @@ public:
     //! Return the dynamic memory usage of the mempool
     size_t getMempoolDynamicUsage() const;
     
-    //! BU: Return the transactions per second that are accepted into the mempool
+    //! Return the transactions per second that are accepted into the mempool
     double getTransactionsPerSecond() const;
 
     quint64 getTotalBytesRecv() const;

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -49,6 +49,11 @@ public:
     int getNumConnections(unsigned int flags = CONNECTIONS_ALL) const;
     int getNumBlocks() const;
 
+    //! Return number of transactions in the mempool
+    long getMempoolSize() const;
+    //! Return the dynamic memory usage of the mempool
+    size_t getMempoolDynamicUsage() const;
+    
     quint64 getTotalBytesRecv() const;
     quint64 getTotalBytesSent() const;
 
@@ -86,6 +91,7 @@ private:
 Q_SIGNALS:
     void numConnectionsChanged(int count);
     void numBlocksChanged(int count, const QDateTime& blockDate);
+    void mempoolSizeChanged(long count, size_t mempoolSizeInBytes);
     void alertsChanged(const QString &warnings);
     void bytesChanged(quint64 totalBytesIn, quint64 totalBytesOut);
 

--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -87,9 +87,9 @@
         </widget>
        </item>
        <item row="3" column="0">
-        <widget class="QLabel" name="label_14">
+        <widget class="QLabel" name="labelClientUserAgent">
          <property name="text">
-          <string>Using OpenSSL version</string>
+          <string>User Agent</string>
          </property>
          <property name="indent">
           <number>10</number>
@@ -97,7 +97,7 @@
         </widget>
        </item>
        <item row="3" column="1">
-        <widget class="QLabel" name="openSSLVersion">
+        <widget class="QLabel" name="clientUserAgent">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -113,9 +113,9 @@
         </widget>
        </item>
        <item row="4" column="0">
-        <widget class="QLabel" name="label_berkeleyDBVersion">
+        <widget class="QLabel" name="label_14">
          <property name="text">
-          <string>Using BerkeleyDB version</string>
+          <string>Using OpenSSL version</string>
          </property>
          <property name="indent">
           <number>10</number>
@@ -123,7 +123,7 @@
         </widget>
        </item>
        <item row="4" column="1">
-        <widget class="QLabel" name="berkeleyDBVersion">
+        <widget class="QLabel" name="openSSLVersion">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -139,14 +139,17 @@
         </widget>
        </item>
        <item row="5" column="0">
-        <widget class="QLabel" name="label_12">
+        <widget class="QLabel" name="label_berkeleyDBVersion">
          <property name="text">
-          <string>Build date</string>
+          <string>Using BerkeleyDB version</string>
+         </property>
+         <property name="indent">
+          <number>10</number>
          </property>
         </widget>
        </item>
        <item row="5" column="1">
-        <widget class="QLabel" name="buildDate">
+        <widget class="QLabel" name="berkeleyDBVersion">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -162,14 +165,14 @@
         </widget>
        </item>
        <item row="6" column="0">
-        <widget class="QLabel" name="label_13">
+        <widget class="QLabel" name="label_12">
          <property name="text">
-          <string>Startup time</string>
+          <string>Build date</string>
          </property>
         </widget>
        </item>
        <item row="6" column="1">
-        <widget class="QLabel" name="startupTime">
+        <widget class="QLabel" name="buildDate">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -185,6 +188,29 @@
         </widget>
        </item>
        <item row="7" column="0">
+        <widget class="QLabel" name="label_13">
+         <property name="text">
+          <string>Startup time</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="1">
+        <widget class="QLabel" name="startupTime">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0">
         <widget class="QLabel" name="label_11">
          <property name="font">
           <font>
@@ -197,14 +223,14 @@
          </property>
         </widget>
        </item>
-       <item row="8" column="0">
+       <item row="9" column="0">
         <widget class="QLabel" name="label_8">
          <property name="text">
           <string>Name</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="1">
+       <item row="9" column="1">
         <widget class="QLabel" name="networkName">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -220,14 +246,14 @@
          </property>
         </widget>
        </item>
-       <item row="9" column="0">
+       <item row="10" column="0">
         <widget class="QLabel" name="label_7">
          <property name="text">
           <string>Number of connections</string>
          </property>
         </widget>
        </item>
-       <item row="9" column="1">
+       <item row="10" column="1">
         <widget class="QLabel" name="numberOfConnections">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -243,7 +269,7 @@
          </property>
         </widget>
        </item>
-       <item row="10" column="0">
+       <item row="11" column="0">
         <widget class="QLabel" name="label_10">
          <property name="font">
           <font>
@@ -256,14 +282,14 @@
          </property>
         </widget>
        </item>
-       <item row="11" column="0">
+       <item row="12" column="0">
         <widget class="QLabel" name="label_3">
          <property name="text">
           <string>Current number of blocks</string>
          </property>
         </widget>
        </item>
-       <item row="11" column="1">
+       <item row="12" column="1">
         <widget class="QLabel" name="numberOfBlocks">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -279,14 +305,14 @@
          </property>
         </widget>
        </item>
-       <item row="12" column="0">
+       <item row="13" column="0">
         <widget class="QLabel" name="label_2">
          <property name="text">
           <string>Last block time</string>
          </property>
         </widget>
        </item>
-       <item row="12" column="1">
+       <item row="13" column="1">
         <widget class="QLabel" name="lastBlockTime">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -302,7 +328,7 @@
          </property>
         </widget>
        </item>
-       <item row="13" column="0">
+       <item row="14" column="0">
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -315,7 +341,7 @@
          </property>
         </spacer>
        </item>
-       <item row="14" column="0">
+       <item row="15" column="0">
         <widget class="QLabel" name="labelDebugLogfile">
          <property name="font">
           <font>
@@ -328,7 +354,7 @@
          </property>
         </widget>
        </item>
-       <item row="15" column="0">
+       <item row="16" column="0">
         <widget class="QPushButton" name="openDebugLogfileButton">
          <property name="toolTip">
           <string>Open the Bitcoin XT debug log file from the current data directory. This can take a few seconds for large log files.</string>
@@ -341,7 +367,7 @@
          </property>
         </widget>
        </item>
-       <item row="16" column="0">
+       <item row="17" column="0">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -23,7 +23,7 @@
       <attribute name="title">
        <string>&amp;Information</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
+      <layout class="QGridLayout" name="gridLayout" columnstretch="0,1,0">
        <property name="horizontalSpacing">
         <number>12</number>
        </property>
@@ -47,7 +47,7 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
+       <item row="1" column="1" colspan="2">
         <widget class="QLabel" name="clientName">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -70,7 +70,7 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="2" column="1" colspan="2">
         <widget class="QLabel" name="clientVersion">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -96,7 +96,7 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="3" column="1" colspan="2">
         <widget class="QLabel" name="clientUserAgent">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -122,7 +122,7 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="4" column="1" colspan="2">
         <widget class="QLabel" name="openSSLVersion">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -148,7 +148,7 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="5" column="1" colspan="2">
         <widget class="QLabel" name="berkeleyDBVersion">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -171,7 +171,7 @@
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="6" column="1" colspan="2">
         <widget class="QLabel" name="buildDate">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -194,7 +194,7 @@
          </property>
         </widget>
        </item>
-       <item row="7" column="1">
+       <item row="7" column="1" colspan="2">
         <widget class="QLabel" name="startupTime">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -210,19 +210,6 @@
          </property>
         </widget>
        </item>
-       <item row="8" column="0">
-        <widget class="QLabel" name="label_11">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Network</string>
-         </property>
-        </widget>
-       </item>
        <item row="9" column="0">
         <widget class="QLabel" name="label_8">
          <property name="text">
@@ -230,7 +217,7 @@
          </property>
         </widget>
        </item>
-       <item row="9" column="1">
+       <item row="9" column="1" colspan="2">
         <widget class="QLabel" name="networkName">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -253,7 +240,7 @@
          </property>
         </widget>
        </item>
-       <item row="10" column="1">
+       <item row="10" column="1" colspan="2">
         <widget class="QLabel" name="numberOfConnections">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -289,7 +276,7 @@
          </property>
         </widget>
        </item>
-       <item row="12" column="1">
+       <item row="12" column="1" colspan="2">
         <widget class="QLabel" name="numberOfBlocks">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -306,13 +293,13 @@
         </widget>
        </item>
        <item row="13" column="0">
-        <widget class="QLabel" name="label_2">
+        <widget class="QLabel" name="labelLastBlockTime">
          <property name="text">
           <string>Last block time</string>
          </property>
         </widget>
        </item>
-       <item row="13" column="1">
+       <item row="13" column="1" colspan="2">
         <widget class="QLabel" name="lastBlockTime">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -329,20 +316,7 @@
         </widget>
        </item>
        <item row="14" column="0">
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="15" column="0">
-        <widget class="QLabel" name="labelDebugLogfile">
+        <widget class="QLabel" name="labelMempoolTitle">
          <property name="font">
           <font>
            <weight>75</weight>
@@ -350,24 +324,110 @@
           </font>
          </property>
          <property name="text">
-          <string>Debug log file</string>
+          <string>Memory Pool</string>
+         </property>
+        </widget>
+       </item>
+       <item row="15" column="0">
+        <widget class="QLabel" name="labelNumberOfTransactions">
+         <property name="text">
+          <string>Current number of transactions</string>
+         </property>
+        </widget>
+       </item>
+       <item row="15" column="1">
+        <widget class="QLabel" name="mempoolNumberTxs">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0">
+        <widget class="QLabel" name="labelNetwork">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Network</string>
          </property>
         </widget>
        </item>
        <item row="16" column="0">
-        <widget class="QPushButton" name="openDebugLogfileButton">
-         <property name="toolTip">
-          <string>Open the Bitcoin XT debug log file from the current data directory. This can take a few seconds for large log files.</string>
-         </property>
+        <widget class="QLabel" name="labelMemoryUsage">
          <property name="text">
-          <string>&amp;Open</string>
-         </property>
-         <property name="autoDefault">
-          <bool>false</bool>
+          <string>Memory usage</string>
          </property>
         </widget>
        </item>
-       <item row="17" column="0">
+       <item row="16" column="1">
+        <widget class="QLabel" name="mempoolSize">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="2" rowspan="3">
+        <layout class="QVBoxLayout" name="verticalLayoutDebugButton">
+         <property name="spacing">
+          <number>3</number>
+         </property>
+         <item>
+          <spacer name="verticalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>10</width>
+             <height>5</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="labelDebugLogfile">
+           <property name="text">
+            <string>Debug log file</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="openDebugLogfileButton">
+           <property name="toolTip">
+            <string>Open the Bitcoin XT debug log file from the current data directory. This can take a few seconds for large log files.</string>
+           </property>
+           <property name="text">
+            <string>&amp;Open</string>
+           </property>
+           <property name="autoDefault">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="18" column="0">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -387,6 +387,30 @@
          </property>
         </widget>
        </item>
+       <item row="17" column="0">
+        <widget class="QLabel" name="labelTransactionsPerSecond">
+         <property name="text">
+          <string>Transactions per second</string>
+         </property>
+        </widget>
+       </item>
+       <item row="17" column="1">
+        <widget class="QLabel" name="transactionsPerSecond">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+
        <item row="14" column="2" rowspan="3">
         <layout class="QVBoxLayout" name="verticalLayoutDebugButton">
          <property name="spacing">

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -342,6 +342,8 @@ void RPCConsole::setClientModel(ClientModel *model)
         updateTrafficStats(model->getTotalBytesRecv(), model->getTotalBytesSent());
         connect(model, SIGNAL(bytesChanged(quint64,quint64)), this, SLOT(updateTrafficStats(quint64, quint64)));
 
+        connect(model, SIGNAL(mempoolSizeChanged(long,size_t)), this, SLOT(setMempoolSize(long,size_t)));
+
         // set up peer table
         ui->peerWidget->setModel(model->getPeerTableModel());
         ui->peerWidget->verticalHeader()->hide();
@@ -450,6 +452,16 @@ void RPCConsole::setNumBlocks(int count, const QDateTime& blockDate)
 {
     ui->numberOfBlocks->setText(QString::number(count));
     ui->lastBlockTime->setText(blockDate.toString());
+}
+
+void RPCConsole::setMempoolSize(long numberOfTxs, size_t dynUsage)
+{
+    ui->mempoolNumberTxs->setText(QString::number(numberOfTxs));
+
+    if (dynUsage < 1000000)
+        ui->mempoolSize->setText(QString::number(dynUsage/1000.0, 'f', 2) + " KB");
+    else
+        ui->mempoolSize->setText(QString::number(dynUsage/1000000.0, 'f', 2) + " MB");
 }
 
 void RPCConsole::on_lineEdit_returnPressed()

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -359,10 +359,10 @@ void RPCConsole::setClientModel(ClientModel *model)
 
         // Provide initial values
         ui->clientVersion->setText(model->formatFullVersion());
+        ui->clientUserAgent->setText(model->formatSubVersion());
         ui->clientName->setText(model->clientName());
         ui->buildDate->setText(model->formatBuildDate());
         ui->startupTime->setText(model->formatClientStartupTime());
-
         ui->networkName->setText(QString::fromStdString(Params().NetworkIDString()));
     }
 }

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -344,6 +344,9 @@ void RPCConsole::setClientModel(ClientModel *model)
 
         connect(model, SIGNAL(mempoolSizeChanged(long,size_t)), this, SLOT(setMempoolSize(long,size_t)));
 
+        // BU:
+        connect(model, SIGNAL(transactionsPerSecondChanged(double)), this, SLOT(setTransactionsPerSecond(double)));
+
         // set up peer table
         ui->peerWidget->setModel(model->getPeerTableModel());
         ui->peerWidget->verticalHeader()->hide();
@@ -463,6 +466,16 @@ void RPCConsole::setMempoolSize(long numberOfTxs, size_t dynUsage)
     else
         ui->mempoolSize->setText(QString::number(dynUsage/1000000.0, 'f', 2) + " MB");
 }
+
+// BU: begin
+void RPCConsole::setTransactionsPerSecond(double nTxPerSec)
+{
+    if (nTxPerSec < 100)
+        ui->transactionsPerSecond->setText(QString::number(nTxPerSec, 'f', 2));
+    else
+        ui->transactionsPerSecond->setText(QString::number((uint64_t)nTxPerSec));
+}
+// BU: end
 
 void RPCConsole::on_lineEdit_returnPressed()
 {

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -344,7 +344,6 @@ void RPCConsole::setClientModel(ClientModel *model)
 
         connect(model, SIGNAL(mempoolSizeChanged(long,size_t)), this, SLOT(setMempoolSize(long,size_t)));
 
-        // BU:
         connect(model, SIGNAL(transactionsPerSecondChanged(double)), this, SLOT(setTransactionsPerSecond(double)));
 
         // set up peer table
@@ -467,7 +466,6 @@ void RPCConsole::setMempoolSize(long numberOfTxs, size_t dynUsage)
         ui->mempoolSize->setText(QString::number(dynUsage/1000000.0, 'f', 2) + " MB");
 }
 
-// BU: begin
 void RPCConsole::setTransactionsPerSecond(double nTxPerSec)
 {
     if (nTxPerSec < 100)
@@ -475,7 +473,6 @@ void RPCConsole::setTransactionsPerSecond(double nTxPerSec)
     else
         ui->transactionsPerSecond->setText(QString::number((uint64_t)nTxPerSec));
 }
-// BU: end
 
 void RPCConsole::on_lineEdit_returnPressed()
 {

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -68,7 +68,7 @@ public Q_SLOTS:
     void setNumBlocks(int count, const QDateTime& blockDate);
     /** Set size (number of transactions and memory usage) of the mempool in the UI */
     void setMempoolSize(long numberOfTxs, size_t dynUsage);
-    /** BU: Set tx's per second in the UI */
+    /** Set tx's per second in the UI */
     void setTransactionsPerSecond(double nTxPerSec);
     /** Go forward or back in history */
     void browseHistory(int offset);

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -66,6 +66,8 @@ public Q_SLOTS:
     void setNumConnections(int count);
     /** Set number of blocks and last block date shown in the UI */
     void setNumBlocks(int count, const QDateTime& blockDate);
+    /** Set size (number of transactions and memory usage) of the mempool in the UI */
+    void setMempoolSize(long numberOfTxs, size_t dynUsage);
     /** Go forward or back in history */
     void browseHistory(int offset);
     /** Scroll console view to end */

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -68,6 +68,8 @@ public Q_SLOTS:
     void setNumBlocks(int count, const QDateTime& blockDate);
     /** Set size (number of transactions and memory usage) of the mempool in the UI */
     void setMempoolSize(long numberOfTxs, size_t dynUsage);
+    /** BU: Set tx's per second in the UI */
+    void setTransactionsPerSecond(double nTxPerSec);
     /** Go forward or back in history */
     void browseHistory(int offset);
     /** Scroll console view to end */

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -980,9 +980,10 @@ UniValue getmempoolinfo(const JSONRPCRequest& request)
             "\nReturns details on the active state of the TX memory pool.\n"
             "\nResult:\n"
             "{\n"
-            "  \"size\": xxxxx                (numeric) Current tx count\n"
-            "  \"bytes\": xxxxx               (numeric) Sum of all tx sizes\n"
-            "  \"usage\": xxxxx               (numeric) Total memory usage for the mempool\n"
+            "  \"size\": xxxxx,               (numeric) Current tx count\n"
+            "  \"bytes\": xxxxx,              (numeric) Sum of all tx sizes\n"
+            "  \"usage\": xxxxx,              (numeric) Total memory usage for the mempool\n"
+            "  \"maxmempool\": xxxxx          (numeric) Maximum memory usage for the mempool\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("getmempoolinfo", "")

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -968,6 +968,7 @@ UniValue mempoolInfoToJSON()
     ret.push_back(Pair("usage", (int64_t) mempool.DynamicMemoryUsage()));
     size_t maxmempool = GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
     ret.push_back(Pair("maxmempool", (int64_t) maxmempool));
+    ret.push_back(Pair("tps", std::floor(mempool.TransactionsPerSecond() * 100) / 100));
 
     return ret;
 }
@@ -983,7 +984,8 @@ UniValue getmempoolinfo(const JSONRPCRequest& request)
             "  \"size\": xxxxx,               (numeric) Current tx count\n"
             "  \"bytes\": xxxxx,              (numeric) Sum of all tx sizes\n"
             "  \"usage\": xxxxx,              (numeric) Total memory usage for the mempool\n"
-            "  \"maxmempool\": xxxxx          (numeric) Maximum memory usage for the mempool\n"
+            "  \"maxmempool\": xxxxx,         (numeric) Maximum memory usage for the mempool\n"
+            "  \"tps\": xxxxx                 (numeric) Transactions per second accepted\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("getmempoolinfo", "")

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -966,6 +966,8 @@ UniValue mempoolInfoToJSON()
     ret.push_back(Pair("size", (int64_t) mempool.size()));
     ret.push_back(Pair("bytes", (int64_t) mempool.GetTotalTxSize()));
     ret.push_back(Pair("usage", (int64_t) mempool.DynamicMemoryUsage()));
+    size_t maxmempool = GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
+    ret.push_back(Pair("maxmempool", (int64_t) maxmempool));
 
     return ret;
 }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -908,6 +908,8 @@ void CTxMemPool::TrimToSize(size_t sizelimit) {
 // BU: begin
 void CTxMemPool::UpdateTransactionsPerSecond()
 {
+    boost::mutex::scoped_lock lock(cs_txPerSec);
+
     static int64_t nLastTime = GetTime();
     double nSecondsToAverage = 60; // Length of time in seconds to smooth the tx rate over
     int64_t nNow = GetTime();

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -904,3 +904,22 @@ void CTxMemPool::TrimToSize(size_t sizelimit) {
         RemoveStaged(stage, false);
     }
 }
+
+// BU: begin
+void CTxMemPool::UpdateTransactionsPerSecond()
+{
+    static int64_t nLastTime = GetTime();
+    double nSecondsToAverage = 60; // Length of time in seconds to smooth the tx rate over
+    int64_t nNow = GetTime();
+
+    // Decay the previous tx rate.  
+    int64_t nDeltaTime = nNow - nLastTime;
+    if (nDeltaTime > 0) {
+        nTxPerSec -= (nTxPerSec / nSecondsToAverage) * nDeltaTime;
+        nLastTime = nNow;
+    }
+
+    // Add the new tx to the rate
+    nTxPerSec += 1/nSecondsToAverage; // The amount that the new tx will add to the tx rate
+}
+// BU: end

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -908,7 +908,7 @@ void CTxMemPool::TrimToSize(size_t sizelimit) {
 // BU: begin
 void CTxMemPool::UpdateTransactionsPerSecond()
 {
-    boost::mutex::scoped_lock lock(cs_txPerSec);
+    std::lock_guard<std::mutex> lock(cs_txPerSec);
 
     static int64_t nLastTime = GetTime();
     double nSecondsToAverage = 60; // Length of time in seconds to smooth the tx rate over

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -905,7 +905,6 @@ void CTxMemPool::TrimToSize(size_t sizelimit) {
     }
 }
 
-// BU: begin
 void CTxMemPool::UpdateTransactionsPerSecond()
 {
     std::lock_guard<std::mutex> lock(cs_txPerSec);
@@ -925,4 +924,3 @@ void CTxMemPool::UpdateTransactionsPerSecond()
     nTxPerSec += 1/nSecondsToAverage; // The amount that the new tx will add to the tx rate
     if (nTxPerSec < 0) nTxPerSec = 0;
 }
-// BU: end

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -921,5 +921,6 @@ void CTxMemPool::UpdateTransactionsPerSecond()
 
     // Add the new tx to the rate
     nTxPerSec += 1/nSecondsToAverage; // The amount that the new tx will add to the tx rate
+    if (nTxPerSec < 0) nTxPerSec = 0;
 }
 // BU: end

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -371,7 +371,7 @@ private:
     uint64_t totalTxSize; //! sum of all mempool tx' byte sizes
     uint64_t cachedInnerUsage; //! sum of dynamic memory usage of all the map elements (NOT the maps themselves)
 
-    boost::mutex cs_txPerSec;
+    std::mutex cs_txPerSec;
     double nTxPerSec; //BU: tx's per second accepted into the mempool
 public:
     typedef boost::multi_index_container<
@@ -531,7 +531,7 @@ public:
     // BU: begin
     double TransactionsPerSecond()
     {
-        boost::mutex::scoped_lock lock(cs_txPerSec);
+        std::lock_guard<std::mutex> lock(cs_txPerSec);
         return nTxPerSec;
     }
     // BU: end

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -20,6 +20,8 @@
 #include "boost/multi_index_container.hpp"
 #include "boost/multi_index/ordered_index.hpp"
 #include "boost/multi_index/hashed_index.hpp"
+#include <boost/thread/locks.hpp>
+#include <boost/thread/mutex.hpp>
 
 class CAutoFile;
 class CBlockIndex;
@@ -369,6 +371,7 @@ private:
     uint64_t totalTxSize; //! sum of all mempool tx' byte sizes
     uint64_t cachedInnerUsage; //! sum of dynamic memory usage of all the map elements (NOT the maps themselves)
 
+    boost::mutex cs_txPerSec;
     double nTxPerSec; //BU: tx's per second accepted into the mempool
 public:
     typedef boost::multi_index_container<
@@ -528,7 +531,7 @@ public:
     // BU: begin
     double TransactionsPerSecond()
     {
-        LOCK(cs);
+        boost::mutex::scoped_lock lock(cs_txPerSec);
         return nTxPerSec;
     }
     // BU: end

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -20,8 +20,6 @@
 #include "boost/multi_index_container.hpp"
 #include "boost/multi_index/ordered_index.hpp"
 #include "boost/multi_index/hashed_index.hpp"
-#include <boost/thread/locks.hpp>
-#include <boost/thread/mutex.hpp>
 
 class CAutoFile;
 class CBlockIndex;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -369,6 +369,7 @@ private:
     uint64_t totalTxSize; //! sum of all mempool tx' byte sizes
     uint64_t cachedInnerUsage; //! sum of dynamic memory usage of all the map elements (NOT the maps themselves)
 
+    double nTxPerSec; //BU: tx's per second accepted into the mempool
 public:
     typedef boost::multi_index_container<
         CTxMemPoolEntry,
@@ -503,6 +504,9 @@ public:
     /** Expire all transaction (and their dependencies) in the mempool older than time. Return the number of removed transactions. */
     int Expire(int64_t time);
 
+    /** BU: Every transaction that is accepted into the mempool will call this method to update the current value*/
+    void UpdateTransactionsPerSecond();
+
     unsigned long size()
     {
         LOCK(cs);
@@ -520,6 +524,14 @@ public:
         LOCK(cs);
         return (mapTx.count(hash) != 0);
     }
+
+    // BU: begin
+    double TransactionsPerSecond()
+    {
+        LOCK(cs);
+        return nTxPerSec;
+    }
+    // BU: end
 
     bool lookup(uint256 hash, CTransaction& result) const;
 


### PR DESCRIPTION
Maintain mempool TPS rate and return in getmempoolinfo.  This the current mempool tx admission rate over a 60-second window.

Also add other getmempoolinfo and debug window data.

https://github.com/bitcoin/bitcoin/pull/6529 [Qt] show client user agent in debug window
https://github.com/bitcoin/bitcoin/pull/6877 rpc: Add maxmempool to getmempoolinfo
https://github.com/bitcoin/bitcoin/pull/6979 [Qt] simple mempool info in debug window
https://github.com/bitcoin/bitcoin/pull/7069 [trivial] Fix -maxmempool InitError
https://github.com/bitcoin/bitcoin/pull/7118 Describe maxmempool in the getmempoolinfo RPC help
https://github.com/BitcoinUnlimited/BitcoinUnlimited/pull/35 Adding Transactions Per Second output to the debug window
https://github.com/BitcoinUnlimited/BitcoinUnlimited/pull/50 Fix for transactions per second (1 of 3 commits)
https://github.com/BitcoinUnlimited/BitcoinUnlimited/pull/1233 Add transactions per second to getmempoolinfo output
https://github.com/BitcoinUnlimited/BitcoinUnlimited/pull/1507 switch from a scoped_lock to a lock_guard in UpdateTransactionsPerSecond
